### PR TITLE
PR2.4: Add export v1

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -5,6 +5,7 @@ from .auth import DEFAULT_AUTH_FILE, load_auth_data
 from .client import DEFAULT_MODEL, ChatGPTWebClient
 from .conversation_send import send_to_conversation as _send_to_conversation
 from .exceptions import AuthError, MediaError, RequestError, WebChatAdapterError
+from .export import export_conversation as _export_conversation
 from .messages import get_messages as _get_messages
 from .types import (
     AttachedConversation,
@@ -19,6 +20,7 @@ from .types import (
 )
 
 ChatGPTWebClient.attach_conversation = _attach_conversation
+ChatGPTWebClient.export_conversation = _export_conversation
 ChatGPTWebClient.get_messages = _get_messages
 ChatGPTWebClient.send_to_conversation = _send_to_conversation
 WebChatClient = ChatGPTWebClient

--- a/src/webchat_adapter/export.py
+++ b/src/webchat_adapter/export.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .types import ChatConversation, ChatMessage, ConversationRef
+
+EXPORT_FORMAT_ALIASES = {
+    "markdown": "markdown",
+    "md": "markdown",
+    "jsonl": "jsonl",
+    "txt": "txt",
+    "text": "txt",
+}
+EMPTY_TEXT = "[empty]"
+
+
+def _normalize_export_format(format: str) -> str:
+    if not isinstance(format, str):
+        raise TypeError("format must be a string")
+
+    normalized = format.strip().lower()
+    export_format = EXPORT_FORMAT_ALIASES.get(normalized)
+    if export_format is None:
+        supported = ", ".join(sorted(set(EXPORT_FORMAT_ALIASES.values())))
+        raise ValueError(f"unsupported export format: {format!r}; supported: {supported}")
+    return export_format
+
+
+def _role_label(role: str | None) -> str:
+    if not isinstance(role, str):
+        return "Message"
+
+    cleaned = " ".join(role.replace("_", " ").split())
+    if not cleaned:
+        return "Message"
+    return cleaned.title()
+
+
+def _display_text(message: ChatMessage) -> str:
+    return message.text if message.text else EMPTY_TEXT
+
+
+def _format_markdown(messages: list[ChatMessage]) -> str:
+    blocks: list[str] = []
+    for message in messages:
+        blocks.append(f"## {_role_label(message.role)}\n\n{_display_text(message)}")
+    return "\n\n".join(blocks)
+
+
+def _format_txt(messages: list[ChatMessage]) -> str:
+    blocks: list[str] = []
+    for message in messages:
+        blocks.append(f"{_role_label(message.role)}:\n{_display_text(message)}")
+    return "\n\n".join(blocks)
+
+
+def _format_jsonl(messages: list[ChatMessage]) -> str:
+    return "\n".join(
+        json.dumps(message.to_dict(), ensure_ascii=False, sort_keys=True)
+        for message in messages
+    )
+
+
+def export_conversation(
+    self: Any,
+    url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
+    *,
+    format: str = "markdown",
+) -> str:
+    """Export the current branch of a conversation in a stable text format."""
+
+    export_format = _normalize_export_format(format)
+    messages = self.get_messages(url_or_id, limit=None, include_empty=True)
+
+    if export_format == "markdown":
+        return _format_markdown(messages)
+    if export_format == "jsonl":
+        return _format_jsonl(messages)
+    if export_format == "txt":
+        return _format_txt(messages)
+
+    raise AssertionError("unreachable export format")

--- a/tests/test_export_conversation.py
+++ b/tests/test_export_conversation.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from webchat_adapter import ChatGPTWebClient, ChatMessage
+
+
+def _client(messages: list[ChatMessage]) -> ChatGPTWebClient:
+    client = object.__new__(ChatGPTWebClient)
+    client.get_messages = lambda _url_or_id, *, limit, include_empty: messages
+    return client
+
+
+def test_export_conversation_method_is_available() -> None:
+    assert hasattr(ChatGPTWebClient, "export_conversation")
+
+
+def test_export_conversation_markdown_formats_messages() -> None:
+    client = _client(
+        [
+            ChatMessage(role="user", text="Hello"),
+            ChatMessage(role="assistant", text="Hi"),
+        ]
+    )
+
+    output = client.export_conversation("conversation-1", format="markdown")
+
+    assert output == "## User\n\nHello\n\n## Assistant\n\nHi"
+
+
+def test_export_conversation_txt_formats_messages() -> None:
+    client = _client(
+        [
+            ChatMessage(role="user", text="Hello"),
+            ChatMessage(role="assistant", text="Hi"),
+        ]
+    )
+
+    output = client.export_conversation("conversation-1", format="txt")
+
+    assert output == "User:\nHello\n\nAssistant:\nHi"
+
+
+def test_export_conversation_jsonl_formats_messages() -> None:
+    messages = [
+        ChatMessage(
+            node_id="node-user",
+            message_id="msg-user",
+            role="user",
+            text="Hello",
+            create_time=1.0,
+            recipient="all",
+        ),
+        ChatMessage(
+            node_id="node-assistant",
+            message_id="msg-assistant",
+            role="assistant",
+            text="Hi",
+            create_time=2.0,
+            recipient="all",
+            model="gpt-5-5-thinking",
+            finish_reason="stop",
+            metadata_preview={"finish_details": {"type": "stop"}},
+        ),
+    ]
+    client = _client(messages)
+
+    output = client.export_conversation("conversation-1", format="jsonl")
+    lines = output.splitlines()
+
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == messages[0].to_dict()
+    assert json.loads(lines[1]) == messages[1].to_dict()
+
+
+def test_export_conversation_jsonl_preserves_unicode() -> None:
+    client = _client([ChatMessage(role="user", text="Привет こんにちは")])
+
+    output = client.export_conversation("conversation-1", format="jsonl")
+
+    assert "Привет こんにちは" in output
+    assert "\\u041f" not in output
+
+
+def test_export_conversation_format_aliases() -> None:
+    client = _client([ChatMessage(role="user", text="Hello")])
+
+    assert client.export_conversation("conversation-1", format="md") == "## User\n\nHello"
+    assert client.export_conversation("conversation-1", format="text") == "User:\nHello"
+
+
+def test_export_conversation_default_format_is_markdown() -> None:
+    client = _client([ChatMessage(role="user", text="Hello")])
+
+    assert client.export_conversation("conversation-1") == "## User\n\nHello"
+
+
+def test_export_conversation_unsupported_format_raises_value_error() -> None:
+    client = _client([])
+
+    with pytest.raises(ValueError, match="unsupported export format"):
+        client.export_conversation("conversation-1", format="html")
+
+
+def test_export_conversation_non_string_format_raises_type_error() -> None:
+    client = _client([])
+
+    with pytest.raises(TypeError, match="format must be a string"):
+        client.export_conversation("conversation-1", format=None)
+
+
+def test_export_conversation_calls_get_messages_with_export_defaults() -> None:
+    client = object.__new__(ChatGPTWebClient)
+    calls = []
+
+    def get_messages(url_or_id: str, *, limit: int | None, include_empty: bool):
+        calls.append((url_or_id, limit, include_empty))
+        return [ChatMessage(role="user", text="Hello")]
+
+    client.get_messages = get_messages
+
+    output = client.export_conversation("conversation-1", format="txt")
+
+    assert output == "User:\nHello"
+    assert calls == [("conversation-1", None, True)]
+
+
+def test_export_conversation_markdown_and_txt_render_empty_text_as_placeholder() -> None:
+    client = _client([ChatMessage(role="tool", text="")])
+
+    assert client.export_conversation("conversation-1", format="markdown") == "## Tool\n\n[empty]"
+    assert client.export_conversation("conversation-1", format="txt") == "Tool:\n[empty]"
+
+
+def test_export_conversation_jsonl_keeps_empty_text_empty() -> None:
+    client = _client([ChatMessage(role="tool", text="")])
+
+    output = client.export_conversation("conversation-1", format="jsonl")
+
+    assert json.loads(output)["text"] == ""
+
+
+def test_export_conversation_role_label_fallbacks() -> None:
+    client = _client(
+        [
+            ChatMessage(role=None, text="No role"),
+            ChatMessage(role="custom_role", text="Custom"),
+            ChatMessage(role="assistant\n# injected", text="Safe label"),
+        ]
+    )
+
+    output = client.export_conversation("conversation-1", format="txt")
+
+    assert output == (
+        "Message:\nNo role\n\n"
+        "Custom Role:\nCustom\n\n"
+        "Assistant # Injected:\nSafe label"
+    )
+
+
+def test_export_conversation_empty_message_list_returns_empty_string() -> None:
+    client = _client([])
+
+    assert client.export_conversation("conversation-1", format="markdown") == ""
+    assert client.export_conversation("conversation-1", format="txt") == ""
+    assert client.export_conversation("conversation-1", format="jsonl") == ""


### PR DESCRIPTION
## Summary

- Add `client.export_conversation(url_or_id, format=...)`.
- Support `markdown`, `jsonl`, and `txt` formats.
- Format exports from existing `get_messages()` results instead of reading raw conversation payloads.
- Render empty Markdown/TXT message text as `[empty]` while preserving empty text in JSONL.
- Add format aliases: `md -> markdown`, `text -> txt`.

## Scope

- No README changes.
- No file-writing API.
- No traversal changes.
- No message text extraction changes.

## Tests

- Cover markdown, txt, jsonl, unicode JSONL, aliases, invalid formats, export defaults, empty messages, role labels, and `get_messages(limit=None, include_empty=True)` integration.

Not run locally from this environment. CI runs `pytest -q` and package build.