### PR TITLE
PR4.1: Add approval result types

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .approval_types import ApprovalEvent, ApprovalResult, ApprovalRound
 from .attach import attach_conversation as _attach_conversation
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
 from .client import DEFAULT_MODEL, ChatGPTWebClient
@@ -41,6 +42,9 @@ ChatGPTWebClient.wait_until_completed = _wait_until_completed
 WebChatClient = ChatGPTWebClient
 
 __all__ = [
+    "ApprovalEvent",
+    "ApprovalResult",
+    "ApprovalRound",
     "AttachedConversation",
     "AuthData",
     "AuthError",

--- a/src/webchat_adapter/approval_types.py
+++ b/src/webchat_adapter/approval_types.py
@@ -92,6 +92,7 @@ def _chat_response_to_dict(response: ChatResponse | None) -> dict[str, Any] | No
         return None
     return {
         "text": response.text,
+        "title": response.title,
         "conversation": response.conversation.to_dict(),
         "metrics": {
             "first_token": response.metrics.first_token,
@@ -107,6 +108,7 @@ def _chat_response_from_dict(payload: Any) -> ChatResponse | None:
     metrics = payload.get("metrics")
     return ChatResponse(
         text="" if payload.get("text") is None else str(payload.get("text")),
+        title=_optional_str(payload.get("title")),
         conversation=ChatConversation.from_dict(payload.get("conversation")),
         metrics=ChatMetrics.from_dict(metrics if isinstance(metrics, dict) else None),
     )

--- a/src/webchat_adapter/approval_types.py
+++ b/src/webchat_adapter/approval_types.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from .types import ChatConversation, ChatMetrics, ChatResponse, PendingApproval
+
+ApprovalEventType = Literal[
+    "approval_detected",
+    "approval_allowed",
+    "approval_denied",
+    "approval_sent",
+    "approval_completed",
+    "approval_failed",
+]
+APPROVAL_EVENT_TYPES: tuple[ApprovalEventType, ...] = (
+    "approval_detected",
+    "approval_allowed",
+    "approval_denied",
+    "approval_sent",
+    "approval_completed",
+    "approval_failed",
+)
+
+ApprovalRoundStatus = Literal[
+    "detected",
+    "allowed",
+    "denied",
+    "sent",
+    "completed",
+    "failed",
+]
+APPROVAL_ROUND_STATUSES: tuple[ApprovalRoundStatus, ...] = (
+    "detected",
+    "allowed",
+    "denied",
+    "sent",
+    "completed",
+    "failed",
+)
+
+ApprovalResultStatus = Literal[
+    "completed",
+    "approval_required",
+    "denied",
+    "failed",
+]
+APPROVAL_RESULT_STATUSES: tuple[ApprovalResultStatus, ...] = (
+    "completed",
+    "approval_required",
+    "denied",
+    "failed",
+)
+
+
+def _optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _positive_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise TypeError(f"{field_name} must be an integer")
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{field_name} must be an integer") from error
+    if result <= 0:
+        raise ValueError(f"{field_name} must be positive")
+    return result
+
+
+def _optional_positive_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    return _positive_int(value, field_name)
+
+
+def _metadata_preview(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TypeError("metadata_preview must be a dict")
+    return copy.deepcopy(value)
+
+
+def _chat_response_to_dict(response: ChatResponse | None) -> dict[str, Any] | None:
+    if response is None:
+        return None
+    return {
+        "text": response.text,
+        "conversation": response.conversation.to_dict(),
+        "metrics": {
+            "first_token": response.metrics.first_token,
+            "last_token": response.metrics.last_token,
+            "total": response.metrics.total,
+        },
+    }
+
+
+def _chat_response_from_dict(payload: Any) -> ChatResponse | None:
+    if not isinstance(payload, dict):
+        return None
+    metrics = payload.get("metrics")
+    return ChatResponse(
+        text="" if payload.get("text") is None else str(payload.get("text")),
+        conversation=ChatConversation.from_dict(payload.get("conversation")),
+        metrics=ChatMetrics.from_dict(metrics if isinstance(metrics, dict) else None),
+    )
+
+
+@dataclass
+class ApprovalEvent:
+    type: ApprovalEventType
+    conversation_id: str | None = None
+    round_index: int | None = None
+    tool_message_id: str | None = None
+    target_message_id: str | None = None
+    recipient: str | None = None
+    allowed: bool | None = None
+    reason: str | None = None
+    metadata_preview: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        event_type = _optional_str(self.type)
+        if event_type not in APPROVAL_EVENT_TYPES:
+            raise ValueError(f"unsupported approval event type: {self.type!r}")
+        self.type = event_type
+        self.conversation_id = _optional_str(self.conversation_id)
+        self.round_index = _optional_positive_int(self.round_index, "round_index")
+        self.tool_message_id = _optional_str(self.tool_message_id)
+        self.target_message_id = _optional_str(self.target_message_id)
+        self.recipient = _optional_str(self.recipient)
+        if self.allowed is not None and not isinstance(self.allowed, bool):
+            self.allowed = bool(self.allowed)
+        self.reason = _optional_str(self.reason)
+        self.metadata_preview = _metadata_preview(self.metadata_preview)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "ApprovalEvent":
+        if not isinstance(payload, dict):
+            raise TypeError("approval event payload must be a dict")
+        return cls(
+            type=payload.get("type"),
+            conversation_id=payload.get("conversation_id"),
+            round_index=payload.get("round_index"),
+            tool_message_id=payload.get("tool_message_id"),
+            target_message_id=payload.get("target_message_id"),
+            recipient=payload.get("recipient"),
+            allowed=payload.get("allowed"),
+            reason=payload.get("reason"),
+            metadata_preview=payload.get("metadata_preview"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "conversation_id": self.conversation_id,
+            "round_index": self.round_index,
+            "tool_message_id": self.tool_message_id,
+            "target_message_id": self.target_message_id,
+            "recipient": self.recipient,
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "metadata_preview": copy.deepcopy(self.metadata_preview),
+        }
+
+
+@dataclass
+class ApprovalRound:
+    index: int
+    approval: PendingApproval | None = None
+    status: ApprovalRoundStatus = "detected"
+    events: list[ApprovalEvent] = field(default_factory=list)
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        self.index = _positive_int(self.index, "index")
+        if self.approval is not None and not isinstance(self.approval, PendingApproval):
+            raise TypeError("approval must be a PendingApproval or None")
+        status = _optional_str(self.status)
+        if status not in APPROVAL_ROUND_STATUSES:
+            raise ValueError(f"unsupported approval round status: {self.status!r}")
+        self.status = status
+        events = []
+        for event in self.events or []:
+            if not isinstance(event, ApprovalEvent):
+                raise TypeError("events must contain ApprovalEvent items")
+            events.append(event)
+        self.events = events
+        self.error = _optional_str(self.error)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "ApprovalRound":
+        if not isinstance(payload, dict):
+            raise TypeError("approval round payload must be a dict")
+        events_payload = payload.get("events")
+        events = []
+        if isinstance(events_payload, list):
+            events = [ApprovalEvent.from_dict(event) for event in events_payload]
+        return cls(
+            index=payload.get("index"),
+            approval=PendingApproval.from_dict(payload.get("approval")),
+            status=payload.get("status", "detected"),
+            events=events,
+            error=payload.get("error"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "approval": self.approval.to_dict() if self.approval is not None else None,
+            "status": self.status,
+            "events": [event.to_dict() for event in self.events],
+            "error": self.error,
+        }
+
+
+@dataclass
+class ApprovalResult:
+    status: ApprovalResultStatus = "completed"
+    rounds: list[ApprovalRound] = field(default_factory=list)
+    events: list[ApprovalEvent] = field(default_factory=list)
+    response: ChatResponse | None = None
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        status = _optional_str(self.status)
+        if status not in APPROVAL_RESULT_STATUSES:
+            raise ValueError(f"unsupported approval result status: {self.status!r}")
+        self.status = status
+
+        rounds = []
+        for round_item in self.rounds or []:
+            if not isinstance(round_item, ApprovalRound):
+                raise TypeError("rounds must contain ApprovalRound items")
+            rounds.append(round_item)
+        self.rounds = rounds
+
+        events = []
+        for event in self.events or []:
+            if not isinstance(event, ApprovalEvent):
+                raise TypeError("events must contain ApprovalEvent items")
+            events.append(event)
+        self.events = events
+
+        if self.response is not None and not isinstance(self.response, ChatResponse):
+            raise TypeError("response must be a ChatResponse or None")
+        self.error = _optional_str(self.error)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "ApprovalResult":
+        if not isinstance(payload, dict):
+            raise TypeError("approval result payload must be a dict")
+        rounds_payload = payload.get("rounds")
+        events_payload = payload.get("events")
+        rounds = []
+        events = []
+        if isinstance(rounds_payload, list):
+            rounds = [ApprovalRound.from_dict(round_item) for round_item in rounds_payload]
+        if isinstance(events_payload, list):
+            events = [ApprovalEvent.from_dict(event) for event in events_payload]
+        return cls(
+            status=payload.get("status", "completed"),
+            rounds=rounds,
+            events=events,
+            response=_chat_response_from_dict(payload.get("response")),
+            error=payload.get("error"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "rounds": [round_item.to_dict() for round_item in self.rounds],
+            "events": [event.to_dict() for event in self.events],
+            "response": _chat_response_to_dict(self.response),
+            "error": self.error,
+        }

--- a/src/webchat_adapter/approval_types.py
+++ b/src/webchat_adapter/approval_types.py
@@ -135,7 +135,7 @@ class ApprovalEvent:
         self.target_message_id = _optional_str(self.target_message_id)
         self.recipient = _optional_str(self.recipient)
         if self.allowed is not None and not isinstance(self.allowed, bool):
-            self.allowed = bool(self.allowed)
+            raise TypeError("allowed must be a bool or None")
         self.reason = _optional_str(self.reason)
         self.metadata_preview = _metadata_preview(self.metadata_preview)
 

--- a/tests/test_approval_types.py
+++ b/tests/test_approval_types.py
@@ -96,6 +96,11 @@ def test_approval_event_allowed_accepts_bool_or_none() -> None:
     assert ApprovalEvent(type="approval_detected").allowed is None
 
 
+def test_approval_event_allowed_rejects_non_bool_values() -> None:
+    with pytest.raises(TypeError, match="allowed must be a bool or None"):
+        ApprovalEvent(type="approval_allowed", allowed="false")
+
+
 def test_approval_event_metadata_none_becomes_empty_dict() -> None:
     event = ApprovalEvent(type="approval_detected", metadata_preview=None)
 

--- a/tests/test_approval_types.py
+++ b/tests/test_approval_types.py
@@ -41,6 +41,7 @@ def _event() -> ApprovalEvent:
 def _response() -> ChatResponse:
     return ChatResponse(
         text="Done",
+        title="Approval workflow",
         conversation=ChatConversation(
             conversation_id="conversation-1",
             message_id="assistant-msg",
@@ -287,6 +288,7 @@ def test_approval_result_to_dict_with_response_preview() -> None:
         "events": [event.to_dict()],
         "response": {
             "text": "Done",
+            "title": "Approval workflow",
             "conversation": response.conversation.to_dict(),
             "metrics": {
                 "first_token": 0.1,

--- a/tests/test_approval_types.py
+++ b/tests/test_approval_types.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import pytest
+
+import webchat_adapter
+from webchat_adapter import (
+    ApprovalEvent,
+    ApprovalResult,
+    ApprovalRound,
+    ChatConversation,
+    ChatMetrics,
+    ChatResponse,
+    PendingApproval,
+)
+from webchat_adapter.approval_types import (
+    APPROVAL_EVENT_TYPES,
+    APPROVAL_RESULT_STATUSES,
+    APPROVAL_ROUND_STATUSES,
+)
+
+
+def _approval() -> PendingApproval:
+    return PendingApproval(
+        tool_message_id="tool-msg",
+        target_message_id="target-node",
+        recipient="python",
+    )
+
+
+def _event() -> ApprovalEvent:
+    return ApprovalEvent(
+        type="approval_detected",
+        conversation_id="conversation-1",
+        round_index=1,
+        tool_message_id="tool-msg",
+        target_message_id="target-node",
+        recipient="python",
+    )
+
+
+def _response() -> ChatResponse:
+    return ChatResponse(
+        text="Done",
+        conversation=ChatConversation(
+            conversation_id="conversation-1",
+            message_id="assistant-msg",
+            finish_reason="stop",
+            parent_message_id="assistant-msg",
+        ),
+        metrics=ChatMetrics(first_token=0.1, last_token=0.3, total=0.4),
+    )
+
+
+def test_approval_event_accepts_known_event_types() -> None:
+    for event_type in APPROVAL_EVENT_TYPES:
+        assert ApprovalEvent(type=event_type).type == event_type
+
+
+def test_approval_event_rejects_unknown_event_type() -> None:
+    with pytest.raises(ValueError, match="unsupported approval event type"):
+        ApprovalEvent(type="unknown")
+
+
+def test_approval_event_normalizes_optional_strings() -> None:
+    event = ApprovalEvent(
+        type=" approval_detected ",
+        conversation_id=" conversation-1 ",
+        tool_message_id=" tool-msg ",
+        target_message_id=" target-node ",
+        recipient=" python ",
+        reason=" allowed_by_policy ",
+    )
+
+    assert event.type == "approval_detected"
+    assert event.conversation_id == "conversation-1"
+    assert event.tool_message_id == "tool-msg"
+    assert event.target_message_id == "target-node"
+    assert event.recipient == "python"
+    assert event.reason == "allowed_by_policy"
+
+
+@pytest.mark.parametrize("round_index", [0, -1])
+def test_approval_event_rejects_non_positive_round_index(round_index: int) -> None:
+    with pytest.raises(ValueError, match="round_index must be positive"):
+        ApprovalEvent(type="approval_detected", round_index=round_index)
+
+
+def test_approval_event_rejects_non_integer_round_index() -> None:
+    with pytest.raises(TypeError, match="round_index must be an integer"):
+        ApprovalEvent(type="approval_detected", round_index="abc")
+
+
+def test_approval_event_allowed_accepts_bool_or_none() -> None:
+    assert ApprovalEvent(type="approval_allowed", allowed=True).allowed is True
+    assert ApprovalEvent(type="approval_denied", allowed=False).allowed is False
+    assert ApprovalEvent(type="approval_detected").allowed is None
+
+
+def test_approval_event_metadata_none_becomes_empty_dict() -> None:
+    event = ApprovalEvent(type="approval_detected", metadata_preview=None)
+
+    assert event.metadata_preview == {}
+
+
+def test_approval_event_metadata_non_dict_raises_type_error() -> None:
+    with pytest.raises(TypeError, match="metadata_preview must be a dict"):
+        ApprovalEvent(type="approval_detected", metadata_preview="bad")
+
+
+def test_approval_event_deep_copies_metadata_on_construction() -> None:
+    metadata = {"nested": {"value": 1}}
+    event = ApprovalEvent(type="approval_detected", metadata_preview=metadata)
+
+    metadata["nested"]["value"] = 2
+
+    assert event.metadata_preview == {"nested": {"value": 1}}
+
+
+def test_approval_event_to_dict_deep_copies_metadata() -> None:
+    event = ApprovalEvent(
+        type="approval_detected",
+        metadata_preview={"nested": {"value": 1}},
+    )
+
+    payload = event.to_dict()
+    payload["metadata_preview"]["nested"]["value"] = 2
+
+    assert event.metadata_preview == {"nested": {"value": 1}}
+
+
+def test_approval_event_from_dict_roundtrip() -> None:
+    event = ApprovalEvent(
+        type="approval_allowed",
+        conversation_id="conversation-1",
+        round_index=1,
+        tool_message_id="tool-msg",
+        target_message_id="target-node",
+        recipient="python",
+        allowed=True,
+        reason="recipient_allowed",
+        metadata_preview={"safe": True},
+    )
+
+    assert ApprovalEvent.from_dict(event.to_dict()) == event
+
+
+def test_approval_event_from_dict_rejects_non_dict_payload() -> None:
+    with pytest.raises(TypeError, match="approval event payload must be a dict"):
+        ApprovalEvent.from_dict(None)
+
+
+def test_approval_round_accepts_known_statuses() -> None:
+    for status in APPROVAL_ROUND_STATUSES:
+        assert ApprovalRound(index=1, status=status).status == status
+
+
+def test_approval_round_validates_positive_index() -> None:
+    with pytest.raises(ValueError, match="index must be positive"):
+        ApprovalRound(index=0)
+    with pytest.raises(TypeError, match="index must be an integer"):
+        ApprovalRound(index="abc")
+
+
+def test_approval_round_rejects_unknown_status() -> None:
+    with pytest.raises(ValueError, match="unsupported approval round status"):
+        ApprovalRound(index=1, status="unknown")
+
+
+def test_approval_round_accepts_pending_approval() -> None:
+    approval = _approval()
+    round_item = ApprovalRound(index=1, approval=approval)
+
+    assert round_item.approval == approval
+
+
+def test_approval_round_rejects_non_pending_approval() -> None:
+    with pytest.raises(TypeError, match="approval must be a PendingApproval or None"):
+        ApprovalRound(index=1, approval="bad")
+
+
+def test_approval_round_rejects_non_approval_event_items() -> None:
+    with pytest.raises(TypeError, match="events must contain ApprovalEvent items"):
+        ApprovalRound(index=1, events=["bad"])
+
+
+def test_approval_round_normalizes_error() -> None:
+    round_item = ApprovalRound(index=1, error=" failed ")
+
+    assert round_item.error == "failed"
+
+
+def test_approval_round_to_dict() -> None:
+    event = _event()
+    approval = _approval()
+    round_item = ApprovalRound(
+        index=1,
+        approval=approval,
+        status="detected",
+        events=[event],
+        error="none",
+    )
+
+    assert round_item.to_dict() == {
+        "index": 1,
+        "approval": approval.to_dict(),
+        "status": "detected",
+        "events": [event.to_dict()],
+        "error": "none",
+    }
+
+
+def test_approval_round_from_dict_roundtrip() -> None:
+    round_item = ApprovalRound(
+        index=1,
+        approval=_approval(),
+        status="completed",
+        events=[_event()],
+        error="none",
+    )
+
+    assert ApprovalRound.from_dict(round_item.to_dict()) == round_item
+
+
+def test_approval_round_from_dict_rejects_non_dict_payload() -> None:
+    with pytest.raises(TypeError, match="approval round payload must be a dict"):
+        ApprovalRound.from_dict(None)
+
+
+def test_approval_result_accepts_known_statuses() -> None:
+    for status in APPROVAL_RESULT_STATUSES:
+        assert ApprovalResult(status=status).status == status
+
+
+def test_approval_result_rejects_unknown_status() -> None:
+    with pytest.raises(ValueError, match="unsupported approval result status"):
+        ApprovalResult(status="unknown")
+
+
+def test_approval_result_rejects_non_round_items() -> None:
+    with pytest.raises(TypeError, match="rounds must contain ApprovalRound items"):
+        ApprovalResult(rounds=["bad"])
+
+
+def test_approval_result_rejects_non_event_items() -> None:
+    with pytest.raises(TypeError, match="events must contain ApprovalEvent items"):
+        ApprovalResult(events=["bad"])
+
+
+def test_approval_result_accepts_chat_response() -> None:
+    response = _response()
+    result = ApprovalResult(response=response)
+
+    assert result.response == response
+
+
+def test_approval_result_rejects_non_chat_response() -> None:
+    with pytest.raises(TypeError, match="response must be a ChatResponse or None"):
+        ApprovalResult(response="bad")
+
+
+def test_approval_result_normalizes_error() -> None:
+    result = ApprovalResult(status="failed", error=" failed ")
+
+    assert result.error == "failed"
+
+
+def test_approval_result_to_dict_with_response_preview() -> None:
+    event = _event()
+    round_item = ApprovalRound(index=1, approval=_approval(), events=[event])
+    response = _response()
+    result = ApprovalResult(
+        status="completed",
+        rounds=[round_item],
+        events=[event],
+        response=response,
+        error=None,
+    )
+
+    assert result.to_dict() == {
+        "status": "completed",
+        "rounds": [round_item.to_dict()],
+        "events": [event.to_dict()],
+        "response": {
+            "text": "Done",
+            "conversation": response.conversation.to_dict(),
+            "metrics": {
+                "first_token": 0.1,
+                "last_token": 0.3,
+                "total": 0.4,
+            },
+        },
+        "error": None,
+    }
+
+
+def test_approval_result_from_dict_roundtrip_with_response() -> None:
+    result = ApprovalResult(
+        status="completed",
+        rounds=[ApprovalRound(index=1, approval=_approval(), events=[_event()])],
+        events=[_event()],
+        response=_response(),
+    )
+
+    assert ApprovalResult.from_dict(result.to_dict()) == result
+
+
+def test_approval_result_from_dict_roundtrip_without_response() -> None:
+    result = ApprovalResult(
+        status="denied",
+        rounds=[ApprovalRound(index=1, approval=_approval(), status="denied")],
+        events=[ApprovalEvent(type="approval_denied", allowed=False, reason="policy_denied")],
+        error="policy_denied",
+    )
+
+    assert ApprovalResult.from_dict(result.to_dict()) == result
+
+
+def test_approval_result_from_dict_rejects_non_dict_payload() -> None:
+    with pytest.raises(TypeError, match="approval result payload must be a dict"):
+        ApprovalResult.from_dict(None)
+
+
+def test_approval_types_are_exported_from_public_package() -> None:
+    assert webchat_adapter.ApprovalEvent is ApprovalEvent
+    assert webchat_adapter.ApprovalRound is ApprovalRound
+    assert webchat_adapter.ApprovalResult is ApprovalResult
+    assert "ApprovalEvent" in webchat_adapter.__all__
+    assert "ApprovalRound" in webchat_adapter.__all__
+    assert "ApprovalResult" in webchat_adapter.__all__


### PR DESCRIPTION
## Summary

- Add typed approval lifecycle models: `ApprovalEvent`, `ApprovalRound`, and `ApprovalResult`.
- Add known event, round, and result status validation.
- Add serialization helpers for approval events, rounds, and results.
- Support optional `PendingApproval` and `ChatResponse` snapshots.
- Export approval types from the public package.

## Scope

- No approval policy yet.
- No approval behavior changes.
- No `approve_pending_action()` integration.
- No `send_and_auto_approve()` integration.
- No event emission changes.
- No CLI or README changes.

## Tests

- Cover validation, serialization roundtrips, metadata deep-copying, response snapshots, nested approval models, strict allowed-flag validation, and public exports.

Not run locally from this environment. CI runs `pytest -q` and package build.