### PR TITLE
PR2.2: Add current branch message reader

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -5,6 +5,7 @@ from .auth import DEFAULT_AUTH_FILE, load_auth_data
 from .client import DEFAULT_MODEL, ChatGPTWebClient
 from .conversation_send import send_to_conversation as _send_to_conversation
 from .exceptions import AuthError, MediaError, RequestError, WebChatAdapterError
+from .messages import get_messages as _get_messages
 from .types import (
     AttachedConversation,
     AuthData,
@@ -18,6 +19,7 @@ from .types import (
 )
 
 ChatGPTWebClient.attach_conversation = _attach_conversation
+ChatGPTWebClient.get_messages = _get_messages
 ChatGPTWebClient.send_to_conversation = _send_to_conversation
 WebChatClient = ChatGPTWebClient
 

--- a/src/webchat_adapter/messages.py
+++ b/src/webchat_adapter/messages.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from .types import ChatConversation, ChatMessage, ConversationRef
+
+METADATA_PREVIEW_KEYS = (
+    "content_type",
+    "finish_details",
+    "is_complete",
+    "model_slug",
+    "model",
+    "default_model_slug",
+    "selected_model",
+)
+MODEL_KEYS = (
+    "model_slug",
+    "model",
+    "default_model_slug",
+    "selected_model",
+)
+
+
+def _optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _conversation_mapping(payload: dict[str, Any]) -> dict[str, Any]:
+    mapping = payload.get("mapping")
+    return mapping if isinstance(mapping, dict) else {}
+
+
+def _current_branch_nodes(payload: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    mapping = _conversation_mapping(payload)
+    node_id = _optional_str(payload.get("current_node"))
+    branch: list[tuple[str, dict[str, Any]]] = []
+    seen: set[str] = set()
+
+    while node_id:
+        if node_id in seen:
+            break
+        seen.add(node_id)
+
+        node = mapping.get(node_id)
+        if not isinstance(node, dict):
+            break
+
+        branch.append((node_id, node))
+        node_id = _optional_str(node.get("parent"))
+
+    branch.reverse()
+    return branch
+
+
+def _message_from_node(node: dict[str, Any]) -> dict[str, Any] | None:
+    message = node.get("message")
+    return message if isinstance(message, dict) else None
+
+
+def _message_role(message: dict[str, Any]) -> str | None:
+    author = message.get("author")
+    if not isinstance(author, dict):
+        return None
+    return _optional_str(author.get("role"))
+
+
+def _message_metadata(message: dict[str, Any]) -> dict[str, Any]:
+    metadata = message.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _message_model(message: dict[str, Any]) -> str | None:
+    metadata = _message_metadata(message)
+    for key in MODEL_KEYS:
+        value = _optional_str(metadata.get(key))
+        if value:
+            return value
+    return None
+
+
+def _message_finish_reason(message: dict[str, Any]) -> str | None:
+    metadata = _message_metadata(message)
+    finish_details = metadata.get("finish_details")
+    if not isinstance(finish_details, dict):
+        return None
+    return _optional_str(finish_details.get("type"))
+
+
+def _message_metadata_preview(message: dict[str, Any]) -> dict[str, Any]:
+    metadata = _message_metadata(message)
+    return {key: metadata[key] for key in METADATA_PREVIEW_KEYS if key in metadata}
+
+
+def _basic_message_text(message: dict[str, Any]) -> str:
+    content = message.get("content")
+    if not isinstance(content, dict):
+        return ""
+
+    text = content.get("text")
+    if isinstance(text, str):
+        return text
+
+    parts = content.get("parts")
+    if not isinstance(parts, list):
+        return ""
+
+    return "\n".join(part for part in parts if isinstance(part, str) and part)
+
+
+def _chat_message_from_node(node_id: str, node: dict[str, Any]) -> ChatMessage | None:
+    message = _message_from_node(node)
+    if message is None:
+        return None
+
+    return ChatMessage(
+        node_id=node_id,
+        message_id=message.get("id"),
+        role=_message_role(message),
+        text=_basic_message_text(message),
+        create_time=message.get("create_time"),
+        recipient=message.get("recipient"),
+        model=_message_model(message),
+        finish_reason=_message_finish_reason(message),
+        metadata_preview=_message_metadata_preview(message),
+    )
+
+
+def _normalize_limit(limit: int | None) -> int | None:
+    if limit is None:
+        return None
+    if isinstance(limit, bool) or not isinstance(limit, int):
+        raise TypeError("limit must be an int or None")
+    if limit < 0:
+        raise ValueError("limit must be greater than or equal to 0")
+    return limit
+
+
+def _normalize_roles(roles: Iterable[str] | None) -> set[str] | None:
+    if roles is None:
+        return None
+    if isinstance(roles, str):
+        raise TypeError("roles must be an iterable of strings, not a string")
+
+    normalized: set[str] = set()
+    for role in roles:
+        if not isinstance(role, str):
+            raise TypeError("roles must contain only strings")
+        value = role.strip()
+        if value:
+            normalized.add(value)
+    return normalized
+
+
+def _message_matches_roles(message: ChatMessage, roles: set[str] | None) -> bool:
+    return roles is None or message.role in roles
+
+
+def get_messages(
+    self: Any,
+    url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
+    *,
+    limit: int | None = None,
+    roles: Iterable[str] | None = None,
+    include_empty: bool = False,
+) -> list[ChatMessage]:
+    """Read messages from the current branch of an existing conversation."""
+
+    normalized_limit = _normalize_limit(limit)
+    normalized_roles = _normalize_roles(roles)
+
+    if normalized_limit == 0 or normalized_roles == set():
+        return []
+
+    ref = ConversationRef.from_any(url_or_id)
+    payload = self._get_conversation_payload(ref.conversation_id)
+    if not isinstance(payload, dict):
+        return []
+
+    messages: list[ChatMessage] = []
+    for node_id, node in _current_branch_nodes(payload):
+        message = _chat_message_from_node(node_id, node)
+        if message is None:
+            continue
+        if not _message_matches_roles(message, normalized_roles):
+            continue
+        if not include_empty and not message.text:
+            continue
+        messages.append(message)
+
+    if normalized_limit is not None:
+        return messages[-normalized_limit:]
+    return messages

--- a/src/webchat_adapter/messages.py
+++ b/src/webchat_adapter/messages.py
@@ -171,11 +171,11 @@ def get_messages(
 
     normalized_limit = _normalize_limit(limit)
     normalized_roles = _normalize_roles(roles)
+    ref = ConversationRef.from_any(url_or_id)
 
     if normalized_limit == 0 or normalized_roles == set():
         return []
 
-    ref = ConversationRef.from_any(url_or_id)
     payload = self._get_conversation_payload(ref.conversation_id)
     if not isinstance(payload, dict):
         return []

--- a/src/webchat_adapter/messages.py
+++ b/src/webchat_adapter/messages.py
@@ -20,6 +20,16 @@ MODEL_KEYS = (
     "default_model_slug",
     "selected_model",
 )
+MODEL_CONTAINER_KEYS = (
+    "model",
+    "selected_model",
+    "default_model",
+)
+NESTED_MODEL_KEYS = (
+    "slug",
+    "name",
+    "id",
+)
 
 
 def _optional_str(value: Any) -> str | None:
@@ -79,6 +89,16 @@ def _message_model(message: dict[str, Any]) -> str | None:
         value = _optional_str(metadata.get(key))
         if value:
             return value
+
+    for key in MODEL_CONTAINER_KEYS:
+        container = metadata.get(key)
+        if not isinstance(container, dict):
+            continue
+        for nested_key in NESTED_MODEL_KEYS:
+            value = _optional_str(container.get(nested_key))
+            if value:
+                return value
+
     return None
 
 

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+import pytest
+
+from webchat_adapter import ChatGPTWebClient, ChatMessage
+
+
+def _message(
+    message_id: str,
+    role: str,
+    text: str | None,
+    *,
+    create_time: float = 1.0,
+    recipient: str = "all",
+    metadata: dict | None = None,
+) -> dict:
+    content: dict = {}
+    if text is not None:
+        content["parts"] = [text]
+    return {
+        "id": message_id,
+        "author": {"role": role},
+        "content": content,
+        "create_time": create_time,
+        "recipient": recipient,
+        "metadata": metadata or {},
+    }
+
+
+def _node(node_id: str, parent: str | None, message: dict | None) -> dict:
+    node = {"id": node_id, "parent": parent}
+    if message is not None:
+        node["message"] = message
+    return node
+
+
+def _payload(*, current_node: str | None, mapping: dict[str, dict]) -> dict:
+    payload = {"conversation_id": "conversation-1", "mapping": mapping}
+    if current_node is not None:
+        payload["current_node"] = current_node
+    return payload
+
+
+def _client(payload: dict | object) -> ChatGPTWebClient:
+    client = object.__new__(ChatGPTWebClient)
+    client._get_conversation_payload = lambda _conversation_id: payload
+    return client
+
+
+def test_get_messages_method_is_available() -> None:
+    assert hasattr(ChatGPTWebClient, "get_messages")
+
+
+def test_get_messages_reads_current_branch_not_entire_mapping() -> None:
+    payload = _payload(
+        current_node="assistant-current",
+        mapping={
+            "root": _node("root", None, None),
+            "user-1": _node(
+                "user-1",
+                "root",
+                _message("msg-user-1", "user", "Prompt", create_time=1.0),
+            ),
+            "assistant-current": _node(
+                "assistant-current",
+                "user-1",
+                _message(
+                    "msg-assistant-current",
+                    "assistant",
+                    "Current answer",
+                    create_time=2.0,
+                ),
+            ),
+            "assistant-other-branch": _node(
+                "assistant-other-branch",
+                "user-1",
+                _message(
+                    "msg-assistant-other",
+                    "assistant",
+                    "Other answer",
+                    create_time=3.0,
+                ),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1")
+
+    assert [message.node_id for message in messages] == [
+        "user-1",
+        "assistant-current",
+    ]
+    assert [message.text for message in messages] == ["Prompt", "Current answer"]
+
+
+def test_get_messages_returns_oldest_to_newest_order() -> None:
+    payload = _payload(
+        current_node="assistant-2",
+        mapping={
+            "user-1": _node(
+                "user-1",
+                None,
+                _message("msg-user-1", "user", "One", create_time=1.0),
+            ),
+            "assistant-1": _node(
+                "assistant-1",
+                "user-1",
+                _message("msg-assistant-1", "assistant", "Two", create_time=2.0),
+            ),
+            "user-2": _node(
+                "user-2",
+                "assistant-1",
+                _message("msg-user-2", "user", "Three", create_time=3.0),
+            ),
+            "assistant-2": _node(
+                "assistant-2",
+                "user-2",
+                _message("msg-assistant-2", "assistant", "Four", create_time=4.0),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1")
+
+    assert [message.node_id for message in messages] == [
+        "user-1",
+        "assistant-1",
+        "user-2",
+        "assistant-2",
+    ]
+
+
+def test_get_messages_limit_returns_last_n_after_filters() -> None:
+    payload = _payload(
+        current_node="assistant-2",
+        mapping={
+            "system-1": _node(
+                "system-1",
+                None,
+                _message("msg-system-1", "system", "System", create_time=0.5),
+            ),
+            "user-1": _node(
+                "user-1",
+                "system-1",
+                _message("msg-user-1", "user", "One", create_time=1.0),
+            ),
+            "assistant-1": _node(
+                "assistant-1",
+                "user-1",
+                _message("msg-assistant-1", "assistant", "Two", create_time=2.0),
+            ),
+            "user-2": _node(
+                "user-2",
+                "assistant-1",
+                _message("msg-user-2", "user", "Three", create_time=3.0),
+            ),
+            "assistant-2": _node(
+                "assistant-2",
+                "user-2",
+                _message("msg-assistant-2", "assistant", "Four", create_time=4.0),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages(
+        "conversation-1",
+        roles={"user", "assistant"},
+        limit=2,
+    )
+
+    assert [message.node_id for message in messages] == ["user-2", "assistant-2"]
+
+
+def test_get_messages_limit_none_returns_all_filtered_messages() -> None:
+    payload = _payload(
+        current_node="assistant-1",
+        mapping={
+            "system-1": _node(
+                "system-1",
+                None,
+                _message("msg-system-1", "system", "System", create_time=0.5),
+            ),
+            "user-1": _node(
+                "user-1",
+                "system-1",
+                _message("msg-user-1", "user", "One", create_time=1.0),
+            ),
+            "assistant-1": _node(
+                "assistant-1",
+                "user-1",
+                _message("msg-assistant-1", "assistant", "Two", create_time=2.0),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages(
+        "conversation-1",
+        roles={"user", "assistant"},
+        limit=None,
+    )
+
+    assert [message.node_id for message in messages] == ["user-1", "assistant-1"]
+
+
+def test_get_messages_limit_zero_returns_empty_list_without_fetching() -> None:
+    client = object.__new__(ChatGPTWebClient)
+
+    def fail_fetch(_conversation_id: str) -> dict:
+        raise AssertionError("payload should not be fetched")
+
+    client._get_conversation_payload = fail_fetch
+
+    assert client.get_messages("conversation-1", limit=0) == []
+
+
+def test_get_messages_negative_limit_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="limit must be greater than or equal to 0"):
+        _client({}).get_messages("conversation-1", limit=-1)
+
+
+def test_get_messages_non_int_limit_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="limit must be an int or None"):
+        _client({}).get_messages("conversation-1", limit=1.5)
+
+
+def test_get_messages_bool_limit_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="limit must be an int or None"):
+        _client({}).get_messages("conversation-1", limit=True)
+
+
+def test_get_messages_filters_by_roles() -> None:
+    payload = _payload(
+        current_node="assistant-1",
+        mapping={
+            "user-1": _node(
+                "user-1",
+                None,
+                _message("msg-user-1", "user", "Prompt", create_time=1.0),
+            ),
+            "assistant-1": _node(
+                "assistant-1",
+                "user-1",
+                _message("msg-assistant-1", "assistant", "Answer", create_time=2.0),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1", roles={"user"})
+
+    assert [message.role for message in messages] == ["user"]
+    assert [message.text for message in messages] == ["Prompt"]
+
+
+def test_get_messages_roles_none_returns_all_roles() -> None:
+    payload = _payload(
+        current_node="assistant-1",
+        mapping={
+            "system-1": _node(
+                "system-1",
+                None,
+                _message("msg-system-1", "system", "System", create_time=0.5),
+            ),
+            "user-1": _node(
+                "user-1",
+                "system-1",
+                _message("msg-user-1", "user", "Prompt", create_time=1.0),
+            ),
+            "assistant-1": _node(
+                "assistant-1",
+                "user-1",
+                _message("msg-assistant-1", "assistant", "Answer", create_time=2.0),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1")
+
+    assert [message.role for message in messages] == ["system", "user", "assistant"]
+
+
+def test_get_messages_empty_roles_returns_empty_list_without_fetching() -> None:
+    client = object.__new__(ChatGPTWebClient)
+
+    def fail_fetch(_conversation_id: str) -> dict:
+        raise AssertionError("payload should not be fetched")
+
+    client._get_conversation_payload = fail_fetch
+
+    assert client.get_messages("conversation-1", roles=set()) == []
+
+
+def test_get_messages_roles_string_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="roles must be an iterable of strings"):
+        _client({}).get_messages("conversation-1", roles="assistant")
+
+
+def test_get_messages_non_string_role_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="roles must contain only strings"):
+        _client({}).get_messages("conversation-1", roles={"assistant", 1})
+
+
+def test_get_messages_include_empty_false_filters_empty_messages() -> None:
+    payload = _payload(
+        current_node="assistant-1",
+        mapping={
+            "user-1": _node(
+                "user-1",
+                None,
+                _message("msg-user-1", "user", "Prompt", create_time=1.0),
+            ),
+            "assistant-1": _node(
+                "assistant-1",
+                "user-1",
+                _message("msg-assistant-1", "assistant", "", create_time=2.0),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1")
+
+    assert [message.node_id for message in messages] == ["user-1"]
+
+
+def test_get_messages_include_empty_true_keeps_empty_messages() -> None:
+    payload = _payload(
+        current_node="assistant-1",
+        mapping={
+            "user-1": _node(
+                "user-1",
+                None,
+                _message("msg-user-1", "user", "Prompt", create_time=1.0),
+            ),
+            "assistant-1": _node(
+                "assistant-1",
+                "user-1",
+                _message("msg-assistant-1", "assistant", "", create_time=2.0),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1", include_empty=True)
+
+    assert [message.node_id for message in messages] == ["user-1", "assistant-1"]
+    assert messages[-1].text == ""
+
+
+def test_get_messages_skips_malformed_node_without_message() -> None:
+    payload = _payload(
+        current_node="assistant-1",
+        mapping={
+            "malformed": _node("malformed", None, None),
+            "assistant-1": _node(
+                "assistant-1",
+                "malformed",
+                _message("msg-assistant-1", "assistant", "Answer", create_time=2.0),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1")
+
+    assert [message.node_id for message in messages] == ["assistant-1"]
+
+
+def test_get_messages_missing_current_node_returns_empty_list() -> None:
+    payload = _payload(
+        current_node=None,
+        mapping={
+            "user-1": _node(
+                "user-1",
+                None,
+                _message("msg-user-1", "user", "Prompt", create_time=1.0),
+            )
+        },
+    )
+
+    assert _client(payload).get_messages("conversation-1") == []
+
+
+def test_get_messages_current_node_missing_in_mapping_returns_empty_list() -> None:
+    payload = _payload(current_node="missing", mapping={})
+
+    assert _client(payload).get_messages("conversation-1") == []
+
+
+def test_get_messages_parent_cycle_does_not_hang() -> None:
+    payload = _payload(
+        current_node="node-a",
+        mapping={
+            "node-a": _node(
+                "node-a",
+                "node-b",
+                _message("msg-a", "assistant", "A", create_time=1.0),
+            ),
+            "node-b": _node(
+                "node-b",
+                "node-a",
+                _message("msg-b", "user", "B", create_time=2.0),
+            ),
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1")
+
+    assert [message.node_id for message in messages] == ["node-b", "node-a"]
+
+
+def test_get_messages_builds_chat_message_fields() -> None:
+    metadata = {
+        "content_type": "text",
+        "finish_details": {"type": "stop"},
+        "is_complete": True,
+        "model_slug": "gpt-5-5-thinking",
+        "ignored": "not copied",
+    }
+    payload = _payload(
+        current_node="assistant-1",
+        mapping={
+            "assistant-1": _node(
+                "assistant-1",
+                None,
+                _message(
+                    "msg-assistant-1",
+                    "assistant",
+                    "Answer",
+                    create_time=123.5,
+                    recipient="all",
+                    metadata=metadata,
+                ),
+            )
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1")
+
+    assert messages == [
+        ChatMessage(
+            node_id="assistant-1",
+            message_id="msg-assistant-1",
+            role="assistant",
+            text="Answer",
+            create_time=123.5,
+            recipient="all",
+            model="gpt-5-5-thinking",
+            finish_reason="stop",
+            metadata_preview={
+                "content_type": "text",
+                "finish_details": {"type": "stop"},
+                "is_complete": True,
+                "model_slug": "gpt-5-5-thinking",
+            },
+        )
+    ]
+
+
+def test_get_messages_reads_content_text_when_available() -> None:
+    payload = _payload(
+        current_node="assistant-1",
+        mapping={
+            "assistant-1": _node(
+                "assistant-1",
+                None,
+                {
+                    "id": "msg-assistant-1",
+                    "author": {"role": "assistant"},
+                    "content": {"text": "Text field"},
+                    "create_time": 1.0,
+                    "recipient": "all",
+                    "metadata": {},
+                },
+            )
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1")
+
+    assert [message.text for message in messages] == ["Text field"]
+
+
+def test_get_messages_joins_string_parts_and_ignores_structured_parts_for_now() -> None:
+    payload = _payload(
+        current_node="assistant-1",
+        mapping={
+            "assistant-1": _node(
+                "assistant-1",
+                None,
+                {
+                    "id": "msg-assistant-1",
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["One", {"type": "image"}, "Two"]},
+                    "create_time": 1.0,
+                    "recipient": "all",
+                    "metadata": {},
+                },
+            )
+        },
+    )
+
+    messages = _client(payload).get_messages("conversation-1")
+
+    assert [message.text for message in messages] == ["One\nTwo"]
+
+
+def test_get_messages_non_dict_payload_returns_empty_list() -> None:
+    assert _client([]).get_messages("conversation-1") == []

--- a/tests/test_get_messages_model_metadata.py
+++ b/tests/test_get_messages_model_metadata.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from webchat_adapter import ChatGPTWebClient
+
+
+def _client(metadata: dict) -> ChatGPTWebClient:
+    payload = {
+        "conversation_id": "conversation-1",
+        "current_node": "assistant-1",
+        "mapping": {
+            "assistant-1": {
+                "id": "assistant-1",
+                "parent": None,
+                "message": {
+                    "id": "msg-assistant-1",
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["Answer"]},
+                    "create_time": 1.0,
+                    "recipient": "all",
+                    "metadata": metadata,
+                },
+            }
+        },
+    }
+    client = object.__new__(ChatGPTWebClient)
+    client._get_conversation_payload = lambda _conversation_id: payload
+    return client
+
+
+def test_get_messages_reads_model_slug_from_nested_model_container() -> None:
+    messages = _client({"model": {"slug": "gpt-5-5-thinking"}}).get_messages(
+        "conversation-1"
+    )
+
+    assert messages[0].model == "gpt-5-5-thinking"
+
+
+def test_get_messages_reads_model_id_from_nested_selected_model_container() -> None:
+    messages = _client({"selected_model": {"id": "gpt-4.1"}}).get_messages(
+        "conversation-1"
+    )
+
+    assert messages[0].model == "gpt-4.1"
+
+
+def test_get_messages_prefers_direct_model_slug_over_nested_container() -> None:
+    messages = _client(
+        {
+            "model_slug": "direct-model",
+            "model": {"slug": "nested-model"},
+        }
+    ).get_messages("conversation-1")
+
+    assert messages[0].model == "direct-model"


### PR DESCRIPTION
## Summary

- Add `client.get_messages(url_or_id, *, limit=None, roles=None, include_empty=False)`.
- Traverse only the active `current_node -> parent -> root` chain, then return messages oldest-to-newest.
- Convert branch nodes into `ChatMessage` values.
- Support `limit` after role/empty filters.
- Support `roles={...}` filtering and defensive role validation.
- Support `include_empty=False` by default.
- Add cycle protection for malformed parent chains.
- Add minimal text extraction for `content.text` and string `content.parts` only.

## Scope

- No markdown/jsonl/txt export.
- No full multimodal/structured text extraction; PR2.3 will harden that layer.
- No README changes.
- No raw mapping dump or alternate branch selection.

## Tests

- Cover method availability, current-branch-only traversal, oldest-to-newest order, limit-after-filters, `limit=None`, `limit=0`, invalid limits, role filtering, invalid roles, `include_empty`, malformed nodes, missing `current_node`, missing mapping node, cycle protection, `ChatMessage` field mapping, basic `content.text`, basic string `parts`, and non-dict payload handling.

Not run locally from this environment. CI runs `pytest -q` and package build.