### PR TITLE
PR3.2: Add conversation status detection

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -7,6 +7,7 @@ from .conversation_send import send_to_conversation as _send_to_conversation
 from .exceptions import AuthError, MediaError, RequestError, WebChatAdapterError
 from .export import export_conversation as _export_conversation
 from .messages import get_messages as _get_messages
+from .status import get_status as _get_status
 from .types import (
     AttachedConversation,
     AuthData,
@@ -23,6 +24,7 @@ from .types import (
 ChatGPTWebClient.attach_conversation = _attach_conversation
 ChatGPTWebClient.export_conversation = _export_conversation
 ChatGPTWebClient.get_messages = _get_messages
+ChatGPTWebClient.get_status = _get_status
 ChatGPTWebClient.send_to_conversation = _send_to_conversation
 WebChatClient = ChatGPTWebClient
 

--- a/src/webchat_adapter/status.py
+++ b/src/webchat_adapter/status.py
@@ -190,7 +190,11 @@ def _has_pending_approval(
 ) -> bool:
     metadata = _message_metadata(message)
     node_dict = node if isinstance(node, dict) else {}
-    return _has_generic_pending_approval_signal(payload, node_dict, metadata) or _confirm_action_pending_approval(payload)
+    return _has_generic_pending_approval_signal(
+        payload,
+        node_dict,
+        metadata,
+    ) or _confirm_action_pending_approval(payload)
 
 
 def _recipient_is_tool(recipient: str | None) -> bool:
@@ -215,14 +219,14 @@ def _status_from_signals(
         return "tool_calling"
     if normalized_async_status in ACTIVE_ASYNC_STATUSES:
         return "running"
-    if role == "assistant" and not finish_reason and recipient in {None, "all"}:
-        return "running"
     if role == "user":
         return "user_last_message"
     if role == "assistant" and recipient in {None, "all"} and finish_reason:
         return "completed"
     if role == "assistant" and recipient in {None, "all"} and normalized_async_status in COMPLETED_ASYNC_STATUSES:
         return "completed"
+    if role == "assistant" and not finish_reason and recipient in {None, "all"}:
+        return "running"
     return "unknown"
 
 

--- a/src/webchat_adapter/status.py
+++ b/src/webchat_adapter/status.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .types import ChatConversation, ConversationRef, ConversationStatus
+
+ACTIVE_ASYNC_STATUSES = {
+    "running",
+    "in_progress",
+    "pending",
+    "queued",
+    "started",
+    "streaming",
+}
+COMPLETED_ASYNC_STATUSES = {
+    "completed",
+    "complete",
+    "finished",
+    "done",
+    "success",
+    "succeeded",
+}
+PENDING_APPROVAL_BOOL_KEYS = (
+    "pending_approval",
+    "requires_approval",
+    "requires_action",
+    "pending_tool_approval",
+)
+PENDING_APPROVAL_COLLECTION_KEYS = (
+    "approval_request",
+    "approval_requests",
+    "pending_approvals",
+)
+STATUS_METADATA_PREVIEW_KEYS = (
+    "async_status",
+    "finish_details",
+    "finish_reason",
+    "is_complete",
+    "status",
+    "model_slug",
+    "jit_plugin_data",
+)
+
+
+def _optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _normalized_status(value: str | None) -> str | None:
+    value = _optional_str(value)
+    return value.lower() if value else None
+
+
+def _conversation_mapping(payload: dict[str, Any]) -> dict[str, Any]:
+    mapping = payload.get("mapping")
+    return mapping if isinstance(mapping, dict) else {}
+
+
+def _current_node_id(payload: dict[str, Any]) -> str | None:
+    return _optional_str(payload.get("current_node"))
+
+
+def _current_node(payload: dict[str, Any]) -> dict[str, Any] | None:
+    node_id = _current_node_id(payload)
+    if node_id is None:
+        return None
+    node = _conversation_mapping(payload).get(node_id)
+    return node if isinstance(node, dict) else None
+
+
+def _message_from_node(node: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(node, dict):
+        return None
+    message = node.get("message")
+    return message if isinstance(message, dict) else None
+
+
+def _message_metadata(message: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(message, dict):
+        return {}
+    metadata = message.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _message_role(message: dict[str, Any] | None) -> str | None:
+    if not isinstance(message, dict):
+        return None
+    author = message.get("author")
+    if not isinstance(author, dict):
+        return None
+    return _optional_str(author.get("role"))
+
+
+def _message_finish_reason(message: dict[str, Any] | None) -> str | None:
+    if not isinstance(message, dict):
+        return None
+
+    metadata = _message_metadata(message)
+    finish_details = metadata.get("finish_details")
+    if isinstance(finish_details, dict):
+        finish_type = _optional_str(finish_details.get("type"))
+        if finish_type:
+            return finish_type
+
+    finish_reason = _optional_str(metadata.get("finish_reason"))
+    if finish_reason:
+        return finish_reason
+
+    return _optional_str(message.get("finish_reason"))
+
+
+def _async_status(
+    payload: dict[str, Any],
+    node: dict[str, Any] | None,
+    message: dict[str, Any] | None,
+) -> str | None:
+    metadata = _message_metadata(message)
+    sources = (payload, node if isinstance(node, dict) else {}, metadata)
+    for source in sources:
+        for key in ("async_status", "status"):
+            value = _optional_str(source.get(key))
+            if value:
+                return value
+    return None
+
+
+def _metadata_preview(message: dict[str, Any] | None) -> dict[str, Any]:
+    metadata = _message_metadata(message)
+    return {key: metadata[key] for key in STATUS_METADATA_PREVIEW_KEYS if key in metadata}
+
+
+def _truthy_approval_signal(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (dict, list, tuple, set)):
+        return bool(value)
+    return False
+
+
+def _has_generic_pending_approval_signal(*sources: dict[str, Any]) -> bool:
+    for source in sources:
+        for key in PENDING_APPROVAL_BOOL_KEYS:
+            if _truthy_approval_signal(source.get(key)):
+                return True
+        for key in PENDING_APPROVAL_COLLECTION_KEYS:
+            if _truthy_approval_signal(source.get(key)):
+                return True
+    return False
+
+
+def _confirm_action_pending_approval(payload: dict[str, Any]) -> bool:
+    mapping = _conversation_mapping(payload)
+    for node in mapping.values():
+        if not isinstance(node, dict) or node.get("children"):
+            continue
+        message = _message_from_node(node)
+        if not isinstance(message, dict):
+            continue
+        if _message_role(message) != "tool":
+            continue
+        metadata = _message_metadata(message)
+        jit_plugin_data = metadata.get("jit_plugin_data")
+        if not isinstance(jit_plugin_data, dict):
+            continue
+        from_server = jit_plugin_data.get("from_server")
+        if not isinstance(from_server, dict) or from_server.get("type") != "confirm_action":
+            continue
+        body = from_server.get("body")
+        if not isinstance(body, dict):
+            continue
+        actions = body.get("actions")
+        if not isinstance(actions, list):
+            continue
+        for action in actions:
+            if not isinstance(action, dict) or action.get("type") != "allow":
+                continue
+            allow = action.get("allow")
+            if isinstance(allow, dict) and _optional_str(allow.get("target_message_id")):
+                return True
+    return False
+
+
+def _has_pending_approval(
+    payload: dict[str, Any],
+    node: dict[str, Any] | None,
+    message: dict[str, Any] | None,
+) -> bool:
+    metadata = _message_metadata(message)
+    node_dict = node if isinstance(node, dict) else {}
+    return _has_generic_pending_approval_signal(payload, node_dict, metadata) or _confirm_action_pending_approval(payload)
+
+
+def _recipient_is_tool(recipient: str | None) -> bool:
+    return recipient not in {None, "", "all"}
+
+
+def _status_from_signals(
+    *,
+    role: str | None,
+    recipient: str | None,
+    async_status: str | None,
+    finish_reason: str | None,
+    pending_approval: bool,
+) -> str:
+    normalized_async_status = _normalized_status(async_status)
+
+    if pending_approval:
+        return "awaiting_tool_approval"
+    if role == "tool":
+        return "tool_running"
+    if role == "assistant" and _recipient_is_tool(recipient):
+        return "tool_calling"
+    if normalized_async_status in ACTIVE_ASYNC_STATUSES:
+        return "running"
+    if role == "assistant" and not finish_reason and recipient in {None, "all"}:
+        return "running"
+    if role == "user":
+        return "user_last_message"
+    if role == "assistant" and recipient in {None, "all"} and finish_reason:
+        return "completed"
+    if role == "assistant" and recipient in {None, "all"} and normalized_async_status in COMPLETED_ASYNC_STATUSES:
+        return "completed"
+    return "unknown"
+
+
+def _unknown_status(payload: dict[str, Any] | None = None) -> ConversationStatus:
+    async_status = _optional_str(payload.get("async_status")) if isinstance(payload, dict) else None
+    return ConversationStatus(status="unknown", async_status=async_status)
+
+
+def _status_from_payload(payload: dict[str, Any]) -> ConversationStatus:
+    node_id = _current_node_id(payload)
+    node = _current_node(payload)
+    message = _message_from_node(node)
+    if node_id is None or node is None or message is None:
+        return _unknown_status(payload)
+
+    role = _message_role(message)
+    recipient = _optional_str(message.get("recipient"))
+    async_status = _async_status(payload, node, message)
+    finish_reason = _message_finish_reason(message)
+    pending_approval = _has_pending_approval(payload, node, message)
+    status = _status_from_signals(
+        role=role,
+        recipient=recipient,
+        async_status=async_status,
+        finish_reason=finish_reason,
+        pending_approval=pending_approval,
+    )
+
+    return ConversationStatus(
+        status=status,
+        node_id=node_id,
+        message_id=message.get("id"),
+        role=role,
+        recipient=recipient,
+        async_status=async_status,
+        finish_reason=finish_reason,
+        pending_approval=pending_approval,
+        metadata_preview=_metadata_preview(message),
+    )
+
+
+def get_status(
+    self: Any,
+    url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
+) -> ConversationStatus:
+    """Inspect the current lifecycle status of an existing conversation."""
+
+    ref = ConversationRef.from_any(url_or_id)
+    payload = self._get_conversation_payload(ref.conversation_id)
+    if not isinstance(payload, dict):
+        return ConversationStatus(status="unknown")
+    return _status_from_payload(payload)

--- a/tests/test_get_status.py
+++ b/tests/test_get_status.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from webchat_adapter import ChatGPTWebClient, ConversationStatus
+
+
+def _message(
+    role: str,
+    *,
+    message_id: str = "msg-1",
+    recipient: str | None = "all",
+    metadata: dict[str, Any] | None = None,
+    finish_reason: str | None = None,
+) -> dict[str, Any]:
+    message: dict[str, Any] = {
+        "id": message_id,
+        "author": {"role": role},
+        "content": {"content_type": "text", "parts": [""]},
+        "create_time": 1.0,
+        "metadata": metadata or {},
+    }
+    if recipient is not None:
+        message["recipient"] = recipient
+    if finish_reason is not None:
+        message["finish_reason"] = finish_reason
+    return message
+
+
+def _node(
+    node_id: str,
+    message: dict[str, Any] | None,
+    *,
+    parent: str | None = None,
+    children: list[str] | None = None,
+    async_status: str | None = None,
+    status: str | None = None,
+) -> dict[str, Any]:
+    node: dict[str, Any] = {"id": node_id, "parent": parent}
+    if message is not None:
+        node["message"] = message
+    if children is not None:
+        node["children"] = children
+    if async_status is not None:
+        node["async_status"] = async_status
+    if status is not None:
+        node["status"] = status
+    return node
+
+
+def _payload(
+    message: dict[str, Any] | None,
+    *,
+    current_node: str | None = "node-1",
+    async_status: str | None = None,
+    status: str | None = None,
+    mapping: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "conversation_id": "conversation-1",
+        "mapping": mapping if mapping is not None else {"node-1": _node("node-1", message)},
+    }
+    if current_node is not None:
+        payload["current_node"] = current_node
+    if async_status is not None:
+        payload["async_status"] = async_status
+    if status is not None:
+        payload["status"] = status
+    return payload
+
+
+def _client(payload: Any) -> ChatGPTWebClient:
+    client = object.__new__(ChatGPTWebClient)
+    client._get_conversation_payload = lambda _conversation_id: payload
+    return client
+
+
+def test_get_status_method_is_available() -> None:
+    assert hasattr(ChatGPTWebClient, "get_status")
+
+
+def test_get_status_completed_assistant_from_finish_details() -> None:
+    client = _client(
+        _payload(
+            _message(
+                "assistant",
+                metadata={"finish_details": {"type": "stop"}},
+            )
+        )
+    )
+
+    status = client.get_status("conversation-1")
+
+    assert isinstance(status, ConversationStatus)
+    assert status.status == "completed"
+    assert status.finish_reason == "stop"
+    assert status.role == "assistant"
+    assert status.recipient == "all"
+
+
+def test_get_status_running_assistant_without_finish_details() -> None:
+    client = _client(_payload(_message("assistant")))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "running"
+
+
+def test_get_status_running_from_payload_async_status() -> None:
+    client = _client(_payload(_message("assistant"), async_status="in_progress"))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "running"
+    assert status.async_status == "in_progress"
+
+
+def test_get_status_completed_from_payload_async_status() -> None:
+    client = _client(_payload(_message("assistant"), async_status="completed"))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "completed"
+    assert status.async_status == "completed"
+
+
+def test_get_status_user_last_message() -> None:
+    client = _client(_payload(_message("user", recipient=None)))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "user_last_message"
+    assert status.role == "user"
+
+
+def test_get_status_active_async_overrides_user_last_message() -> None:
+    client = _client(_payload(_message("user", recipient=None), async_status="running"))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "running"
+    assert status.role == "user"
+
+
+def test_get_status_tool_calling_from_assistant_recipient() -> None:
+    client = _client(_payload(_message("assistant", recipient="python")))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "tool_calling"
+    assert status.recipient == "python"
+
+
+def test_get_status_tool_running_from_tool_role() -> None:
+    client = _client(_payload(_message("tool", recipient="all")))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "tool_running"
+    assert status.role == "tool"
+
+
+def test_get_status_awaiting_tool_approval_from_metadata_signal() -> None:
+    client = _client(
+        _payload(
+            _message(
+                "assistant",
+                recipient="python",
+                metadata={"pending_approval": True},
+            )
+        )
+    )
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "awaiting_tool_approval"
+    assert status.pending_approval is True
+    assert status.recipient == "python"
+
+
+def test_get_status_awaiting_tool_approval_from_confirm_action_leaf() -> None:
+    mapping = {
+        "assistant-tool-call": _node(
+            "assistant-tool-call",
+            _message("assistant", message_id="target-msg", recipient="python"),
+            children=["tool-approval"],
+        ),
+        "tool-approval": _node(
+            "tool-approval",
+            _message(
+                "tool",
+                message_id="approval-msg",
+                recipient="all",
+                metadata={
+                    "jit_plugin_data": {
+                        "from_server": {
+                            "type": "confirm_action",
+                            "body": {
+                                "actions": [
+                                    {
+                                        "type": "allow",
+                                        "allow": {"target_message_id": "assistant-tool-call"},
+                                    }
+                                ]
+                            },
+                        }
+                    }
+                },
+            ),
+            parent="assistant-tool-call",
+            children=[],
+        ),
+    }
+    client = _client(_payload(None, current_node="tool-approval", mapping=mapping))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "awaiting_tool_approval"
+    assert status.pending_approval is True
+    assert status.node_id == "tool-approval"
+    assert status.message_id == "approval-msg"
+    assert status.role == "tool"
+
+
+def test_get_status_missing_current_node_returns_unknown() -> None:
+    client = _client(_payload(_message("assistant"), current_node=None))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "unknown"
+
+
+def test_get_status_current_node_not_in_mapping_returns_unknown() -> None:
+    client = _client(_payload(_message("assistant"), current_node="missing"))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "unknown"
+
+
+def test_get_status_malformed_current_node_returns_unknown() -> None:
+    payload = {
+        "conversation_id": "conversation-1",
+        "current_node": "node-1",
+        "mapping": {"node-1": "not-a-node"},
+    }
+    client = _client(payload)
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "unknown"
+
+
+def test_get_status_node_without_message_returns_unknown() -> None:
+    client = _client(_payload(None))
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "unknown"
+
+
+def test_get_status_non_dict_payload_returns_unknown() -> None:
+    client = _client([])
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "unknown"
+
+
+def test_get_status_fills_current_message_fields() -> None:
+    client = _client(
+        _payload(
+            _message(
+                "assistant",
+                message_id="msg-1",
+                recipient="all",
+                metadata={"finish_details": {"type": "stop"}},
+            )
+        )
+    )
+
+    status = client.get_status("conversation-1")
+
+    assert status.node_id == "node-1"
+    assert status.message_id == "msg-1"
+    assert status.role == "assistant"
+    assert status.recipient == "all"
+    assert status.finish_reason == "stop"
+
+
+def test_get_status_metadata_preview_uses_selected_keys_only() -> None:
+    client = _client(
+        _payload(
+            _message(
+                "assistant",
+                metadata={
+                    "finish_details": {"type": "stop"},
+                    "async_status": "completed",
+                    "huge_payload": {"ignore": True},
+                },
+            )
+        )
+    )
+
+    status = client.get_status("conversation-1")
+
+    assert status.metadata_preview == {
+        "async_status": "completed",
+        "finish_details": {"type": "stop"},
+    }
+
+
+def test_get_status_reads_async_status_from_node_and_metadata() -> None:
+    node_async_client = _client(
+        _payload(
+            _message("assistant"),
+            mapping={"node-1": _node("node-1", _message("assistant"), async_status="queued")},
+        )
+    )
+    metadata_async_client = _client(
+        _payload(_message("assistant", metadata={"async_status": "streaming"}))
+    )
+
+    assert node_async_client.get_status("conversation-1").async_status == "queued"
+    assert metadata_async_client.get_status("conversation-1").async_status == "streaming"
+
+
+def test_get_status_reads_finish_reason_from_fallback_fields() -> None:
+    metadata_client = _client(
+        _payload(_message("assistant", metadata={"finish_reason": "stop"}))
+    )
+    message_client = _client(_payload(_message("assistant", finish_reason="stop")))
+
+    assert metadata_client.get_status("conversation-1").finish_reason == "stop"
+    assert message_client.get_status("conversation-1").finish_reason == "stop"
+
+
+def test_get_status_validates_conversation_reference_before_fetching() -> None:
+    client = object.__new__(ChatGPTWebClient)
+    client._get_conversation_payload = lambda _conversation_id: pytest.fail(
+        "payload should not be fetched for invalid references"
+    )
+
+    with pytest.raises(ValueError, match="conversation_id is required"):
+        client.get_status("")


### PR DESCRIPTION
## Summary

- Add `client.get_status(url_or_id)`.
- Inspect the current conversation payload node and lifecycle metadata.
- Return `ConversationStatus` with status, current node/message fields, recipient, async_status, finish_reason, pending_approval, and metadata_preview.
- Detect completed, running, awaiting_tool_approval, tool_calling, tool_running, user_last_message, and unknown conservatively.
- Reuse the existing confirm-action approval payload shape for pending approval detection.

## Scope

- No `PendingApproval` descriptor yet.
- No `wait_until_completed()`.
- No polling.
- No send/approval mutation.
- No README or CLI changes.

## Tests

- Cover completed/running/tool/user/approval/unknown states.
- Cover populated `ConversationStatus` fields, metadata preview filtering, async/finish fallback fields, and invalid reference validation.

Not run locally from this environment. CI runs `pytest -q` and package build.