### PR TITLE
PR3.3: Add pending approval descriptor

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -7,6 +7,7 @@ from .conversation_send import send_to_conversation as _send_to_conversation
 from .exceptions import AuthError, MediaError, RequestError, WebChatAdapterError
 from .export import export_conversation as _export_conversation
 from .messages import get_messages as _get_messages
+from .status import get_pending_approval as _get_pending_approval
 from .status import get_status as _get_status
 from .types import (
     AttachedConversation,
@@ -19,11 +20,13 @@ from .types import (
     ConversationStatus,
     MediaItem,
     MediaSource,
+    PendingApproval,
 )
 
 ChatGPTWebClient.attach_conversation = _attach_conversation
 ChatGPTWebClient.export_conversation = _export_conversation
 ChatGPTWebClient.get_messages = _get_messages
+ChatGPTWebClient.get_pending_approval = _get_pending_approval
 ChatGPTWebClient.get_status = _get_status
 ChatGPTWebClient.send_to_conversation = _send_to_conversation
 WebChatClient = ChatGPTWebClient
@@ -44,6 +47,7 @@ __all__ = [
     "MediaError",
     "MediaItem",
     "MediaSource",
+    "PendingApproval",
     "RequestError",
     "WebChatAdapterError",
     "WebChatClient",

--- a/src/webchat_adapter/status.py
+++ b/src/webchat_adapter/status.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .types import ChatConversation, ConversationRef, ConversationStatus
+from .types import ChatConversation, ConversationRef, ConversationStatus, PendingApproval
 
 ACTIVE_ASYNC_STATUSES = {
     "running",
@@ -151,36 +151,80 @@ def _has_generic_pending_approval_signal(*sources: dict[str, Any]) -> bool:
     return False
 
 
-def _confirm_action_pending_approval(payload: dict[str, Any]) -> bool:
+def _approval_from_confirm_action_node(
+    payload: dict[str, Any],
+    node: dict[str, Any],
+) -> PendingApproval | None:
+    message = _message_from_node(node)
+    if not isinstance(message, dict):
+        return None
+    if _message_role(message) != "tool":
+        return None
+
+    tool_message_id = _optional_str(message.get("id"))
+    if tool_message_id is None:
+        return None
+
+    metadata = _message_metadata(message)
+    jit_plugin_data = metadata.get("jit_plugin_data")
+    if not isinstance(jit_plugin_data, dict):
+        return None
+    from_server = jit_plugin_data.get("from_server")
+    if not isinstance(from_server, dict) or from_server.get("type") != "confirm_action":
+        return None
+    body = from_server.get("body")
+    if not isinstance(body, dict):
+        return None
+    actions = body.get("actions")
+    if not isinstance(actions, list):
+        return None
+
     mapping = _conversation_mapping(payload)
-    for node in mapping.values():
+    for action in actions:
+        if not isinstance(action, dict) or action.get("type") != "allow":
+            continue
+        allow = action.get("allow")
+        if not isinstance(allow, dict):
+            continue
+        target_message_id = _optional_str(allow.get("target_message_id"))
+        if target_message_id is None:
+            continue
+        target_node = mapping.get(target_message_id)
+        if not isinstance(target_node, dict):
+            continue
+        target_message = _message_from_node(target_node)
+        if not isinstance(target_message, dict):
+            continue
+        recipient = _optional_str(target_message.get("recipient"))
+        if recipient is None:
+            continue
+        return PendingApproval(
+            tool_message_id=tool_message_id,
+            target_message_id=target_message_id,
+            recipient=recipient,
+        )
+    return None
+
+
+def _find_pending_approval(payload: dict[str, Any]) -> PendingApproval | None:
+    candidates: list[tuple[float, PendingApproval]] = []
+    for node in _conversation_mapping(payload).values():
         if not isinstance(node, dict) or node.get("children"):
             continue
-        message = _message_from_node(node)
-        if not isinstance(message, dict):
+        approval = _approval_from_confirm_action_node(payload, node)
+        if approval is None:
             continue
-        if _message_role(message) != "tool":
-            continue
-        metadata = _message_metadata(message)
-        jit_plugin_data = metadata.get("jit_plugin_data")
-        if not isinstance(jit_plugin_data, dict):
-            continue
-        from_server = jit_plugin_data.get("from_server")
-        if not isinstance(from_server, dict) or from_server.get("type") != "confirm_action":
-            continue
-        body = from_server.get("body")
-        if not isinstance(body, dict):
-            continue
-        actions = body.get("actions")
-        if not isinstance(actions, list):
-            continue
-        for action in actions:
-            if not isinstance(action, dict) or action.get("type") != "allow":
-                continue
-            allow = action.get("allow")
-            if isinstance(allow, dict) and _optional_str(allow.get("target_message_id")):
-                return True
-    return False
+        message = _message_from_node(node) or {}
+        create_time = message.get("create_time")
+        try:
+            sortable_create_time = float(create_time or 0)
+        except (TypeError, ValueError):
+            sortable_create_time = 0.0
+        candidates.append((sortable_create_time, approval))
+    if not candidates:
+        return None
+    _create_time, approval = max(candidates, key=lambda item: item[0])
+    return approval
 
 
 def _has_pending_approval(
@@ -194,7 +238,7 @@ def _has_pending_approval(
         payload,
         node_dict,
         metadata,
-    ) or _confirm_action_pending_approval(payload)
+    ) or _find_pending_approval(payload) is not None
 
 
 def _recipient_is_tool(recipient: str | None) -> bool:
@@ -279,3 +323,16 @@ def get_status(
     if not isinstance(payload, dict):
         return ConversationStatus(status="unknown")
     return _status_from_payload(payload)
+
+
+def get_pending_approval(
+    self: Any,
+    url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
+) -> PendingApproval | None:
+    """Return the actionable pending tool approval descriptor, if one exists."""
+
+    ref = ConversationRef.from_any(url_or_id)
+    payload = self._get_conversation_payload(ref.conversation_id)
+    if not isinstance(payload, dict):
+        return None
+    return _find_pending_approval(payload)

--- a/src/webchat_adapter/types.py
+++ b/src/webchat_adapter/types.py
@@ -36,6 +36,13 @@ def _optional_str(value: Any) -> str | None:
     return value or None
 
 
+def _required_str(value: Any, field_name: str) -> str:
+    value = _optional_str(value)
+    if value is None:
+        raise ValueError(f"{field_name} is required")
+    return value
+
+
 @dataclass(init=False)
 class AuthData:
     accessToken: str | None = None
@@ -393,6 +400,46 @@ class ConversationStatus:
             "finish_reason": self.finish_reason,
             "pending_approval": self.pending_approval,
             "metadata_preview": copy.deepcopy(self.metadata_preview),
+        }
+
+
+@dataclass(frozen=True)
+class PendingApproval:
+    tool_message_id: str
+    target_message_id: str
+    recipient: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "tool_message_id",
+            _required_str(self.tool_message_id, "tool_message_id"),
+        )
+        object.__setattr__(
+            self,
+            "target_message_id",
+            _required_str(self.target_message_id, "target_message_id"),
+        )
+        object.__setattr__(self, "recipient", _required_str(self.recipient, "recipient"))
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "PendingApproval | None":
+        if not isinstance(payload, dict):
+            return None
+        try:
+            return cls(
+                tool_message_id=payload.get("tool_message_id"),
+                target_message_id=payload.get("target_message_id"),
+                recipient=payload.get("recipient"),
+            )
+        except ValueError:
+            return None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_message_id": self.tool_message_id,
+            "target_message_id": self.target_message_id,
+            "recipient": self.recipient,
         }
 
 

--- a/tests/test_pending_approval.py
+++ b/tests/test_pending_approval.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from typing import Any
+
+import pytest
+
+import webchat_adapter
+from webchat_adapter import ChatGPTWebClient, PendingApproval
+
+
+def _message(
+    role: str,
+    *,
+    message_id: str | None = "msg-1",
+    recipient: str | None = "all",
+    metadata: dict[str, Any] | None = None,
+    create_time: float = 1.0,
+) -> dict[str, Any]:
+    message: dict[str, Any] = {
+        "author": {"role": role},
+        "content": {"content_type": "text", "parts": [""]},
+        "create_time": create_time,
+        "metadata": metadata or {},
+    }
+    if message_id is not None:
+        message["id"] = message_id
+    if recipient is not None:
+        message["recipient"] = recipient
+    return message
+
+
+def _node(
+    node_id: str,
+    message: dict[str, Any] | None,
+    *,
+    parent: str | None = None,
+    children: list[str] | None = None,
+) -> dict[str, Any]:
+    node: dict[str, Any] = {"id": node_id, "parent": parent}
+    if message is not None:
+        node["message"] = message
+    if children is not None:
+        node["children"] = children
+    return node
+
+
+def _confirm_action_metadata(target_message_id: str | None = "target-node") -> dict[str, Any]:
+    allow: dict[str, Any] = {}
+    if target_message_id is not None:
+        allow["target_message_id"] = target_message_id
+    return {
+        "jit_plugin_data": {
+            "from_server": {
+                "type": "confirm_action",
+                "body": {
+                    "actions": [
+                        {
+                            "type": "allow",
+                            "allow": allow,
+                        }
+                    ]
+                },
+            }
+        }
+    }
+
+
+def _payload(mapping: dict[str, dict[str, Any]], *, current_node: str = "tool-node") -> dict[str, Any]:
+    return {
+        "conversation_id": "conversation-1",
+        "current_node": current_node,
+        "mapping": mapping,
+    }
+
+
+def _approval_payload(
+    *,
+    target_node_id: str = "target-node",
+    target_recipient: str | None = "python",
+    tool_node_id: str = "tool-node",
+    tool_message_id: str | None = "tool-msg",
+    tool_children: list[str] | None = [],
+    create_time: float = 1.0,
+) -> dict[str, Any]:
+    return _payload(
+        {
+            target_node_id: _node(
+                target_node_id,
+                _message(
+                    "assistant",
+                    message_id="target-msg",
+                    recipient=target_recipient,
+                ),
+                children=[tool_node_id],
+            ),
+            tool_node_id: _node(
+                tool_node_id,
+                _message(
+                    "tool",
+                    message_id=tool_message_id,
+                    recipient="all",
+                    metadata=_confirm_action_metadata(target_node_id),
+                    create_time=create_time,
+                ),
+                parent=target_node_id,
+                children=tool_children,
+            ),
+        },
+        current_node=tool_node_id,
+    )
+
+
+def _client(payload: Any) -> ChatGPTWebClient:
+    client = object.__new__(ChatGPTWebClient)
+    client._get_conversation_payload = lambda _conversation_id: payload
+    return client
+
+
+def test_pending_approval_normalizes_required_fields() -> None:
+    approval = PendingApproval(
+        tool_message_id=" tool-msg ",
+        target_message_id=" target-node ",
+        recipient=" python ",
+    )
+
+    assert approval.tool_message_id == "tool-msg"
+    assert approval.target_message_id == "target-node"
+    assert approval.recipient == "python"
+
+
+@pytest.mark.parametrize(
+    ("field", "kwargs"),
+    [
+        (
+            "tool_message_id",
+            {"tool_message_id": "", "target_message_id": "target", "recipient": "python"},
+        ),
+        (
+            "target_message_id",
+            {"tool_message_id": "tool", "target_message_id": "", "recipient": "python"},
+        ),
+        (
+            "recipient",
+            {"tool_message_id": "tool", "target_message_id": "target", "recipient": ""},
+        ),
+    ],
+)
+def test_pending_approval_rejects_empty_required_fields(
+    field: str,
+    kwargs: dict[str, str],
+) -> None:
+    with pytest.raises(ValueError, match=f"{field} is required"):
+        PendingApproval(**kwargs)
+
+
+def test_pending_approval_is_frozen() -> None:
+    approval = PendingApproval(
+        tool_message_id="tool-msg",
+        target_message_id="target-node",
+        recipient="python",
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        approval.recipient = "browser"
+
+
+def test_pending_approval_to_dict() -> None:
+    approval = PendingApproval(
+        tool_message_id="tool-msg",
+        target_message_id="target-node",
+        recipient="python",
+    )
+
+    assert approval.to_dict() == {
+        "tool_message_id": "tool-msg",
+        "target_message_id": "target-node",
+        "recipient": "python",
+    }
+
+
+def test_pending_approval_from_dict_roundtrip() -> None:
+    approval = PendingApproval(
+        tool_message_id="tool-msg",
+        target_message_id="target-node",
+        recipient="python",
+    )
+
+    assert PendingApproval.from_dict(approval.to_dict()) == approval
+
+
+def test_pending_approval_from_dict_invalid_returns_none() -> None:
+    assert PendingApproval.from_dict(None) is None
+    assert PendingApproval.from_dict({}) is None
+    assert PendingApproval.from_dict({"tool_message_id": "tool"}) is None
+
+
+def test_pending_approval_is_exported_from_public_package() -> None:
+    assert webchat_adapter.PendingApproval is PendingApproval
+    assert "PendingApproval" in webchat_adapter.__all__
+
+
+def test_get_pending_approval_method_is_available() -> None:
+    assert hasattr(ChatGPTWebClient, "get_pending_approval")
+
+
+def test_get_pending_approval_returns_none_without_approval() -> None:
+    client = _client(
+        _payload(
+            {
+                "node-1": _node(
+                    "node-1",
+                    _message("assistant", metadata={"finish_details": {"type": "stop"}}),
+                    children=[],
+                )
+            },
+            current_node="node-1",
+        )
+    )
+
+    assert client.get_pending_approval("conversation-1") is None
+
+
+def test_get_pending_approval_extracts_confirm_action_descriptor() -> None:
+    client = _client(_approval_payload())
+
+    approval = client.get_pending_approval("conversation-1")
+
+    assert approval == PendingApproval(
+        tool_message_id="tool-msg",
+        target_message_id="target-node",
+        recipient="python",
+    )
+
+
+def test_get_pending_approval_chooses_latest_confirm_action_leaf() -> None:
+    mapping = {
+        "target-old": _node(
+            "target-old",
+            _message("assistant", message_id="target-old-msg", recipient="python"),
+            children=["tool-old"],
+        ),
+        "tool-old": _node(
+            "tool-old",
+            _message(
+                "tool",
+                message_id="tool-old-msg",
+                metadata=_confirm_action_metadata("target-old"),
+                create_time=1.0,
+            ),
+            parent="target-old",
+            children=[],
+        ),
+        "target-new": _node(
+            "target-new",
+            _message("assistant", message_id="target-new-msg", recipient="browser"),
+            children=["tool-new"],
+        ),
+        "tool-new": _node(
+            "tool-new",
+            _message(
+                "tool",
+                message_id="tool-new-msg",
+                metadata=_confirm_action_metadata("target-new"),
+                create_time=2.0,
+            ),
+            parent="target-new",
+            children=[],
+        ),
+    }
+    client = _client(_payload(mapping, current_node="tool-new"))
+
+    approval = client.get_pending_approval("conversation-1")
+
+    assert approval == PendingApproval(
+        tool_message_id="tool-new-msg",
+        target_message_id="target-new",
+        recipient="browser",
+    )
+
+
+def test_get_pending_approval_ignores_non_leaf_confirm_action() -> None:
+    client = _client(_approval_payload(tool_children=["allow-node"]))
+
+    assert client.get_pending_approval("conversation-1") is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _approval_payload(tool_message_id=None),
+        _approval_payload(target_recipient=None),
+        _payload(
+            {
+                "target-node": _node(
+                    "target-node",
+                    _message("assistant", recipient="python"),
+                    children=["tool-node"],
+                ),
+                "tool-node": _node(
+                    "tool-node",
+                    _message(
+                        "tool",
+                        message_id="tool-msg",
+                        metadata=_confirm_action_metadata(None),
+                    ),
+                    children=[],
+                ),
+            }
+        ),
+        _payload(
+            {
+                "tool-node": _node(
+                    "tool-node",
+                    _message(
+                        "tool",
+                        message_id="tool-msg",
+                        metadata=_confirm_action_metadata("missing-target"),
+                    ),
+                    children=[],
+                )
+            }
+        ),
+        _payload(
+            {
+                "target-node": _node(
+                    "target-node",
+                    _message("assistant", recipient="python"),
+                    children=["tool-node"],
+                ),
+                "tool-node": _node(
+                    "tool-node",
+                    _message(
+                        "tool",
+                        message_id="tool-msg",
+                        metadata={
+                            "jit_plugin_data": {
+                                "from_server": {
+                                    "type": "confirm_action",
+                                    "body": {"actions": [{"type": "deny"}]},
+                                }
+                            }
+                        },
+                    ),
+                    children=[],
+                ),
+            }
+        ),
+    ],
+)
+def test_get_pending_approval_ignores_malformed_confirm_action_payloads(
+    payload: dict[str, Any],
+) -> None:
+    client = _client(payload)
+
+    assert client.get_pending_approval("conversation-1") is None
+
+
+def test_get_status_still_detects_confirm_action_as_pending_approval() -> None:
+    client = _client(_approval_payload())
+
+    status = client.get_status("conversation-1")
+
+    assert status.status == "awaiting_tool_approval"
+    assert status.pending_approval is True
+
+
+def test_generic_pending_status_does_not_create_pending_approval_descriptor() -> None:
+    client = _client(
+        _payload(
+            {
+                "node-1": _node(
+                    "node-1",
+                    _message(
+                        "assistant",
+                        recipient="python",
+                        metadata={"pending_approval": True},
+                    ),
+                    children=[],
+                )
+            },
+            current_node="node-1",
+        )
+    )
+
+    status = client.get_status("conversation-1")
+    approval = client.get_pending_approval("conversation-1")
+
+    assert status.status == "awaiting_tool_approval"
+    assert status.pending_approval is True
+    assert approval is None
+
+
+def test_get_pending_approval_returns_none_for_non_dict_payload() -> None:
+    client = _client([])
+
+    assert client.get_pending_approval("conversation-1") is None
+
+
+def test_get_pending_approval_validates_conversation_reference_before_fetching() -> None:
+    client = object.__new__(ChatGPTWebClient)
+    client._get_conversation_payload = lambda _conversation_id: pytest.fail(
+        "payload should not be fetched for invalid references"
+    )
+
+    with pytest.raises(ValueError, match="conversation_id is required"):
+        client.get_pending_approval("")


### PR DESCRIPTION
## Summary

- Add `PendingApproval` as an immutable read-only descriptor.
- Add `client.get_pending_approval(url_or_id)`.
- Extract actionable `confirm_action` approvals from conversation mapping.
- Return the latest pending approval by `create_time`.
- Reuse pending approval extraction in `get_status()`.

## Scope

- No approve/deny mutation.
- No auto-approval policy.
- No `wait_until_completed()`.
- No polling.
- No CLI or README changes.

## Tests

- Cover `PendingApproval` validation, immutability, serialization, public export, no-approval cases, `confirm_action` extraction, latest approval selection, malformed payloads, generic pending flags, and `get_status()` regression.

Not run locally from this environment. CI runs `pytest -q` and package build.