### PR TITLE
PR1.3: Add attach_conversation

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .attach import attach_conversation as _attach_conversation
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
 from .client import DEFAULT_MODEL, ChatGPTWebClient
 from .exceptions import AuthError, MediaError, RequestError, WebChatAdapterError
@@ -14,6 +15,7 @@ from .types import (
     MediaSource,
 )
 
+ChatGPTWebClient.attach_conversation = _attach_conversation
 WebChatClient = ChatGPTWebClient
 
 __all__ = [

--- a/src/webchat_adapter/attach.py
+++ b/src/webchat_adapter/attach.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .types import AttachedConversation, ChatConversation, ConversationRef
+
+
+def _metadata_model(metadata: Any) -> str | None:
+    if not isinstance(metadata, dict):
+        return None
+    for key in ("model_slug", "model", "default_model_slug", "selected_model"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _message_id(message: dict[str, Any] | None) -> str | None:
+    if not isinstance(message, dict):
+        return None
+    value = message.get("id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _finish_reason(message: dict[str, Any] | None) -> str | None:
+    if not isinstance(message, dict):
+        return None
+    metadata = message.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    finish_details = metadata.get("finish_details")
+    if not isinstance(finish_details, dict):
+        return None
+    reason = finish_details.get("type")
+    if isinstance(reason, str) and reason.strip():
+        return reason.strip()
+    return None
+
+
+def _attached_conversation_message(client: Any, payload: dict[str, Any]) -> dict[str, Any] | None:
+    current_message = client._current_message_from_conversation(payload)
+    if isinstance(current_message, dict):
+        return current_message
+
+    assistant_message, _text = client._latest_assistant_from_conversation(payload)
+    if isinstance(assistant_message, dict):
+        return assistant_message
+
+    message, _text = client._latest_message_any_from_conversation(payload)
+    return message if isinstance(message, dict) else None
+
+
+def _detect_model_from_conversation_payload(client: Any, payload: dict[str, Any]) -> str | None:
+    current_message = client._current_message_from_conversation(payload)
+    if isinstance(current_message, dict):
+        model = _metadata_model(current_message.get("metadata"))
+        if model:
+            return model
+
+    assistant_message, _text = client._latest_assistant_from_conversation(payload)
+    if isinstance(assistant_message, dict):
+        model = _metadata_model(assistant_message.get("metadata"))
+        if model:
+            return model
+
+    model = _metadata_model(payload.get("metadata"))
+    if model:
+        return model
+
+    for key in ("model_slug", "model", "default_model_slug", "selected_model"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    return None
+
+
+def attach_conversation(
+    self: Any,
+    url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
+) -> AttachedConversation:
+    """Attach to an existing chatgpt.com conversation by URL or id."""
+
+    ref = ConversationRef.from_any(url_or_id)
+    payload = self._get_conversation_payload(ref.conversation_id)
+    selected_message = _attached_conversation_message(self, payload)
+    message_id = _message_id(selected_message)
+
+    conversation = ChatConversation(
+        conversation_id=ref.conversation_id,
+        message_id=message_id,
+        parent_message_id=message_id,
+        finish_reason=_finish_reason(selected_message),
+        is_thinking=False,
+    )
+    return AttachedConversation.from_payload(
+        payload,
+        conversation=conversation,
+        detected_model=_detect_model_from_conversation_payload(self, payload),
+    )

--- a/tests/test_attach_conversation.py
+++ b/tests/test_attach_conversation.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import webchat_adapter as adapter
+import webchat_adapter.client as client_mod
+
+
+CONVERSATION_ID = "conv-123"
+
+
+def _client_with_payload(payload: dict[str, Any]) -> tuple[adapter.ChatGPTWebClient, list[str]]:
+    client = object.__new__(adapter.ChatGPTWebClient)
+    calls: list[str] = []
+
+    def get_conversation_payload(conversation_id: str) -> dict[str, Any]:
+        calls.append(conversation_id)
+        return payload
+
+    client._get_conversation_payload = get_conversation_payload
+    return client, calls
+
+
+def _message_node(
+    message_id: str,
+    *,
+    role: str = "assistant",
+    text: str = "message",
+    create_time: float = 1.0,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "message": {
+            "id": message_id,
+            "author": {"role": role},
+            "create_time": create_time,
+            "content": {"content_type": "text", "parts": [text]},
+            "metadata": dict(metadata or {}),
+        }
+    }
+
+
+def test_attach_conversation_is_available_on_public_client_class() -> None:
+    assert hasattr(adapter.ChatGPTWebClient, "attach_conversation")
+    assert hasattr(client_mod.ChatGPTWebClient, "attach_conversation")
+
+
+def test_attach_conversation_accepts_raw_id() -> None:
+    client, calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "current_node": "assistant-1",
+            "mapping": {
+                "assistant-1": _message_node(
+                    "assistant-1",
+                    metadata={"finish_details": {"type": "stop"}},
+                ),
+            },
+            "title": "Existing chat",
+            "async_status": None,
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert calls == [CONVERSATION_ID]
+    assert isinstance(attached, adapter.AttachedConversation)
+    assert attached.conversation_id == CONVERSATION_ID
+    assert attached.conversation.message_id == "assistant-1"
+    assert attached.conversation.parent_message_id == "assistant-1"
+    assert attached.conversation.finish_reason == "stop"
+    assert attached.current_node == "assistant-1"
+    assert attached.title == "Existing chat"
+    assert attached.raw_status == {"async_status": None}
+
+
+def test_attach_conversation_accepts_chatgpt_url() -> None:
+    client, calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "mapping": {},
+        }
+    )
+
+    attached = client.attach_conversation(f"https://chatgpt.com/c/{CONVERSATION_ID}")
+
+    assert calls == [CONVERSATION_ID]
+    assert attached.conversation_id == CONVERSATION_ID
+
+
+def test_attach_conversation_uses_latest_assistant_when_current_node_is_missing() -> None:
+    client, _calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "mapping": {
+                "assistant-old": _message_node("assistant-old", create_time=1.0),
+                "assistant-new": _message_node("assistant-new", create_time=2.0),
+            },
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert attached.conversation.message_id == "assistant-new"
+    assert attached.conversation.parent_message_id == "assistant-new"
+
+
+def test_attach_conversation_uses_latest_any_message_when_no_assistant_exists() -> None:
+    client, _calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "mapping": {
+                "user-old": _message_node("user-old", role="user", create_time=1.0),
+                "user-new": _message_node("user-new", role="user", create_time=2.0),
+            },
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert attached.conversation.message_id == "user-new"
+    assert attached.conversation.parent_message_id == "user-new"
+
+
+def test_attach_conversation_detects_model_from_current_message_metadata() -> None:
+    client, _calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "current_node": "assistant-1",
+            "mapping": {
+                "assistant-1": _message_node(
+                    "assistant-1",
+                    metadata={"model_slug": "gpt-5-5-thinking"},
+                ),
+            },
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert attached.detected_model == "gpt-5-5-thinking"
+
+
+def test_attach_conversation_detects_model_from_latest_assistant_metadata() -> None:
+    client, _calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "current_node": "user-1",
+            "mapping": {
+                "user-1": _message_node("user-1", role="user", create_time=3.0),
+                "assistant-1": _message_node(
+                    "assistant-1",
+                    create_time=2.0,
+                    metadata={"model": "gpt-4.1"},
+                ),
+            },
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert attached.detected_model == "gpt-4.1"
+
+
+def test_attach_conversation_detects_model_from_payload_metadata() -> None:
+    client, _calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "mapping": {},
+            "metadata": {"default_model_slug": "gpt-4.1-mini"},
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert attached.detected_model == "gpt-4.1-mini"
+
+
+def test_attach_conversation_returns_none_when_model_is_unknown() -> None:
+    client, _calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "mapping": {},
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert attached.detected_model is None
+
+
+def test_attach_conversation_rejects_invalid_reference() -> None:
+    client, calls = _client_with_payload({"conversation_id": CONVERSATION_ID})
+
+    with pytest.raises(ValueError, match="/c/<conversation_id>"):
+        client.attach_conversation("https://chatgpt.com/g/g-example")
+
+    assert calls == []
+
+
+def test_attach_conversation_propagates_fetch_errors() -> None:
+    client = object.__new__(adapter.ChatGPTWebClient)
+
+    def get_conversation_payload(conversation_id: str) -> dict[str, Any]:
+        raise adapter.RequestError(f"conversation status=404: {conversation_id}")
+
+    client._get_conversation_payload = get_conversation_payload
+
+    with pytest.raises(adapter.RequestError, match="status=404"):
+        client.attach_conversation(CONVERSATION_ID)


### PR DESCRIPTION
## Summary

- Add public `client.attach_conversation(url_or_id)` support for existing ChatGPT web conversations.
- Normalize raw ids, ChatGPT conversation URLs, `ChatConversation`, and dict inputs via `ConversationRef`.
- Fetch conversation payload through the existing `_get_conversation_payload(...)` path.
- Build `ChatConversation` from current node, latest assistant fallback, or latest available message fallback.
- Detect model best-effort from current message metadata, latest assistant metadata, payload metadata, or top-level payload model fields.
- Return `AttachedConversation` with normalized conversation state and lightweight metadata.
- Add tests for raw ids, URLs, selected message fallback behavior, model detection, unknown model behavior, invalid references, and fetch error propagation.

## Scope

- No `send_to_conversation()` implementation.
- No preserve-model send behavior.
- No `send()` changes.
- No auth/curl/approval/status lifecycle changes.
- No raw payload public API.

## Implementation note

The attach logic is isolated in `src/webchat_adapter/attach.py` and wired onto `ChatGPTWebClient` as a public method. This keeps the PR focused and avoids touching the existing transport-heavy `client.py` send/approval code.

## Tests

Not run locally from this environment. CI runs `pytest -q` and package build.