### PR TITLE
PR3.4: Add wait_until_completed

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -4,7 +4,13 @@ from .attach import attach_conversation as _attach_conversation
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
 from .client import DEFAULT_MODEL, ChatGPTWebClient
 from .conversation_send import send_to_conversation as _send_to_conversation
-from .exceptions import AuthError, MediaError, RequestError, WebChatAdapterError
+from .exceptions import (
+    AuthError,
+    ConversationTimeoutError,
+    MediaError,
+    RequestError,
+    WebChatAdapterError,
+)
 from .export import export_conversation as _export_conversation
 from .messages import get_messages as _get_messages
 from .status import get_pending_approval as _get_pending_approval
@@ -21,7 +27,9 @@ from .types import (
     MediaItem,
     MediaSource,
     PendingApproval,
+    WaitResult,
 )
+from .wait import wait_until_completed as _wait_until_completed
 
 ChatGPTWebClient.attach_conversation = _attach_conversation
 ChatGPTWebClient.export_conversation = _export_conversation
@@ -29,6 +37,7 @@ ChatGPTWebClient.get_messages = _get_messages
 ChatGPTWebClient.get_pending_approval = _get_pending_approval
 ChatGPTWebClient.get_status = _get_status
 ChatGPTWebClient.send_to_conversation = _send_to_conversation
+ChatGPTWebClient.wait_until_completed = _wait_until_completed
 WebChatClient = ChatGPTWebClient
 
 __all__ = [
@@ -42,6 +51,7 @@ __all__ = [
     "ChatResponse",
     "ConversationRef",
     "ConversationStatus",
+    "ConversationTimeoutError",
     "DEFAULT_AUTH_FILE",
     "DEFAULT_MODEL",
     "MediaError",
@@ -49,6 +59,7 @@ __all__ = [
     "MediaSource",
     "PendingApproval",
     "RequestError",
+    "WaitResult",
     "WebChatAdapterError",
     "WebChatClient",
     "load_auth_data",

--- a/src/webchat_adapter/exceptions.py
+++ b/src/webchat_adapter/exceptions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 
 class WebChatAdapterError(RuntimeError):
     """Base exception for the package."""
@@ -15,3 +17,22 @@ class RequestError(WebChatAdapterError):
 
 class MediaError(WebChatAdapterError):
     """Media normalization, download, or upload failure."""
+
+
+class ConversationTimeoutError(WebChatAdapterError):
+    """Conversation did not reach a terminal wait state before timeout."""
+
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        timeout: float,
+        last_status: Any = None,
+    ) -> None:
+        self.timeout = timeout
+        self.last_status = last_status
+        last_status_value = getattr(last_status, "status", None)
+        if message is None:
+            suffix = f"; last status: {last_status_value}" if last_status_value else ""
+            message = f"conversation did not complete within {timeout:.1f} seconds{suffix}"
+        super().__init__(message)

--- a/src/webchat_adapter/types.py
+++ b/src/webchat_adapter/types.py
@@ -508,6 +508,61 @@ class ChatMessage:
 
 
 @dataclass
+class WaitResult:
+    status: ConversationStatus
+    message: ChatMessage | None = None
+    approval: PendingApproval | None = None
+    elapsed: float = 0.0
+    polls: int = 0
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, ConversationStatus):
+            raise TypeError("status must be a ConversationStatus")
+        if self.message is not None and not isinstance(self.message, ChatMessage):
+            raise TypeError("message must be a ChatMessage or None")
+        if self.approval is not None and not isinstance(self.approval, PendingApproval):
+            raise TypeError("approval must be a PendingApproval or None")
+
+        try:
+            self.elapsed = float(self.elapsed)
+        except (TypeError, ValueError):
+            self.elapsed = 0.0
+        if self.elapsed < 0:
+            self.elapsed = 0.0
+
+        try:
+            self.polls = int(self.polls)
+        except (TypeError, ValueError):
+            self.polls = 0
+        if self.polls < 0:
+            self.polls = 0
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "WaitResult":
+        if not isinstance(payload, dict):
+            return cls(status=ConversationStatus())
+        message_payload = payload.get("message")
+        return cls(
+            status=ConversationStatus.from_dict(payload.get("status")),
+            message=ChatMessage.from_dict(message_payload)
+            if isinstance(message_payload, dict)
+            else None,
+            approval=PendingApproval.from_dict(payload.get("approval")),
+            elapsed=payload.get("elapsed", 0.0),
+            polls=payload.get("polls", 0),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.to_dict(),
+            "message": self.message.to_dict() if self.message is not None else None,
+            "approval": self.approval.to_dict() if self.approval is not None else None,
+            "elapsed": self.elapsed,
+            "polls": self.polls,
+        }
+
+
+@dataclass
 class ChatMetrics:
     first_token: float | None = None
     last_token: float | None = None

--- a/src/webchat_adapter/wait.py
+++ b/src/webchat_adapter/wait.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from .exceptions import ConversationTimeoutError
+from .types import ChatConversation, ChatMessage, ConversationRef, WaitResult
+
+
+def _coerce_timeout(value: Any) -> float:
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError) as error:
+        raise TypeError("timeout must be a number") from error
+    if timeout < 0:
+        raise ValueError("timeout must be >= 0")
+    return timeout
+
+
+def _coerce_interval(value: Any) -> float:
+    try:
+        interval = float(value)
+    except (TypeError, ValueError) as error:
+        raise TypeError("interval must be a number") from error
+    if interval <= 0:
+        raise ValueError("interval must be > 0")
+    return interval
+
+
+def _latest_assistant_message(self: Any, ref: ConversationRef) -> ChatMessage | None:
+    messages = self.get_messages(
+        ref,
+        limit=1,
+        roles={"assistant"},
+        include_empty=False,
+    )
+    if not isinstance(messages, list) or not messages:
+        return None
+    message = messages[0]
+    return message if isinstance(message, ChatMessage) else None
+
+
+def wait_until_completed(
+    self: Any,
+    url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
+    timeout: float = 90,
+    *,
+    interval: float = 2.0,
+) -> WaitResult:
+    """Wait until a conversation completes or reaches a controlled lifecycle state."""
+
+    ref = ConversationRef.from_any(url_or_id)
+    timeout_seconds = _coerce_timeout(timeout)
+    interval_seconds = _coerce_interval(interval)
+    started = time.monotonic()
+    deadline = started + timeout_seconds
+    polls = 0
+    last_status = None
+
+    while True:
+        polls += 1
+        status = self.get_status(ref)
+        last_status = status
+        elapsed = time.monotonic() - started
+
+        if getattr(status, "status", None) == "completed":
+            return WaitResult(
+                status=status,
+                message=_latest_assistant_message(self, ref),
+                elapsed=elapsed,
+                polls=polls,
+            )
+
+        if getattr(status, "status", None) == "awaiting_tool_approval":
+            return WaitResult(
+                status=status,
+                approval=self.get_pending_approval(ref),
+                elapsed=elapsed,
+                polls=polls,
+            )
+
+        now = time.monotonic()
+        if now >= deadline:
+            raise ConversationTimeoutError(
+                timeout=timeout_seconds,
+                last_status=last_status,
+            )
+
+        sleep_seconds = min(interval_seconds, max(0.0, deadline - now))
+        if sleep_seconds > 0:
+            time.sleep(sleep_seconds)

--- a/src/webchat_adapter/wait.py
+++ b/src/webchat_adapter/wait.py
@@ -27,17 +27,34 @@ def _coerce_interval(value: Any) -> float:
     return interval
 
 
-def _latest_assistant_message(self: Any, ref: ConversationRef) -> ChatMessage | None:
+def _completed_assistant_message(
+    self: Any,
+    ref: ConversationRef,
+    status: Any,
+) -> ChatMessage | None:
     messages = self.get_messages(
         ref,
-        limit=1,
+        limit=None,
         roles={"assistant"},
-        include_empty=False,
+        include_empty=True,
     )
     if not isinstance(messages, list) or not messages:
         return None
-    message = messages[0]
-    return message if isinstance(message, ChatMessage) else None
+
+    status_node_id = getattr(status, "node_id", None)
+    status_message_id = getattr(status, "message_id", None)
+    for message in messages:
+        if not isinstance(message, ChatMessage):
+            continue
+        if status_node_id is not None and message.node_id == status_node_id:
+            return message
+        if status_message_id is not None and message.message_id == status_message_id:
+            return message
+
+    for message in reversed(messages):
+        if isinstance(message, ChatMessage):
+            return message
+    return None
 
 
 def wait_until_completed(
@@ -66,7 +83,7 @@ def wait_until_completed(
         if getattr(status, "status", None) == "completed":
             return WaitResult(
                 status=status,
-                message=_latest_assistant_message(self, ref),
+                message=_completed_assistant_message(self, ref, status),
                 elapsed=elapsed,
                 polls=polls,
             )

--- a/tests/test_wait_until_completed.py
+++ b/tests/test_wait_until_completed.py
@@ -146,7 +146,41 @@ def test_wait_until_completed_returns_latest_assistant_message_on_completed() ->
     assert result.approval is None
     assert result.polls == 1
     assert client.message_calls == [
-        (ConversationRef("conversation-1"), 1, {"assistant"}, False)
+        (ConversationRef("conversation-1"), None, {"assistant"}, True)
+    ]
+
+
+def test_wait_until_completed_prefers_completed_status_message_even_when_empty() -> None:
+    earlier = ChatMessage(
+        node_id="earlier-node",
+        message_id="earlier-msg",
+        role="assistant",
+        text="Earlier answer",
+    )
+    completed = ChatMessage(
+        node_id="completed-node",
+        message_id="completed-msg",
+        role="assistant",
+        text="",
+    )
+    client = FakeWaitClient(
+        [
+            ConversationStatus(
+                status="completed",
+                node_id="completed-node",
+                message_id="completed-msg",
+            )
+        ],
+        messages=[earlier, completed],
+    )
+
+    result = client.wait_until_completed("conversation-1", timeout=90, interval=0.01)
+
+    assert result.status.status == "completed"
+    assert result.message == completed
+    assert result.message.text == ""
+    assert client.message_calls == [
+        (ConversationRef("conversation-1"), None, {"assistant"}, True)
     ]
 
 

--- a/tests/test_wait_until_completed.py
+++ b/tests/test_wait_until_completed.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import webchat_adapter
+import webchat_adapter.wait as wait_module
+from webchat_adapter import (
+    ChatGPTWebClient,
+    ChatMessage,
+    ConversationRef,
+    ConversationStatus,
+    ConversationTimeoutError,
+    PendingApproval,
+    WaitResult,
+)
+from webchat_adapter.wait import wait_until_completed
+
+
+class FakeWaitClient:
+    wait_until_completed = wait_until_completed
+
+    def __init__(
+        self,
+        statuses: list[ConversationStatus],
+        *,
+        messages: list[ChatMessage] | None = None,
+        approval: PendingApproval | None = None,
+    ) -> None:
+        self.statuses = list(statuses)
+        self.messages = messages or []
+        self.approval = approval
+        self.status_refs: list[ConversationRef] = []
+        self.message_calls: list[tuple[ConversationRef, int | None, set[str] | None, bool]] = []
+        self.approval_refs: list[ConversationRef] = []
+
+    def get_status(self, ref: ConversationRef) -> ConversationStatus:
+        self.status_refs.append(ref)
+        if len(self.statuses) > 1:
+            return self.statuses.pop(0)
+        return self.statuses[0]
+
+    def get_messages(
+        self,
+        ref: ConversationRef,
+        *,
+        limit: int | None,
+        roles: set[str] | None,
+        include_empty: bool,
+    ) -> list[ChatMessage]:
+        self.message_calls.append((ref, limit, roles, include_empty))
+        return self.messages
+
+    def get_pending_approval(self, ref: ConversationRef) -> PendingApproval | None:
+        self.approval_refs.append(ref)
+        return self.approval
+
+
+def test_wait_until_completed_method_is_available() -> None:
+    assert hasattr(ChatGPTWebClient, "wait_until_completed")
+
+
+def test_wait_result_to_dict() -> None:
+    result = WaitResult(
+        status=ConversationStatus(status="completed"),
+        message=ChatMessage(role="assistant", text="Done"),
+        elapsed=1.5,
+        polls=2,
+    )
+
+    assert result.to_dict() == {
+        "status": {
+            "status": "completed",
+            "node_id": None,
+            "message_id": None,
+            "role": None,
+            "recipient": None,
+            "async_status": None,
+            "finish_reason": None,
+            "pending_approval": False,
+            "metadata_preview": {},
+        },
+        "message": {
+            "node_id": None,
+            "message_id": None,
+            "role": "assistant",
+            "text": "Done",
+            "create_time": None,
+            "recipient": None,
+            "model": None,
+            "finish_reason": None,
+            "metadata_preview": {},
+        },
+        "approval": None,
+        "elapsed": 1.5,
+        "polls": 2,
+    }
+
+
+def test_wait_result_from_dict_roundtrip() -> None:
+    result = WaitResult(
+        status=ConversationStatus(status="awaiting_tool_approval", pending_approval=True),
+        approval=PendingApproval(
+            tool_message_id="tool-msg",
+            target_message_id="target-node",
+            recipient="python",
+        ),
+        elapsed=2.5,
+        polls=3,
+    )
+
+    assert WaitResult.from_dict(result.to_dict()) == result
+
+
+def test_wait_result_validates_nested_types() -> None:
+    with pytest.raises(TypeError, match="status must be a ConversationStatus"):
+        WaitResult(status="completed")
+    with pytest.raises(TypeError, match="message must be a ChatMessage or None"):
+        WaitResult(status=ConversationStatus(), message="not-a-message")
+    with pytest.raises(TypeError, match="approval must be a PendingApproval or None"):
+        WaitResult(status=ConversationStatus(), approval="not-an-approval")
+
+
+def test_wait_result_is_exported_from_public_package() -> None:
+    assert webchat_adapter.WaitResult is WaitResult
+    assert "WaitResult" in webchat_adapter.__all__
+
+
+def test_conversation_timeout_error_is_exported_from_public_package() -> None:
+    assert webchat_adapter.ConversationTimeoutError is ConversationTimeoutError
+    assert "ConversationTimeoutError" in webchat_adapter.__all__
+
+
+def test_wait_until_completed_returns_latest_assistant_message_on_completed() -> None:
+    message = ChatMessage(role="assistant", text="Done")
+    client = FakeWaitClient(
+        [ConversationStatus(status="completed")],
+        messages=[message],
+    )
+
+    result = client.wait_until_completed("conversation-1", timeout=90, interval=0.01)
+
+    assert result.status.status == "completed"
+    assert result.message == message
+    assert result.approval is None
+    assert result.polls == 1
+    assert client.message_calls == [
+        (ConversationRef("conversation-1"), 1, {"assistant"}, False)
+    ]
+
+
+def test_wait_until_completed_completed_without_assistant_message_returns_result() -> None:
+    client = FakeWaitClient([ConversationStatus(status="completed")], messages=[])
+
+    result = client.wait_until_completed("conversation-1", timeout=90, interval=0.01)
+
+    assert result.status.status == "completed"
+    assert result.message is None
+
+
+def test_wait_until_completed_returns_approval_result() -> None:
+    approval = PendingApproval(
+        tool_message_id="tool-msg",
+        target_message_id="target-node",
+        recipient="python",
+    )
+    client = FakeWaitClient(
+        [ConversationStatus(status="awaiting_tool_approval", pending_approval=True)],
+        approval=approval,
+    )
+
+    result = client.wait_until_completed("conversation-1", timeout=90, interval=0.01)
+
+    assert result.status.status == "awaiting_tool_approval"
+    assert result.approval == approval
+    assert result.message is None
+    assert result.polls == 1
+    assert client.approval_refs == [ConversationRef("conversation-1")]
+    assert client.message_calls == []
+
+
+def test_wait_until_completed_returns_approval_result_without_descriptor() -> None:
+    client = FakeWaitClient(
+        [ConversationStatus(status="awaiting_tool_approval", pending_approval=True)],
+        approval=None,
+    )
+
+    result = client.wait_until_completed("conversation-1", timeout=90, interval=0.01)
+
+    assert result.status.status == "awaiting_tool_approval"
+    assert result.approval is None
+
+
+def test_wait_until_completed_polls_until_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wait_module.time, "sleep", lambda _seconds: None)
+    client = FakeWaitClient(
+        [
+            ConversationStatus(status="running"),
+            ConversationStatus(status="tool_calling"),
+            ConversationStatus(status="running"),
+            ConversationStatus(status="completed"),
+        ],
+        messages=[ChatMessage(role="assistant", text="Done")],
+    )
+
+    result = client.wait_until_completed("conversation-1", timeout=90, interval=0.01)
+
+    assert result.status.status == "completed"
+    assert result.polls == 4
+    assert len(client.status_refs) == 4
+
+
+@pytest.mark.parametrize(
+    "first_status",
+    ["user_last_message", "tool_running", "unknown"],
+)
+def test_wait_until_completed_waits_for_non_terminal_statuses(
+    first_status: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(wait_module.time, "sleep", lambda _seconds: None)
+    client = FakeWaitClient(
+        [
+            ConversationStatus(status=first_status),
+            ConversationStatus(status="completed"),
+        ],
+        messages=[ChatMessage(role="assistant", text="Done")],
+    )
+
+    result = client.wait_until_completed("conversation-1", timeout=90, interval=0.01)
+
+    assert result.status.status == "completed"
+    assert result.polls == 2
+
+
+def test_wait_until_completed_timeout_raises_controlled_error() -> None:
+    status = ConversationStatus(status="running")
+    client = FakeWaitClient([status])
+
+    with pytest.raises(ConversationTimeoutError) as exc_info:
+        client.wait_until_completed("conversation-1", timeout=0, interval=0.01)
+
+    assert exc_info.value.timeout == 0.0
+    assert exc_info.value.last_status == status
+    assert "running" in str(exc_info.value)
+
+
+def test_wait_until_completed_validates_timeout_and_interval_before_polling() -> None:
+    client = object.__new__(ChatGPTWebClient)
+    client.get_status = lambda _ref: pytest.fail("status should not be fetched")
+
+    with pytest.raises(ValueError, match="timeout must be >= 0"):
+        client.wait_until_completed("conversation-1", timeout=-1)
+    with pytest.raises(ValueError, match="interval must be > 0"):
+        client.wait_until_completed("conversation-1", interval=0)
+    with pytest.raises(TypeError, match="timeout must be a number"):
+        client.wait_until_completed("conversation-1", timeout="soon")
+    with pytest.raises(TypeError, match="interval must be a number"):
+        client.wait_until_completed("conversation-1", interval="soon")
+
+
+def test_wait_until_completed_validates_conversation_reference_before_polling() -> None:
+    client = object.__new__(ChatGPTWebClient)
+    client.get_status = lambda _ref: pytest.fail("status should not be fetched")
+
+    with pytest.raises(ValueError, match="conversation_id is required"):
+        client.wait_until_completed("")


### PR DESCRIPTION
## Summary

- Add `WaitResult` as a wait operation snapshot.
- Add `ConversationTimeoutError` for controlled wait timeouts.
- Add `client.wait_until_completed(url_or_id, timeout=90, interval=2.0)`.
- Poll `get_status()` until completed or awaiting_tool_approval.
- Return latest assistant `ChatMessage` on completed.
- Return `PendingApproval` descriptor when approval is required.
- Raise `ConversationTimeoutError` on timeout.

## Scope

- No approve/deny mutation.
- No auto-approval policy.
- No send/continue behavior.
- No CLI or README changes.
- No status detection changes.

## Tests

- Cover completed, approval, polling transitions, unknown/user/tool states, timeout, validation, result serialization, and public exports.

Not run locally from this environment. CI runs `pytest -q` and package build.