### PR TITLE
PR2.3: Harden message text extraction

### DIFF
--- a/src/webchat_adapter/message_text.py
+++ b/src/webchat_adapter/message_text.py
@@ -22,11 +22,13 @@ MEDIA_KIND_BY_MIME_PREFIX = {
     "video/": "video",
 }
 MEDIA_KIND_MARKERS = (
-    ("image", "image"),
-    ("audio", "audio"),
-    ("video", "video"),
-    ("file", "file"),
+    ("image_asset_pointer", "image"),
+    ("audio_asset_pointer", "audio"),
+    ("video_asset_pointer", "video"),
+    ("asset_pointer", "media"),
+    ("assetpointer", "media"),
     ("attachment", "file"),
+    ("file", "file"),
 )
 ASSET_POINTER_KEYS = (
     "asset_pointer",
@@ -138,8 +140,6 @@ def _media_kind(value: dict[str, Any]) -> str | None:
         for marker, kind in MEDIA_KIND_MARKERS:
             if marker in normalized:
                 return kind
-        if "asset_pointer" in normalized or "assetpointer" in normalized:
-            return "media"
 
     for key in ASSET_POINTER_KEYS:
         if key in value:

--- a/src/webchat_adapter/message_text.py
+++ b/src/webchat_adapter/message_text.py
@@ -44,17 +44,17 @@ def extract_message_text(message: dict[str, Any]) -> str:
         return ""
 
     chunks: list[str] = []
-    seen: set[int] = set()
-    _collect_text(message.get("content"), chunks, seen)
+    stack: set[int] = set()
+    _collect_text(message.get("content"), chunks, stack)
 
     if not chunks:
-        _collect_text(message.get("text"), chunks, seen)
-        _collect_text(message.get("multimodal_text"), chunks, seen)
+        _collect_text(message.get("text"), chunks, stack)
+        _collect_text(message.get("multimodal_text"), chunks, stack)
 
     return "\n".join(chunks).strip()
 
 
-def _collect_text(value: Any, chunks: list[str], seen: set[int]) -> None:
+def _collect_text(value: Any, chunks: list[str], stack: set[int]) -> None:
     if value is None:
         return
 
@@ -65,30 +65,39 @@ def _collect_text(value: Any, chunks: list[str], seen: set[int]) -> None:
     if isinstance(value, (int, float, bool)):
         return
 
-    value_id = id(value)
-    if value_id in seen:
-        return
-    seen.add(value_id)
-
     if isinstance(value, list):
-        for item in value:
-            _collect_text(item, chunks, seen)
+        value_id = id(value)
+        if value_id in stack:
+            return
+        stack.add(value_id)
+        try:
+            for item in value:
+                _collect_text(item, chunks, stack)
+        finally:
+            stack.discard(value_id)
         return
 
     if not isinstance(value, dict):
         return
 
-    placeholder = _media_placeholder(value)
-    if placeholder:
-        _append_text(chunks, placeholder)
+    value_id = id(value)
+    if value_id in stack:
+        return
+    stack.add(value_id)
+    try:
+        placeholder = _media_placeholder(value)
+        if placeholder:
+            _append_text(chunks, placeholder)
 
-    for key in TEXT_FIELD_KEYS:
-        if key in value:
-            _collect_text(value[key], chunks, seen)
+        for key in TEXT_FIELD_KEYS:
+            if key in value:
+                _collect_text(value[key], chunks, stack)
 
-    for key in PART_FIELD_KEYS:
-        if key in value:
-            _collect_text(value[key], chunks, seen)
+        for key in PART_FIELD_KEYS:
+            if key in value:
+                _collect_text(value[key], chunks, stack)
+    finally:
+        stack.discard(value_id)
 
 
 def _append_text(chunks: list[str], value: str) -> None:

--- a/src/webchat_adapter/message_text.py
+++ b/src/webchat_adapter/message_text.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any
+
+TEXT_FIELD_KEYS = (
+    "text",
+    "content",
+    "value",
+    "caption",
+    "alt_text",
+    "title",
+)
+PART_FIELD_KEYS = (
+    "parts",
+    "multimodal_text",
+    "items",
+    "children",
+)
+MEDIA_KIND_BY_MIME_PREFIX = {
+    "image/": "image",
+    "audio/": "audio",
+    "video/": "video",
+}
+MEDIA_KIND_MARKERS = (
+    ("image", "image"),
+    ("audio", "audio"),
+    ("video", "video"),
+    ("file", "file"),
+    ("attachment", "file"),
+)
+
+
+def extract_message_text(message: dict[str, Any]) -> str:
+    """Best-effort text extraction from unstable ChatGPT web message payloads."""
+
+    if not isinstance(message, dict):
+        return ""
+
+    chunks: list[str] = []
+    seen: set[int] = set()
+    _collect_text(message.get("content"), chunks, seen)
+
+    if not chunks:
+        _collect_text(message.get("text"), chunks, seen)
+        _collect_text(message.get("multimodal_text"), chunks, seen)
+
+    return "\n".join(chunks).strip()
+
+
+def _collect_text(value: Any, chunks: list[str], seen: set[int]) -> None:
+    if value is None:
+        return
+
+    if isinstance(value, str):
+        _append_text(chunks, value)
+        return
+
+    if isinstance(value, (int, float, bool)):
+        return
+
+    value_id = id(value)
+    if value_id in seen:
+        return
+    seen.add(value_id)
+
+    if isinstance(value, list):
+        for item in value:
+            _collect_text(item, chunks, seen)
+        return
+
+    if not isinstance(value, dict):
+        return
+
+    placeholder = _media_placeholder(value)
+    if placeholder:
+        _append_text(chunks, placeholder)
+
+    for key in TEXT_FIELD_KEYS:
+        if key in value:
+            _collect_text(value[key], chunks, seen)
+
+    for key in PART_FIELD_KEYS:
+        if key in value:
+            _collect_text(value[key], chunks, seen)
+
+
+def _append_text(chunks: list[str], value: str) -> None:
+    text = value.strip()
+    if not text:
+        return
+    if chunks and chunks[-1] == text:
+        return
+    chunks.append(text)
+
+
+def _media_placeholder(value: dict[str, Any]) -> str | None:
+    media_kind = _media_kind(value)
+    if media_kind is None:
+        return None
+
+    file_name = _media_file_name(value)
+    if file_name and media_kind == "file":
+        return f"[file: {file_name}]"
+    return f"[{media_kind}]"
+
+
+def _media_kind(value: dict[str, Any]) -> str | None:
+    mime_type = value.get("mime_type") or value.get("mimeType")
+    if isinstance(mime_type, str):
+        mime_type = mime_type.strip().lower()
+        for prefix, kind in MEDIA_KIND_BY_MIME_PREFIX.items():
+            if mime_type.startswith(prefix):
+                return kind
+        if mime_type:
+            return "file"
+
+    for key in ("type", "content_type", "asset_pointer", "assetPointer"):
+        raw_value = value.get(key)
+        if not isinstance(raw_value, str):
+            continue
+        normalized = raw_value.strip().lower()
+        for marker, kind in MEDIA_KIND_MARKERS:
+            if marker in normalized:
+                return kind
+        if "asset_pointer" in normalized or "assetpointer" in normalized:
+            return "media"
+
+    if _media_file_name(value) and _has_media_signal(value):
+        return "file"
+
+    return None
+
+
+def _media_file_name(value: dict[str, Any]) -> str | None:
+    for key in ("file_name", "filename", "name"):
+        file_name = value.get(key)
+        if isinstance(file_name, str) and file_name.strip():
+            return file_name.strip()
+    return None
+
+
+def _has_media_signal(value: dict[str, Any]) -> bool:
+    signal_keys = (
+        "mime_type",
+        "mimeType",
+        "file_name",
+        "filename",
+        "asset_pointer",
+        "assetPointer",
+        "image_asset_pointer",
+        "audio_asset_pointer",
+        "video_asset_pointer",
+    )
+    return any(key in value for key in signal_keys)

--- a/src/webchat_adapter/message_text.py
+++ b/src/webchat_adapter/message_text.py
@@ -28,6 +28,13 @@ MEDIA_KIND_MARKERS = (
     ("file", "file"),
     ("attachment", "file"),
 )
+ASSET_POINTER_KEYS = (
+    "asset_pointer",
+    "assetPointer",
+    "image_asset_pointer",
+    "audio_asset_pointer",
+    "video_asset_pointer",
+)
 
 
 def extract_message_text(message: dict[str, Any]) -> str:
@@ -114,7 +121,7 @@ def _media_kind(value: dict[str, Any]) -> str | None:
         if mime_type:
             return "file"
 
-    for key in ("type", "content_type", "asset_pointer", "assetPointer"):
+    for key in ("type", "content_type"):
         raw_value = value.get(key)
         if not isinstance(raw_value, str):
             continue
@@ -125,10 +132,24 @@ def _media_kind(value: dict[str, Any]) -> str | None:
         if "asset_pointer" in normalized or "assetpointer" in normalized:
             return "media"
 
+    for key in ASSET_POINTER_KEYS:
+        if key in value:
+            return _asset_pointer_kind(key)
+
     if _media_file_name(value) and _has_media_signal(value):
         return "file"
 
     return None
+
+
+def _asset_pointer_kind(key: str) -> str:
+    if key.startswith("image"):
+        return "image"
+    if key.startswith("audio"):
+        return "audio"
+    if key.startswith("video"):
+        return "video"
+    return "media"
 
 
 def _media_file_name(value: dict[str, Any]) -> str | None:
@@ -145,10 +166,6 @@ def _has_media_signal(value: dict[str, Any]) -> bool:
         "mimeType",
         "file_name",
         "filename",
-        "asset_pointer",
-        "assetPointer",
-        "image_asset_pointer",
-        "audio_asset_pointer",
-        "video_asset_pointer",
+        *ASSET_POINTER_KEYS,
     )
     return any(key in value for key in signal_keys)

--- a/src/webchat_adapter/messages.py
+++ b/src/webchat_adapter/messages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
+from .message_text import extract_message_text
 from .types import ChatConversation, ChatMessage, ConversationRef
 
 METADATA_PREVIEW_KEYS = (
@@ -115,22 +116,6 @@ def _message_metadata_preview(message: dict[str, Any]) -> dict[str, Any]:
     return {key: metadata[key] for key in METADATA_PREVIEW_KEYS if key in metadata}
 
 
-def _basic_message_text(message: dict[str, Any]) -> str:
-    content = message.get("content")
-    if not isinstance(content, dict):
-        return ""
-
-    text = content.get("text")
-    if isinstance(text, str):
-        return text
-
-    parts = content.get("parts")
-    if not isinstance(parts, list):
-        return ""
-
-    return "\n".join(part for part in parts if isinstance(part, str) and part)
-
-
 def _chat_message_from_node(node_id: str, node: dict[str, Any]) -> ChatMessage | None:
     message = _message_from_node(node)
     if message is None:
@@ -140,7 +125,7 @@ def _chat_message_from_node(node_id: str, node: dict[str, Any]) -> ChatMessage |
         node_id=node_id,
         message_id=message.get("id"),
         role=_message_role(message),
-        text=_basic_message_text(message),
+        text=extract_message_text(message),
         create_time=message.get("create_time"),
         recipient=message.get("recipient"),
         model=_message_model(message),

--- a/tests/test_get_messages_text_extraction.py
+++ b/tests/test_get_messages_text_extraction.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from webchat_adapter import ChatGPTWebClient
+
+
+def _client(message: dict) -> ChatGPTWebClient:
+    payload = {
+        "conversation_id": "conversation-1",
+        "current_node": "message-1",
+        "mapping": {
+            "message-1": {
+                "id": "message-1",
+                "parent": None,
+                "message": message,
+            }
+        },
+    }
+    client = object.__new__(ChatGPTWebClient)
+    client._get_conversation_payload = lambda _conversation_id: payload
+    return client
+
+
+def _message(content: object, *, role: str = "user") -> dict:
+    return {
+        "id": "msg-1",
+        "author": {"role": role},
+        "content": content,
+        "create_time": 1.0,
+        "recipient": "all",
+        "metadata": {},
+    }
+
+
+def test_get_messages_keeps_media_only_message_by_default() -> None:
+    message = _message({"parts": [{"type": "image_asset_pointer"}]})
+
+    messages = _client(message).get_messages("conversation-1")
+
+    assert [message.text for message in messages] == ["[image]"]
+
+
+def test_get_messages_filters_truly_empty_message_by_default() -> None:
+    message = _message({"parts": [{"unknown": {"nested": 1}}]})
+
+    messages = _client(message).get_messages("conversation-1")
+
+    assert messages == []
+
+
+def test_get_messages_include_empty_true_keeps_truly_empty_message() -> None:
+    message = _message({"parts": [{"unknown": {"nested": 1}}]})
+
+    messages = _client(message).get_messages("conversation-1", include_empty=True)
+
+    assert len(messages) == 1
+    assert messages[0].text == ""
+
+
+def test_get_messages_does_not_crash_on_tool_message_without_text() -> None:
+    message = _message({"result": {"ok": True}}, role="tool")
+
+    messages = _client(message).get_messages("conversation-1", include_empty=True)
+
+    assert len(messages) == 1
+    assert messages[0].role == "tool"
+    assert messages[0].text == ""

--- a/tests/test_message_text_extraction.py
+++ b/tests/test_message_text_extraction.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from webchat_adapter.message_text import extract_message_text
+
+
+def test_extract_message_text_reads_content_text() -> None:
+    assert extract_message_text({"content": {"text": "Hello"}}) == "Hello"
+
+
+def test_extract_message_text_reads_string_parts() -> None:
+    message = {"content": {"parts": ["Hello", "world"]}}
+
+    assert extract_message_text(message) == "Hello\nworld"
+
+
+def test_extract_message_text_reads_structured_text_part() -> None:
+    message = {"content": {"parts": [{"type": "text", "text": "Hello"}]}}
+
+    assert extract_message_text(message) == "Hello"
+
+
+def test_extract_message_text_reads_structured_known_text_fields() -> None:
+    message = {
+        "content": {
+            "parts": [
+                {"caption": "Caption"},
+                {"alt_text": "Alt text"},
+                {"title": "Title"},
+                {"value": "Value"},
+            ]
+        }
+    }
+
+    assert extract_message_text(message) == "Caption\nAlt text\nTitle\nValue"
+
+
+def test_extract_message_text_reads_multimodal_text_with_image_placeholder() -> None:
+    message = {
+        "content": {
+            "content_type": "multimodal_text",
+            "parts": [
+                {"type": "text", "text": "Look"},
+                {"type": "image_asset_pointer"},
+            ],
+        }
+    }
+
+    assert extract_message_text(message) == "Look\n[image]"
+
+
+def test_extract_message_text_reads_multimodal_text_string() -> None:
+    message = {"content": {"multimodal_text": "Look at this"}}
+
+    assert extract_message_text(message) == "Look at this"
+
+
+def test_extract_message_text_reads_multimodal_text_list() -> None:
+    message = {"content": {"multimodal_text": [{"text": "A"}, {"text": "B"}]}}
+
+    assert extract_message_text(message) == "A\nB"
+
+
+def test_extract_message_text_emits_file_placeholder_with_filename() -> None:
+    message = {"content": {"parts": [{"type": "file", "file_name": "report.pdf"}]}}
+
+    assert extract_message_text(message) == "[file: report.pdf]"
+
+
+def test_extract_message_text_emits_image_placeholder_from_mime_type() -> None:
+    message = {"content": {"parts": [{"mime_type": "image/png"}]}}
+
+    assert extract_message_text(message) == "[image]"
+
+
+def test_extract_message_text_emits_audio_and_video_placeholders() -> None:
+    audio = {"content": {"parts": [{"mime_type": "audio/mpeg"}]}}
+    video = {"content": {"parts": [{"mime_type": "video/mp4"}]}}
+
+    assert extract_message_text(audio) == "[audio]"
+    assert extract_message_text(video) == "[video]"
+
+
+def test_extract_message_text_emits_media_placeholder_from_asset_pointer_key() -> None:
+    message = {"content": {"parts": [{"asset_pointer": "file-service://asset"}]}}
+
+    assert extract_message_text(message) == "[media]"
+
+
+def test_extract_message_text_unknown_dict_returns_empty_string() -> None:
+    message = {"content": {"parts": [{"unknown": {"nested": 1}}]}}
+
+    assert extract_message_text(message) == ""
+
+
+def test_extract_message_text_reads_content_as_string() -> None:
+    assert extract_message_text({"content": "tool output"}) == "tool output"
+
+
+def test_extract_message_text_reads_content_as_list() -> None:
+    assert extract_message_text({"content": ["A", {"text": "B"}]}) == "A\nB"
+
+
+def test_extract_message_text_empty_messages_return_empty_string() -> None:
+    assert extract_message_text({}) == ""
+    assert extract_message_text({"content": None}) == ""
+    assert extract_message_text({"content": {"parts": []}}) == ""
+
+
+def test_extract_message_text_tool_and_system_shapes_do_not_crash() -> None:
+    tool_message = {"author": {"role": "tool"}, "content": {"result": {"ok": True}}}
+    system_message = {"author": {"role": "system"}, "content": None}
+
+    assert extract_message_text(tool_message) == ""
+    assert extract_message_text(system_message) == ""
+
+
+def test_extract_message_text_reads_tool_text_when_present() -> None:
+    message = {"author": {"role": "tool"}, "content": {"text": "Tool output"}}
+
+    assert extract_message_text(message) == "Tool output"
+
+
+def test_extract_message_text_deduplicates_adjacent_duplicate_chunks() -> None:
+    message = {"content": {"text": "Hello", "parts": ["Hello", "world"]}}
+
+    assert extract_message_text(message) == "Hello\nworld"
+
+
+def test_extract_message_text_does_not_recurse_forever_on_cycles() -> None:
+    content: dict = {"text": "Hello"}
+    content["parts"] = [content]
+
+    assert extract_message_text({"content": content}) == "Hello"
+
+
+def test_extract_message_text_allows_reused_structured_objects_in_sibling_positions() -> None:
+    part = {"text": "Repeated"}
+    message = {"content": {"parts": [part, part]}}
+
+    assert extract_message_text(message) == "Repeated"


### PR DESCRIPTION
## Summary

- Add a dedicated `message_text.extract_message_text()` helper.
- Extract text from `content.text`, `content.parts`, `multimodal_text`, and structured text parts.
- Emit simple placeholders for media-like payloads.
- Keep `get_messages()` stable on empty, tool, system, and unknown message shapes.
- Wire `get_messages()` to use the new extractor without changing its public signature.

## Scope

- No export API.
- No README changes.
- No traversal changes.
- No new public method.

## Tests

- Add focused extraction tests.
- Add `get_messages()` integration tests for media-only and empty messages.

Not run locally from this environment. CI runs `pytest -q` and package build.