### PR TITLE
PR1.4: Preserve model detection

### DIFF
--- a/src/webchat_adapter/attach.py
+++ b/src/webchat_adapter/attach.py
@@ -2,17 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .model_detection import detect_model_from_conversation_payload
 from .types import AttachedConversation, ChatConversation, ConversationRef
-
-
-def _metadata_model(metadata: Any) -> str | None:
-    if not isinstance(metadata, dict):
-        return None
-    for key in ("model_slug", "model", "default_model_slug", "selected_model"):
-        value = metadata.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    return None
 
 
 def _message_id(message: dict[str, Any] | None) -> str | None:
@@ -52,31 +43,6 @@ def _attached_conversation_message(client: Any, payload: dict[str, Any]) -> dict
     return message if isinstance(message, dict) else None
 
 
-def _detect_model_from_conversation_payload(client: Any, payload: dict[str, Any]) -> str | None:
-    current_message = client._current_message_from_conversation(payload)
-    if isinstance(current_message, dict):
-        model = _metadata_model(current_message.get("metadata"))
-        if model:
-            return model
-
-    assistant_message, _text = client._latest_assistant_from_conversation(payload)
-    if isinstance(assistant_message, dict):
-        model = _metadata_model(assistant_message.get("metadata"))
-        if model:
-            return model
-
-    model = _metadata_model(payload.get("metadata"))
-    if model:
-        return model
-
-    for key in ("model_slug", "model", "default_model_slug", "selected_model"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-
-    return None
-
-
 def attach_conversation(
     self: Any,
     url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
@@ -98,5 +64,5 @@ def attach_conversation(
     return AttachedConversation.from_payload(
         payload,
         conversation=conversation,
-        detected_model=_detect_model_from_conversation_payload(self, payload),
+        detected_model=detect_model_from_conversation_payload(payload),
     )

--- a/src/webchat_adapter/model_detection.py
+++ b/src/webchat_adapter/model_detection.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import Any
+
+MODEL_KEYS = (
+    "model_slug",
+    "model",
+    "default_model_slug",
+    "selected_model",
+)
+MODEL_CONTAINER_KEYS = (
+    "model",
+    "selected_model",
+    "default_model",
+)
+NESTED_MODEL_KEYS = (
+    "slug",
+    "name",
+    "id",
+)
+
+
+def _clean_model(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _model_from_mapping(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+
+    for key in MODEL_KEYS:
+        model = _clean_model(value.get(key))
+        if model:
+            return model
+
+    for key in MODEL_CONTAINER_KEYS:
+        container = value.get(key)
+        if not isinstance(container, dict):
+            continue
+        for nested_key in NESTED_MODEL_KEYS:
+            model = _clean_model(container.get(nested_key))
+            if model:
+                return model
+
+    return None
+
+
+def _conversation_mapping(payload: dict[str, Any]) -> dict[str, Any]:
+    mapping = payload.get("mapping")
+    return mapping if isinstance(mapping, dict) else {}
+
+
+def _message_from_node(node: Any) -> dict[str, Any] | None:
+    if not isinstance(node, dict):
+        return None
+    message = node.get("message")
+    return message if isinstance(message, dict) else None
+
+
+def _current_message(payload: dict[str, Any]) -> dict[str, Any] | None:
+    current_node = payload.get("current_node")
+    if not isinstance(current_node, str) or not current_node.strip():
+        return None
+    return _message_from_node(_conversation_mapping(payload).get(current_node))
+
+
+def _latest_message(
+    payload: dict[str, Any],
+    *,
+    role: str | None = None,
+) -> dict[str, Any] | None:
+    candidates: list[tuple[float, dict[str, Any]]] = []
+    for node in _conversation_mapping(payload).values():
+        message = _message_from_node(node)
+        if message is None:
+            continue
+
+        if role is not None:
+            author = message.get("author")
+            if not isinstance(author, dict) or author.get("role") != role:
+                continue
+
+        message_id = message.get("id")
+        if not isinstance(message_id, str) or not message_id.strip():
+            continue
+
+        create_time = message.get("create_time")
+        try:
+            score = float(create_time or 0)
+        except (TypeError, ValueError):
+            score = 0.0
+        candidates.append((score, message))
+
+    if not candidates:
+        return None
+    _score, message = max(candidates, key=lambda item: item[0])
+    return message
+
+
+def _model_from_message(message: dict[str, Any] | None) -> str | None:
+    if not isinstance(message, dict):
+        return None
+    return _model_from_mapping(message.get("metadata"))
+
+
+def detect_model_from_conversation_payload(payload: Any) -> str | None:
+    """Best-effort model extraction from a chatgpt.com conversation payload.
+
+    The ChatGPT web conversation payload is not a stable public schema. This
+    helper intentionally detects only known model-like fields from known payload
+    locations and returns None instead of guessing when the model cannot be
+    found.
+    """
+
+    if not isinstance(payload, dict):
+        return None
+
+    for message in (
+        _current_message(payload),
+        _latest_message(payload, role="assistant"),
+        _latest_message(payload),
+    ):
+        model = _model_from_message(message)
+        if model:
+            return model
+
+    model = _model_from_mapping(payload.get("metadata"))
+    if model:
+        return model
+
+    return _model_from_mapping(payload)

--- a/tests/test_attach_conversation.py
+++ b/tests/test_attach_conversation.py
@@ -178,6 +178,25 @@ def test_attach_conversation_detects_model_from_payload_metadata() -> None:
     assert attached.detected_model == "gpt-4.1-mini"
 
 
+def test_attach_conversation_uses_hardened_nested_model_detection() -> None:
+    client, _calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "current_node": "assistant-1",
+            "mapping": {
+                "assistant-1": _message_node(
+                    "assistant-1",
+                    metadata={"selected_model": {"slug": "gpt-selected"}},
+                ),
+            },
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert attached.detected_model == "gpt-selected"
+
+
 def test_attach_conversation_returns_none_when_model_is_unknown() -> None:
     client, _calls = _client_with_payload(
         {

--- a/tests/test_model_detection.py
+++ b/tests/test_model_detection.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from typing import Any
+
+from webchat_adapter.model_detection import detect_model_from_conversation_payload
+
+
+def _message_node(
+    message_id: str,
+    *,
+    role: str = "assistant",
+    create_time: float = 1.0,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "message": {
+            "id": message_id,
+            "author": {"role": role},
+            "create_time": create_time,
+            "content": {"content_type": "text", "parts": ["message"]},
+            "metadata": dict(metadata or {}),
+        }
+    }
+
+
+def test_detect_model_prefers_current_node_metadata() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "current_node": "assistant-current",
+        "mapping": {
+            "assistant-old": _message_node(
+                "assistant-old",
+                create_time=1.0,
+                metadata={"model_slug": "gpt-old"},
+            ),
+            "assistant-current": _message_node(
+                "assistant-current",
+                create_time=2.0,
+                metadata={"model_slug": "gpt-current"},
+            ),
+        },
+    }
+
+    assert detect_model_from_conversation_payload(payload) == "gpt-current"
+
+
+def test_detect_model_falls_back_to_latest_assistant_metadata() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "current_node": "user-latest",
+        "mapping": {
+            "assistant-latest": _message_node(
+                "assistant-latest",
+                create_time=2.0,
+                metadata={"model_slug": "gpt-assistant"},
+            ),
+            "user-latest": _message_node(
+                "user-latest",
+                role="user",
+                create_time=3.0,
+            ),
+        },
+    }
+
+    assert detect_model_from_conversation_payload(payload) == "gpt-assistant"
+
+
+def test_detect_model_falls_back_to_latest_any_message_metadata() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "mapping": {
+            "user-old": _message_node(
+                "user-old",
+                role="user",
+                create_time=1.0,
+                metadata={"model_slug": "gpt-old"},
+            ),
+            "user-new": _message_node(
+                "user-new",
+                role="user",
+                create_time=2.0,
+                metadata={"model_slug": "gpt-user"},
+            ),
+        },
+    }
+
+    assert detect_model_from_conversation_payload(payload) == "gpt-user"
+
+
+def test_detect_model_falls_back_to_payload_metadata() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "mapping": {},
+        "metadata": {"default_model_slug": "gpt-meta"},
+    }
+
+    assert detect_model_from_conversation_payload(payload) == "gpt-meta"
+
+
+def test_detect_model_falls_back_to_top_level_fields() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "mapping": {},
+        "model_slug": "gpt-top",
+    }
+
+    assert detect_model_from_conversation_payload(payload) == "gpt-top"
+
+
+def test_detect_model_reads_nested_model_object() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "current_node": "assistant-current",
+        "mapping": {
+            "assistant-current": _message_node(
+                "assistant-current",
+                metadata={"model": {"slug": "gpt-nested"}},
+            ),
+        },
+    }
+
+    assert detect_model_from_conversation_payload(payload) == "gpt-nested"
+
+
+def test_detect_model_reads_nested_selected_model_object() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "metadata": {"selected_model": {"slug": "gpt-selected"}},
+    }
+
+    assert detect_model_from_conversation_payload(payload) == "gpt-selected"
+
+
+def test_detect_model_ignores_empty_strings() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "mapping": {},
+        "metadata": {"model_slug": "   ", "model": ""},
+    }
+
+    assert detect_model_from_conversation_payload(payload) is None
+
+
+def test_detect_model_ignores_non_string_scalar_values() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "mapping": {},
+        "metadata": {"model_slug": 123, "model": {"bad": "shape"}},
+    }
+
+    assert detect_model_from_conversation_payload(payload) is None
+
+
+def test_detect_model_returns_none_for_unknown_payload() -> None:
+    payload = {"conversation_id": "conv-123", "mapping": {}}
+
+    assert detect_model_from_conversation_payload(payload) is None
+
+
+def test_detect_model_returns_none_for_non_dict_payload() -> None:
+    assert detect_model_from_conversation_payload(None) is None
+
+
+def test_detect_model_does_not_recursively_guess_unrelated_slug() -> None:
+    payload = {
+        "conversation_id": "conv-123",
+        "mapping": {},
+        "metadata": {
+            "tool": {"slug": "not-a-model"},
+            "attachment": {"name": "also-not-a-model"},
+        },
+    }
+
+    assert detect_model_from_conversation_payload(payload) is None


### PR DESCRIPTION
## Summary

- Add a dedicated internal model detection helper for conversation payloads.
- Preserve best-effort semantics: detect known model fields from known payload locations only.
- Return `None` when the model cannot be found instead of guessing or falling back to `DEFAULT_MODEL`.
- Wire `attach_conversation()` to the hardened detector.
- Add focused tests for priority order, nested model shapes, unknown payloads, and false-positive avoidance.

## Scope

- No `send_to_conversation()` implementation.
- No `send()` changes.
- No preserve-model application yet.
- No public model detection API.
- No fallback to `DEFAULT_MODEL`.

## Notes

ChatGPT web payloads are not a stable public schema, so this detection is intentionally best-effort.

## Tests

Not run locally from this environment. CI runs `pytest -q` and package build.