### PR TITLE
PR1.1: Add ConversationRef parser

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
 from .client import DEFAULT_MODEL, ChatGPTWebClient
 from .exceptions import AuthError, MediaError, RequestError, WebChatAdapterError
-from .types import AuthData, ChatConversation, ChatMetrics, ChatResponse, MediaItem, MediaSource
+from .types import (
+    AuthData,
+    ChatConversation,
+    ChatMetrics,
+    ChatResponse,
+    ConversationRef,
+    MediaItem,
+    MediaSource,
+)
 
 WebChatClient = ChatGPTWebClient
 
@@ -14,6 +22,7 @@ __all__ = [
     "ChatGPTWebClient",
     "ChatMetrics",
     "ChatResponse",
+    "ConversationRef",
     "DEFAULT_AUTH_FILE",
     "DEFAULT_MODEL",
     "MediaError",

--- a/src/webchat_adapter/types.py
+++ b/src/webchat_adapter/types.py
@@ -4,6 +4,7 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 MediaSource = bytes | bytearray | str | Path | os.PathLike[str]
 MediaItem = MediaSource | tuple[MediaSource, str | None]
@@ -138,6 +139,76 @@ class ChatConversation:
             "parent_message_id": self.parent_message_id,
             "is_thinking": self.is_thinking,
         }
+
+
+@dataclass(frozen=True)
+class ConversationRef:
+    conversation_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.conversation_id, str):
+            raise TypeError("conversation_id must be a string")
+        conversation_id = self.conversation_id.strip()
+        if not conversation_id:
+            raise ValueError("conversation_id is required")
+        if any(separator in conversation_id for separator in ("/", "?", "#")):
+            raise ValueError("conversation_id must be a raw id, not a URL")
+        object.__setattr__(self, "conversation_id", conversation_id)
+
+    @classmethod
+    def from_any(
+        cls,
+        value: "ConversationRef | ChatConversation | dict[str, Any] | str",
+    ) -> "ConversationRef":
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, ChatConversation):
+            return cls._from_optional_id(
+                value.conversation_id,
+                "conversation.conversation_id is required",
+            )
+        if isinstance(value, dict):
+            return cls._from_optional_id(
+                value.get("conversation_id"),
+                "conversation_id is required",
+            )
+        if isinstance(value, str):
+            return cls._from_string(value)
+        raise TypeError(
+            "conversation reference must be a raw id, ChatGPT conversation URL, "
+            "ChatConversation, dict, or ConversationRef"
+        )
+
+    @classmethod
+    def _from_optional_id(cls, value: Any, error_message: str) -> "ConversationRef":
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(error_message)
+        return cls(value)
+
+    @classmethod
+    def _from_string(cls, value: str) -> "ConversationRef":
+        raw_value = value.strip()
+        if not raw_value:
+            raise ValueError("conversation_id is required")
+
+        parsed = urlparse(raw_value)
+        if parsed.scheme or parsed.netloc:
+            return cls(cls._conversation_id_from_url(raw_value))
+        return cls(raw_value)
+
+    @staticmethod
+    def _conversation_id_from_url(value: str) -> str:
+        parsed = urlparse(value)
+        hostname = (parsed.hostname or "").lower()
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError("conversation URL must use http or https")
+        if hostname not in {"chatgpt.com", "chat.openai.com"}:
+            raise ValueError("conversation URL host is not supported")
+
+        parts = [part for part in parsed.path.split("/") if part]
+        if len(parts) != 2 or parts[0] != "c":
+            raise ValueError("conversation URL must have /c/<conversation_id> path")
+        return parts[1]
 
 
 @dataclass

--- a/tests/test_conversation_ref.py
+++ b/tests/test_conversation_ref.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+import webchat_adapter as adapter
+
+
+CONVERSATION_ID = "conv-123"
+
+
+def test_conversation_ref_accepts_raw_id() -> None:
+    ref = adapter.ConversationRef.from_any(f"  {CONVERSATION_ID}  ")
+
+    assert ref == adapter.ConversationRef(CONVERSATION_ID)
+    assert ref.conversation_id == CONVERSATION_ID
+
+
+def test_conversation_ref_accepts_chatgpt_url() -> None:
+    ref = adapter.ConversationRef.from_any(f"https://chatgpt.com/c/{CONVERSATION_ID}")
+
+    assert ref.conversation_id == CONVERSATION_ID
+
+
+def test_conversation_ref_accepts_chatgpt_url_with_query_and_fragment() -> None:
+    ref = adapter.ConversationRef.from_any(
+        f"https://chatgpt.com/c/{CONVERSATION_ID}?model=gpt-5#message"
+    )
+
+    assert ref.conversation_id == CONVERSATION_ID
+
+
+def test_conversation_ref_accepts_legacy_chat_openai_url() -> None:
+    ref = adapter.ConversationRef.from_any(f"https://chat.openai.com/c/{CONVERSATION_ID}/")
+
+    assert ref.conversation_id == CONVERSATION_ID
+
+
+def test_conversation_ref_accepts_chat_conversation() -> None:
+    conversation = adapter.ChatConversation(
+        conversation_id=CONVERSATION_ID,
+        message_id="message-123",
+    )
+
+    ref = adapter.ConversationRef.from_any(conversation)
+
+    assert ref.conversation_id == CONVERSATION_ID
+
+
+def test_conversation_ref_accepts_dict_with_conversation_id() -> None:
+    ref = adapter.ConversationRef.from_any(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "message_id": "message-123",
+        }
+    )
+
+    assert ref.conversation_id == CONVERSATION_ID
+
+
+def test_conversation_ref_accepts_existing_ref() -> None:
+    existing = adapter.ConversationRef(CONVERSATION_ID)
+
+    assert adapter.ConversationRef.from_any(existing) is existing
+
+
+def test_conversation_ref_rejects_empty_raw_id() -> None:
+    with pytest.raises(ValueError, match="conversation_id is required"):
+        adapter.ConversationRef.from_any("  ")
+
+
+def test_conversation_ref_rejects_raw_url_like_id() -> None:
+    with pytest.raises(ValueError, match="raw id"):
+        adapter.ConversationRef("https://chatgpt.com/c/conv-123")
+
+
+def test_conversation_ref_rejects_non_conversation_url() -> None:
+    with pytest.raises(ValueError, match="/c/<conversation_id>"):
+        adapter.ConversationRef.from_any("https://chatgpt.com/g/g-example")
+
+
+def test_conversation_ref_rejects_unsupported_url_host() -> None:
+    with pytest.raises(ValueError, match="host"):
+        adapter.ConversationRef.from_any("https://example.com/c/conv-123")
+
+
+def test_conversation_ref_rejects_missing_dict_conversation_id() -> None:
+    with pytest.raises(ValueError, match="conversation_id is required"):
+        adapter.ConversationRef.from_any({"id": CONVERSATION_ID})
+
+
+def test_conversation_ref_rejects_empty_chat_conversation() -> None:
+    with pytest.raises(ValueError, match="conversation.conversation_id is required"):
+        adapter.ConversationRef.from_any(adapter.ChatConversation())
+
+
+def test_conversation_ref_rejects_unsupported_input_type() -> None:
+    with pytest.raises(TypeError, match="conversation reference"):
+        adapter.ConversationRef.from_any(None)  # type: ignore[arg-type]
+
+
+def test_conversation_ref_is_exported_from_public_api() -> None:
+    assert "ConversationRef" in adapter.__all__
+    assert adapter.ConversationRef(CONVERSATION_ID).conversation_id == CONVERSATION_ID


### PR DESCRIPTION
## Summary

- Add `ConversationRef`, a frozen value object for normalizing references to existing ChatGPT web conversations.
- Support raw conversation IDs, `chatgpt.com/c/<id>` URLs, legacy `chat.openai.com/c/<id>` URLs, `ChatConversation`, dicts with `conversation_id`, and existing `ConversationRef` instances.
- Export `ConversationRef` from the public package API.
- Add focused parser/unit tests.

## Scope

Parser-only PR. No network calls, no attach behavior, no `send()` changes, no auth/curl/approval changes.

## Tests

Not run locally from this environment. Added `tests/test_conversation_ref.py` for the new parser contract.