### PR TITLE
PR1.5: Add send_to_conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,24 @@ response = client.send(
 )
 ```
 
-## Continue a Conversation
+## Continue an Existing ChatGPT Web Conversation
+
+```python
+from webchat_adapter import ChatGPTWebClient
+
+client = ChatGPTWebClient(auth_file="auth_data.json")
+
+response = client.send_to_conversation(
+    "https://chatgpt.com/c/...",
+    "Продолжи с этого места.",
+)
+
+print(response.text)
+```
+
+`send_to_conversation()` attaches to the latest web conversation state, resolves the current parent message automatically, and preserves the detected model when possible. Model detection is best-effort because ChatGPT web payloads can change. If the model cannot be detected, the SDK uses the normal `send()` default model.
+
+## Continue from an SDK Response
 
 ```python
 from webchat_adapter import ChatGPTWebClient

--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .attach import attach_conversation as _attach_conversation
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
 from .client import DEFAULT_MODEL, ChatGPTWebClient
+from .conversation_send import send_to_conversation as _send_to_conversation
 from .exceptions import AuthError, MediaError, RequestError, WebChatAdapterError
 from .types import (
     AttachedConversation,
@@ -16,6 +17,7 @@ from .types import (
 )
 
 ChatGPTWebClient.attach_conversation = _attach_conversation
+ChatGPTWebClient.send_to_conversation = _send_to_conversation
 WebChatClient = ChatGPTWebClient
 
 __all__ = [

--- a/src/webchat_adapter/conversation_send.py
+++ b/src/webchat_adapter/conversation_send.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Sequence
+
+from .client import DEFAULT_MODEL
+from .types import AttachedConversation, ChatConversation, ChatResponse, ConversationRef, MediaItem
+
+
+def _resolve_send_model(
+    *,
+    attached: AttachedConversation,
+    preserve_model: bool,
+    model: str | None,
+) -> str:
+    if model is not None:
+        return model
+    if preserve_model and attached.detected_model:
+        return attached.detected_model
+    return DEFAULT_MODEL
+
+
+def send_to_conversation(
+    self: Any,
+    url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
+    prompt: str,
+    *,
+    preserve_model: bool = True,
+    model: str | None = None,
+    system: str | None = None,
+    web_search: bool = False,
+    temporary: bool = False,
+    reasoning_effort: str | None = None,
+    media: Sequence[MediaItem] | None = None,
+    on_token: Callable[[str], None] | None = None,
+) -> ChatResponse:
+    """Send a prompt to an existing chatgpt.com conversation by URL or id."""
+
+    attached = self.attach_conversation(url_or_id)
+    resolved_model = _resolve_send_model(
+        attached=attached,
+        preserve_model=preserve_model,
+        model=model,
+    )
+    return self.send(
+        prompt,
+        model=resolved_model,
+        system=system,
+        web_search=web_search,
+        temporary=temporary,
+        reasoning_effort=reasoning_effort,
+        conversation=attached.conversation,
+        media=media,
+        on_token=on_token,
+    )

--- a/tests/test_send_to_conversation.py
+++ b/tests/test_send_to_conversation.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import webchat_adapter as adapter
+from webchat_adapter.client import DEFAULT_MODEL
+
+
+CONVERSATION_ID = "conv-123"
+
+
+def _attached(*, detected_model: str | None = "gpt-5-5-thinking") -> adapter.AttachedConversation:
+    return adapter.AttachedConversation(
+        conversation=adapter.ChatConversation(
+            conversation_id=CONVERSATION_ID,
+            message_id="message-123",
+            parent_message_id="message-123",
+        ),
+        detected_model=detected_model,
+    )
+
+
+def _client_with_attach_and_send(
+    attached: adapter.AttachedConversation,
+) -> tuple[adapter.ChatGPTWebClient, list[Any], list[dict[str, Any]], adapter.ChatResponse]:
+    client = object.__new__(adapter.ChatGPTWebClient)
+    attach_calls: list[Any] = []
+    send_calls: list[dict[str, Any]] = []
+    response = adapter.ChatResponse(
+        text="continued",
+        conversation=adapter.ChatConversation(
+            conversation_id=CONVERSATION_ID,
+            message_id="assistant-1",
+        ),
+    )
+
+    def attach_conversation(url_or_id: Any) -> adapter.AttachedConversation:
+        attach_calls.append(url_or_id)
+        return attached
+
+    def send(prompt: str, **kwargs: Any) -> adapter.ChatResponse:
+        send_calls.append({"prompt": prompt, **kwargs})
+        return response
+
+    client.attach_conversation = attach_conversation
+    client.send = send
+    return client, attach_calls, send_calls, response
+
+
+def test_send_to_conversation_is_available_on_public_client_class() -> None:
+    assert hasattr(adapter.ChatGPTWebClient, "send_to_conversation")
+
+
+def test_send_to_conversation_attaches_and_sends_with_detected_model() -> None:
+    attached = _attached(detected_model="gpt-5-5-thinking")
+    client, attach_calls, send_calls, response = _client_with_attach_and_send(attached)
+
+    result = client.send_to_conversation(CONVERSATION_ID, "Продолжи")
+
+    assert result is response
+    assert attach_calls == [CONVERSATION_ID]
+    assert send_calls == [
+        {
+            "prompt": "Продолжи",
+            "model": "gpt-5-5-thinking",
+            "system": None,
+            "web_search": False,
+            "temporary": False,
+            "reasoning_effort": None,
+            "conversation": attached.conversation,
+            "media": None,
+            "on_token": None,
+        }
+    ]
+
+
+def test_send_to_conversation_passes_url_to_attach_unchanged() -> None:
+    attached = _attached()
+    client, attach_calls, _send_calls, _response = _client_with_attach_and_send(attached)
+    url = f"https://chatgpt.com/c/{CONVERSATION_ID}"
+
+    client.send_to_conversation(url, "Продолжи")
+
+    assert attach_calls == [url]
+
+
+def test_send_to_conversation_explicit_model_wins_over_detected_model() -> None:
+    attached = _attached(detected_model="gpt-5-5-thinking")
+    client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
+
+    client.send_to_conversation(
+        CONVERSATION_ID,
+        "Продолжи",
+        model="gpt-4.1",
+        preserve_model=True,
+    )
+
+    assert send_calls[0]["model"] == "gpt-4.1"
+
+
+def test_send_to_conversation_preserve_model_false_ignores_detected_model() -> None:
+    attached = _attached(detected_model="gpt-5-5-thinking")
+    client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
+
+    client.send_to_conversation(
+        CONVERSATION_ID,
+        "Продолжи",
+        preserve_model=False,
+    )
+
+    assert send_calls[0]["model"] == DEFAULT_MODEL
+
+
+def test_send_to_conversation_unknown_detected_model_uses_default_model() -> None:
+    attached = _attached(detected_model=None)
+    client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
+
+    client.send_to_conversation(CONVERSATION_ID, "Продолжи")
+
+    assert send_calls[0]["model"] == DEFAULT_MODEL
+
+
+def test_send_to_conversation_default_reasoning_effort_stays_none() -> None:
+    attached = _attached()
+    client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
+
+    client.send_to_conversation(CONVERSATION_ID, "Продолжи")
+
+    assert send_calls[0]["reasoning_effort"] is None
+
+
+def test_send_to_conversation_passes_explicit_reasoning_effort() -> None:
+    attached = _attached()
+    client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
+
+    client.send_to_conversation(
+        CONVERSATION_ID,
+        "Продолжи",
+        reasoning_effort="extended",
+    )
+
+    assert send_calls[0]["reasoning_effort"] == "extended"
+
+
+def test_send_to_conversation_passes_send_options_through() -> None:
+    attached = _attached()
+    client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
+    media = [(b"image-bytes", "image.png")]
+
+    def on_token(token: str) -> None:
+        assert token
+
+    client.send_to_conversation(
+        CONVERSATION_ID,
+        "Продолжи",
+        system="system prompt",
+        web_search=True,
+        temporary=True,
+        media=media,
+        on_token=on_token,
+    )
+
+    call = send_calls[0]
+    assert call["system"] == "system prompt"
+    assert call["web_search"] is True
+    assert call["temporary"] is True
+    assert call["media"] == media
+    assert call["on_token"] is on_token
+
+
+def test_send_to_conversation_propagates_attach_errors_without_sending() -> None:
+    client = object.__new__(adapter.ChatGPTWebClient)
+    send_called = False
+
+    def attach_conversation(url_or_id: Any) -> adapter.AttachedConversation:
+        raise adapter.RequestError(f"conversation status=404: {url_or_id}")
+
+    def send(prompt: str, **kwargs: Any) -> adapter.ChatResponse:
+        nonlocal send_called
+        send_called = True
+        return adapter.ChatResponse(text="unexpected")
+
+    client.attach_conversation = attach_conversation
+    client.send = send
+
+    with pytest.raises(adapter.RequestError, match="status=404"):
+        client.send_to_conversation(CONVERSATION_ID, "Продолжи")
+
+    assert send_called is False


### PR DESCRIPTION
## Summary

- Add `client.send_to_conversation(url_or_id, prompt, preserve_model=True)` as the main M1 convenience API.
- Implement it as a thin wrapper over `attach_conversation()` + existing `send()`.
- Preserve detected model by default when `attach_conversation()` finds one.
- Let explicit `model=...` override detected model.
- Fall back to the normal `send()` default model when model detection returns `None`.
- Preserve the important default that `reasoning_effort` is untouched unless explicitly passed.
- Document the new URL/id continuation flow in README.

## Scope

- No `send()` transport changes.
- No approval/status lifecycle changes.
- No auto-approval integration.
- No reasoning-effort detection or preservation.
- No model-detection changes beyond consuming the PR1.4 result.

## Tests

- Add focused tests for attach → send delegation.
- Cover detected-model preservation, explicit model override, `preserve_model=False`, unknown detected model fallback, reasoning-effort semantics, send option pass-through, URL pass-through, and attach error propagation.

Not run locally from this environment. CI runs `pytest -q` and package build.