### PR TITLE
PR3.1: Add ConversationStatus type

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -15,6 +15,7 @@ from .types import (
     ChatMetrics,
     ChatResponse,
     ConversationRef,
+    ConversationStatus,
     MediaItem,
     MediaSource,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "ChatMetrics",
     "ChatResponse",
     "ConversationRef",
+    "ConversationStatus",
     "DEFAULT_AUTH_FILE",
     "DEFAULT_MODEL",
     "MediaError",

--- a/src/webchat_adapter/types.py
+++ b/src/webchat_adapter/types.py
@@ -4,11 +4,29 @@ import copy
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 MediaSource = bytes | bytearray | str | Path | os.PathLike[str]
 MediaItem = MediaSource | tuple[MediaSource, str | None]
+ConversationStatusValue = Literal[
+    "completed",
+    "running",
+    "awaiting_tool_approval",
+    "tool_calling",
+    "tool_running",
+    "user_last_message",
+    "unknown",
+]
+CONVERSATION_STATUS_VALUES: tuple[ConversationStatusValue, ...] = (
+    "completed",
+    "running",
+    "awaiting_tool_approval",
+    "tool_calling",
+    "tool_running",
+    "user_last_message",
+    "unknown",
+)
 
 
 def _optional_str(value: Any) -> str | None:
@@ -313,6 +331,68 @@ class AttachedConversation:
             "detected_model": self.detected_model,
             "title": self.title,
             "raw_status": dict(self.raw_status),
+        }
+
+
+@dataclass
+class ConversationStatus:
+    status: ConversationStatusValue = "unknown"
+    node_id: str | None = None
+    message_id: str | None = None
+    role: str | None = None
+    recipient: str | None = None
+    async_status: str | None = None
+    finish_reason: str | None = None
+    pending_approval: bool = False
+    metadata_preview: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        status = _optional_str(self.status)
+        if status not in CONVERSATION_STATUS_VALUES:
+            raise ValueError(f"unsupported conversation status: {self.status!r}")
+        self.status = status
+        self.node_id = _optional_str(self.node_id)
+        self.message_id = _optional_str(self.message_id)
+        self.role = _optional_str(self.role)
+        self.recipient = _optional_str(self.recipient)
+        self.async_status = _optional_str(self.async_status)
+        self.finish_reason = _optional_str(self.finish_reason)
+        self.pending_approval = bool(self.pending_approval)
+
+        if self.metadata_preview is None:
+            self.metadata_preview = {}
+        elif not isinstance(self.metadata_preview, dict):
+            raise TypeError("metadata_preview must be a dict")
+        else:
+            self.metadata_preview = copy.deepcopy(self.metadata_preview)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "ConversationStatus":
+        if not isinstance(payload, dict):
+            return cls()
+        return cls(
+            status=payload.get("status", "unknown"),
+            node_id=payload.get("node_id"),
+            message_id=payload.get("message_id"),
+            role=payload.get("role"),
+            recipient=payload.get("recipient"),
+            async_status=payload.get("async_status"),
+            finish_reason=payload.get("finish_reason"),
+            pending_approval=payload.get("pending_approval", False),
+            metadata_preview=payload.get("metadata_preview"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "node_id": self.node_id,
+            "message_id": self.message_id,
+            "role": self.role,
+            "recipient": self.recipient,
+            "async_status": self.async_status,
+            "finish_reason": self.finish_reason,
+            "pending_approval": self.pending_approval,
+            "metadata_preview": copy.deepcopy(self.metadata_preview),
         }
 
 

--- a/tests/test_conversation_status.py
+++ b/tests/test_conversation_status.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import pytest
+
+import webchat_adapter
+from webchat_adapter import ConversationStatus
+from webchat_adapter.types import CONVERSATION_STATUS_VALUES
+
+
+def test_conversation_status_defaults_to_unknown() -> None:
+    status = ConversationStatus()
+
+    assert status.status == "unknown"
+    assert status.node_id is None
+    assert status.message_id is None
+    assert status.role is None
+    assert status.recipient is None
+    assert status.async_status is None
+    assert status.finish_reason is None
+    assert status.pending_approval is False
+    assert status.metadata_preview == {}
+
+
+def test_conversation_status_accepts_known_statuses() -> None:
+    for value in CONVERSATION_STATUS_VALUES:
+        assert ConversationStatus(status=value).status == value
+
+
+def test_conversation_status_rejects_unknown_status() -> None:
+    with pytest.raises(ValueError, match="unsupported conversation status"):
+        ConversationStatus(status="done")
+
+
+def test_conversation_status_normalizes_optional_string_fields() -> None:
+    status = ConversationStatus(
+        status=" completed ",
+        node_id=" node ",
+        message_id=" msg ",
+        role=" assistant ",
+        recipient=" all ",
+        async_status=" completed ",
+        finish_reason=" stop ",
+    )
+
+    assert status.status == "completed"
+    assert status.node_id == "node"
+    assert status.message_id == "msg"
+    assert status.role == "assistant"
+    assert status.recipient == "all"
+    assert status.async_status == "completed"
+    assert status.finish_reason == "stop"
+
+
+def test_conversation_status_non_string_optional_fields_become_none() -> None:
+    status = ConversationStatus(
+        node_id=123,
+        message_id=[],
+        role={},
+        recipient=object(),
+        async_status=False,
+        finish_reason=0,
+    )
+
+    assert status.node_id is None
+    assert status.message_id is None
+    assert status.role is None
+    assert status.recipient is None
+    assert status.async_status is None
+    assert status.finish_reason is None
+
+
+def test_conversation_status_pending_approval_coerces_bool() -> None:
+    assert ConversationStatus(pending_approval=1).pending_approval is True
+    assert ConversationStatus(pending_approval=0).pending_approval is False
+
+
+def test_conversation_status_metadata_preview_none_becomes_empty_dict() -> None:
+    assert ConversationStatus(metadata_preview=None).metadata_preview == {}
+
+
+def test_conversation_status_metadata_preview_non_dict_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="metadata_preview must be a dict"):
+        ConversationStatus(metadata_preview=[])
+
+
+def test_conversation_status_deep_copies_metadata_preview_on_construction() -> None:
+    metadata = {"nested": {"value": 1}}
+
+    status = ConversationStatus(metadata_preview=metadata)
+    metadata["nested"]["value"] = 2
+
+    assert status.metadata_preview["nested"]["value"] == 1
+
+
+def test_conversation_status_to_dict_deep_copies_metadata_preview() -> None:
+    status = ConversationStatus(metadata_preview={"nested": {"value": 1}})
+
+    payload = status.to_dict()
+    payload["metadata_preview"]["nested"]["value"] = 2
+
+    assert status.metadata_preview["nested"]["value"] == 1
+
+
+def test_conversation_status_to_dict_returns_stable_keys() -> None:
+    status = ConversationStatus(
+        status="completed",
+        node_id="node-1",
+        message_id="msg-1",
+        role="assistant",
+        recipient="all",
+        async_status="completed",
+        finish_reason="stop",
+        pending_approval=True,
+        metadata_preview={"finish_details": {"type": "stop"}},
+    )
+
+    assert status.to_dict() == {
+        "status": "completed",
+        "node_id": "node-1",
+        "message_id": "msg-1",
+        "role": "assistant",
+        "recipient": "all",
+        "async_status": "completed",
+        "finish_reason": "stop",
+        "pending_approval": True,
+        "metadata_preview": {"finish_details": {"type": "stop"}},
+    }
+
+
+def test_conversation_status_from_dict_roundtrip() -> None:
+    original = ConversationStatus(
+        status="running",
+        node_id="node-1",
+        message_id="msg-1",
+        role="assistant",
+        recipient="python",
+        async_status="in_progress",
+        finish_reason=None,
+        pending_approval=False,
+        metadata_preview={"async_status": "in_progress"},
+    )
+
+    loaded = ConversationStatus.from_dict(original.to_dict())
+
+    assert loaded == original
+
+
+def test_conversation_status_from_dict_non_dict_returns_default() -> None:
+    assert ConversationStatus.from_dict(None) == ConversationStatus()
+    assert ConversationStatus.from_dict([]) == ConversationStatus()
+
+
+def test_conversation_status_is_exported_from_public_package() -> None:
+    assert webchat_adapter.ConversationStatus is ConversationStatus
+    assert "ConversationStatus" in webchat_adapter.__all__


### PR DESCRIPTION
## Summary

- Add `ConversationStatus` as the stable lifecycle status model.
- Add known status value validation.
- Add optional lifecycle fields for node/message/role/recipient/async_status/finish_reason.
- Add `pending_approval` and `metadata_preview` fields.
- Add `to_dict()` and `from_dict()` helpers.
- Export `ConversationStatus` from the public package.

## Scope

- No `get_status()` yet.
- No payload lifecycle detection.
- No pending approval descriptor.
- No wait/polling behavior.
- No CLI or README changes.

## Tests

- Cover defaults, status validation, field normalization, metadata deep-copying, serialization roundtrip, `from_dict()` fallback, and public export.

Not run locally from this environment. CI runs `pytest -q` and package build.