### PR TITLE
PR1.2: Add AttachedConversation type

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -4,6 +4,7 @@ from .auth import DEFAULT_AUTH_FILE, load_auth_data
 from .client import DEFAULT_MODEL, ChatGPTWebClient
 from .exceptions import AuthError, MediaError, RequestError, WebChatAdapterError
 from .types import (
+    AttachedConversation,
     AuthData,
     ChatConversation,
     ChatMetrics,
@@ -16,6 +17,7 @@ from .types import (
 WebChatClient = ChatGPTWebClient
 
 __all__ = [
+    "AttachedConversation",
     "AuthData",
     "AuthError",
     "ChatConversation",

--- a/src/webchat_adapter/types.py
+++ b/src/webchat_adapter/types.py
@@ -10,6 +10,13 @@ MediaSource = bytes | bytearray | str | Path | os.PathLike[str]
 MediaItem = MediaSource | tuple[MediaSource, str | None]
 
 
+def _optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
 @dataclass(init=False)
 class AuthData:
     accessToken: str | None = None
@@ -209,6 +216,89 @@ class ConversationRef:
         if len(parts) != 2 or parts[0] != "c":
             raise ValueError("conversation URL must have /c/<conversation_id> path")
         return parts[1]
+
+
+@dataclass
+class AttachedConversation:
+    conversation: ChatConversation
+    current_node: str | None = None
+    detected_model: str | None = None
+    title: str | None = None
+    raw_status: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.conversation, ChatConversation):
+            raise TypeError("conversation must be a ChatConversation")
+        ref = ConversationRef.from_any(self.conversation)
+        conversation_dict = self.conversation.to_dict()
+        conversation_dict["conversation_id"] = ref.conversation_id
+        self.conversation = ChatConversation.from_dict(conversation_dict)
+        self.current_node = _optional_str(self.current_node)
+        self.detected_model = _optional_str(self.detected_model)
+        self.title = _optional_str(self.title)
+        if self.raw_status is None:
+            self.raw_status = {}
+        elif not isinstance(self.raw_status, dict):
+            raise TypeError("raw_status must be a dict")
+        else:
+            self.raw_status = dict(self.raw_status)
+
+    @property
+    def conversation_id(self) -> str:
+        ref = ConversationRef.from_any(self.conversation)
+        return ref.conversation_id
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: dict[str, Any],
+        *,
+        conversation: ChatConversation | None = None,
+        detected_model: str | None = None,
+        title: str | None = None,
+        raw_status: dict[str, Any] | None = None,
+    ) -> "AttachedConversation":
+        if not isinstance(payload, dict):
+            raise TypeError("conversation payload must be a dict")
+
+        payload_conversation_id = _optional_str(payload.get("conversation_id"))
+        if conversation is None:
+            conversation = ChatConversation(conversation_id=payload_conversation_id)
+        elif not _optional_str(conversation.conversation_id) and payload_conversation_id:
+            conversation_dict = conversation.to_dict()
+            conversation_dict["conversation_id"] = payload_conversation_id
+            conversation = ChatConversation.from_dict(conversation_dict)
+
+        return cls(
+            conversation=conversation,
+            current_node=_optional_str(payload.get("current_node")),
+            detected_model=detected_model,
+            title=title if title is not None else _optional_str(payload.get("title")),
+            raw_status=raw_status
+            if raw_status is not None
+            else cls._lightweight_status_from_payload(payload),
+        )
+
+    @staticmethod
+    def _lightweight_status_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        keys = (
+            "async_status",
+            "create_time",
+            "update_time",
+            "is_archived",
+            "is_starred",
+        )
+        return {key: payload[key] for key in keys if key in payload}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "conversation": self.conversation.to_dict(),
+            "conversation_id": self.conversation_id,
+            "current_node": self.current_node,
+            "detected_model": self.detected_model,
+            "title": self.title,
+            "raw_status": dict(self.raw_status),
+        }
 
 
 @dataclass

--- a/src/webchat_adapter/types.py
+++ b/src/webchat_adapter/types.py
@@ -262,9 +262,23 @@ class AttachedConversation:
             raise TypeError("conversation payload must be a dict")
 
         payload_conversation_id = _optional_str(payload.get("conversation_id"))
+        conversation_id = (
+            _optional_str(conversation.conversation_id)
+            if conversation is not None
+            else None
+        )
+        if (
+            conversation_id
+            and payload_conversation_id
+            and conversation_id != payload_conversation_id
+        ):
+            raise ValueError(
+                "conversation.conversation_id does not match payload.conversation_id"
+            )
+
         if conversation is None:
             conversation = ChatConversation(conversation_id=payload_conversation_id)
-        elif not _optional_str(conversation.conversation_id) and payload_conversation_id:
+        elif not conversation_id and payload_conversation_id:
             conversation_dict = conversation.to_dict()
             conversation_dict["conversation_id"] = payload_conversation_id
             conversation = ChatConversation.from_dict(conversation_dict)

--- a/tests/test_attached_conversation.py
+++ b/tests/test_attached_conversation.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 import webchat_adapter as adapter
@@ -132,26 +130,20 @@ def test_attached_conversation_rejects_missing_conversation_id() -> None:
 
 
 def test_attached_conversation_rejects_non_conversation() -> None:
-    not_conversation: Any = {"conversation_id": CONVERSATION_ID}
-
     with pytest.raises(TypeError, match="ChatConversation"):
-        adapter.AttachedConversation(conversation=not_conversation)
+        adapter.AttachedConversation(conversation={"conversation_id": CONVERSATION_ID})  # type: ignore[arg-type]
 
 
 def test_attached_conversation_rejects_non_dict_payload() -> None:
-    not_payload: Any = None
-
     with pytest.raises(TypeError, match="payload"):
-        adapter.AttachedConversation.from_payload(not_payload)
+        adapter.AttachedConversation.from_payload(None)  # type: ignore[arg-type]
 
 
 def test_attached_conversation_rejects_non_dict_raw_status() -> None:
-    raw_status: Any = "running"
-
     with pytest.raises(TypeError, match="raw_status"):
         adapter.AttachedConversation(
             conversation=adapter.ChatConversation(conversation_id=CONVERSATION_ID),
-            raw_status=raw_status,
+            raw_status="running",  # type: ignore[arg-type]
         )
 
 

--- a/tests/test_attached_conversation.py
+++ b/tests/test_attached_conversation.py
@@ -139,15 +139,19 @@ def test_attached_conversation_rejects_non_conversation() -> None:
 
 
 def test_attached_conversation_rejects_non_dict_payload() -> None:
+    not_payload: Any = None
+
     with pytest.raises(TypeError, match="payload"):
-        adapter.AttachedConversation.from_payload(None)  # type: ignore[arg-type]
+        adapter.AttachedConversation.from_payload(not_payload)
 
 
 def test_attached_conversation_rejects_non_dict_raw_status() -> None:
+    raw_status: Any = "running"
+
     with pytest.raises(TypeError, match="raw_status"):
         adapter.AttachedConversation(
             conversation=adapter.ChatConversation(conversation_id=CONVERSATION_ID),
-            raw_status="running",  # type: ignore[arg-type]
+            raw_status=raw_status,
         )
 
 

--- a/tests/test_attached_conversation.py
+++ b/tests/test_attached_conversation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 import webchat_adapter as adapter
@@ -130,20 +132,26 @@ def test_attached_conversation_rejects_missing_conversation_id() -> None:
 
 
 def test_attached_conversation_rejects_non_conversation() -> None:
+    not_conversation: Any = {"conversation_id": CONVERSATION_ID}
+
     with pytest.raises(TypeError, match="ChatConversation"):
-        adapter.AttachedConversation(conversation={"conversation_id": CONVERSATION_ID})  # type: ignore[arg-type]
+        adapter.AttachedConversation(conversation=not_conversation)
 
 
 def test_attached_conversation_rejects_non_dict_payload() -> None:
+    not_payload: Any = None
+
     with pytest.raises(TypeError, match="payload"):
-        adapter.AttachedConversation.from_payload(None)  # type: ignore[arg-type]
+        adapter.AttachedConversation.from_payload(not_payload)
 
 
 def test_attached_conversation_rejects_non_dict_raw_status() -> None:
+    raw_status: Any = "running"
+
     with pytest.raises(TypeError, match="raw_status"):
         adapter.AttachedConversation(
             conversation=adapter.ChatConversation(conversation_id=CONVERSATION_ID),
-            raw_status="running",  # type: ignore[arg-type]
+            raw_status=raw_status,
         )
 
 

--- a/tests/test_attached_conversation.py
+++ b/tests/test_attached_conversation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 import webchat_adapter as adapter
@@ -130,10 +132,10 @@ def test_attached_conversation_rejects_missing_conversation_id() -> None:
 
 
 def test_attached_conversation_rejects_non_conversation() -> None:
+    not_conversation: Any = {"conversation_id": CONVERSATION_ID}
+
     with pytest.raises(TypeError, match="ChatConversation"):
-        adapter.AttachedConversation(
-            conversation={"conversation_id": CONVERSATION_ID},  # type: ignore[arg-type]
-        )
+        adapter.AttachedConversation(conversation=not_conversation)
 
 
 def test_attached_conversation_rejects_non_dict_payload() -> None:

--- a/tests/test_attached_conversation.py
+++ b/tests/test_attached_conversation.py
@@ -85,6 +85,14 @@ def test_attached_conversation_from_payload_fills_missing_conversation_id() -> N
     assert attached.conversation.message_id == "message-123"
 
 
+def test_attached_conversation_from_payload_rejects_mismatched_conversation_id() -> None:
+    with pytest.raises(ValueError, match="does not match"):
+        adapter.AttachedConversation.from_payload(
+            {"conversation_id": "payload-conv"},
+            conversation=adapter.ChatConversation(conversation_id="conversation-conv"),
+        )
+
+
 def test_attached_conversation_copies_raw_status() -> None:
     raw_status = {"async_status": "running"}
 

--- a/tests/test_attached_conversation.py
+++ b/tests/test_attached_conversation.py
@@ -131,7 +131,9 @@ def test_attached_conversation_rejects_missing_conversation_id() -> None:
 
 def test_attached_conversation_rejects_non_conversation() -> None:
     with pytest.raises(TypeError, match="ChatConversation"):
-        adapter.AttachedConversation(conversation={"conversation_id": CONVERSATION_ID})  # type: ignore[arg-type]
+        adapter.AttachedConversation(
+            conversation={"conversation_id": CONVERSATION_ID},  # type: ignore[arg-type]
+        )
 
 
 def test_attached_conversation_rejects_non_dict_payload() -> None:

--- a/tests/test_attached_conversation.py
+++ b/tests/test_attached_conversation.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pytest
+
+import webchat_adapter as adapter
+
+
+CONVERSATION_ID = "conv-123"
+
+
+def test_attached_conversation_exposes_conversation_id() -> None:
+    attached = adapter.AttachedConversation(
+        conversation=adapter.ChatConversation(conversation_id=f"  {CONVERSATION_ID}  "),
+        current_node=" node-123 ",
+        detected_model=" gpt-5-5-thinking ",
+        title=" Test title ",
+        raw_status={"async_status": None},
+    )
+
+    assert attached.conversation_id == CONVERSATION_ID
+    assert attached.conversation.conversation_id == CONVERSATION_ID
+    assert attached.current_node == "node-123"
+    assert attached.detected_model == "gpt-5-5-thinking"
+    assert attached.title == "Test title"
+    assert attached.raw_status == {"async_status": None}
+
+
+def test_attached_conversation_from_payload_extracts_lightweight_fields() -> None:
+    attached = adapter.AttachedConversation.from_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "current_node": "node-current",
+            "title": "Existing chat",
+            "async_status": "running",
+            "update_time": 123.0,
+            "mapping": {"large": "payload should not be copied into raw_status"},
+        }
+    )
+
+    assert attached.conversation_id == CONVERSATION_ID
+    assert attached.conversation.conversation_id == CONVERSATION_ID
+    assert attached.current_node == "node-current"
+    assert attached.title == "Existing chat"
+    assert attached.detected_model is None
+    assert attached.raw_status == {
+        "async_status": "running",
+        "update_time": 123.0,
+    }
+
+
+def test_attached_conversation_from_payload_preserves_supplied_conversation_state() -> None:
+    attached = adapter.AttachedConversation.from_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "current_node": "node-current",
+            "title": "Payload title",
+        },
+        conversation=adapter.ChatConversation(
+            conversation_id=CONVERSATION_ID,
+            message_id="message-123",
+            parent_message_id="parent-123",
+        ),
+        detected_model="gpt-5-5-thinking",
+        title="Explicit title",
+        raw_status={"source": "summary"},
+    )
+
+    assert attached.conversation_id == CONVERSATION_ID
+    assert attached.conversation.message_id == "message-123"
+    assert attached.conversation.parent_message_id == "parent-123"
+    assert attached.detected_model == "gpt-5-5-thinking"
+    assert attached.title == "Explicit title"
+    assert attached.raw_status == {"source": "summary"}
+
+
+def test_attached_conversation_from_payload_fills_missing_conversation_id() -> None:
+    attached = adapter.AttachedConversation.from_payload(
+        {"conversation_id": CONVERSATION_ID},
+        conversation=adapter.ChatConversation(message_id="message-123"),
+    )
+
+    assert attached.conversation_id == CONVERSATION_ID
+    assert attached.conversation.message_id == "message-123"
+
+
+def test_attached_conversation_copies_raw_status() -> None:
+    raw_status = {"async_status": "running"}
+
+    attached = adapter.AttachedConversation(
+        conversation=adapter.ChatConversation(conversation_id=CONVERSATION_ID),
+        raw_status=raw_status,
+    )
+    raw_status["async_status"] = "changed"
+
+    assert attached.raw_status == {"async_status": "running"}
+
+
+def test_attached_conversation_to_dict_includes_convenience_conversation_id() -> None:
+    attached = adapter.AttachedConversation(
+        conversation=adapter.ChatConversation(
+            conversation_id=CONVERSATION_ID,
+            message_id="message-123",
+        ),
+        current_node="node-current",
+        detected_model="gpt-5-5-thinking",
+        title="Existing chat",
+        raw_status={"async_status": None},
+    )
+
+    assert attached.to_dict() == {
+        "conversation": {
+            "conversation_id": CONVERSATION_ID,
+            "message_id": "message-123",
+            "user_id": None,
+            "finish_reason": None,
+            "parent_message_id": None,
+            "is_thinking": False,
+        },
+        "conversation_id": CONVERSATION_ID,
+        "current_node": "node-current",
+        "detected_model": "gpt-5-5-thinking",
+        "title": "Existing chat",
+        "raw_status": {"async_status": None},
+    }
+
+
+def test_attached_conversation_rejects_missing_conversation_id() -> None:
+    with pytest.raises(ValueError, match="conversation.conversation_id is required"):
+        adapter.AttachedConversation(conversation=adapter.ChatConversation())
+
+
+def test_attached_conversation_rejects_non_conversation() -> None:
+    with pytest.raises(TypeError, match="ChatConversation"):
+        adapter.AttachedConversation(conversation={"conversation_id": CONVERSATION_ID})  # type: ignore[arg-type]
+
+
+def test_attached_conversation_rejects_non_dict_payload() -> None:
+    with pytest.raises(TypeError, match="payload"):
+        adapter.AttachedConversation.from_payload(None)  # type: ignore[arg-type]
+
+
+def test_attached_conversation_rejects_non_dict_raw_status() -> None:
+    with pytest.raises(TypeError, match="raw_status"):
+        adapter.AttachedConversation(
+            conversation=adapter.ChatConversation(conversation_id=CONVERSATION_ID),
+            raw_status="running",  # type: ignore[arg-type]
+        )
+
+
+def test_attached_conversation_is_exported_from_public_api() -> None:
+    assert "AttachedConversation" in adapter.__all__
+    assert adapter.AttachedConversation(
+        conversation=adapter.ChatConversation(conversation_id=CONVERSATION_ID)
+    ).conversation_id == CONVERSATION_ID


### PR DESCRIPTION
## Summary

- Add `AttachedConversation`, a public container for future `attach_conversation()` results.
- Store normalized `ChatConversation`, convenience `conversation_id`, `current_node`, `detected_model`, `title`, and lightweight `raw_status` metadata.
- Add `from_payload(...)` and `to_dict()` helpers for PR1.3 integration without adding network behavior.
- Export `AttachedConversation` from the public package API.
- Add focused unit tests for normalization, payload construction, lightweight status extraction, copying, invalid inputs, and public export.

## Scope

Type-only PR. No network fetch, no `attach_conversation()` method, no `send()` changes, no auth/curl/approval changes.

## Tests

Not run locally from this environment. CI runs `pytest -q` and package build.