### PR TITLE
PR4.2: Add approval policy v1

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .approval_policy import ApprovalDecision, ApprovalPolicy
 from .approval_types import ApprovalEvent, ApprovalResult, ApprovalRound
 from .attach import attach_conversation as _attach_conversation
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
@@ -42,7 +43,9 @@ ChatGPTWebClient.wait_until_completed = _wait_until_completed
 WebChatClient = ChatGPTWebClient
 
 __all__ = [
+    "ApprovalDecision",
     "ApprovalEvent",
+    "ApprovalPolicy",
     "ApprovalResult",
     "ApprovalRound",
     "AttachedConversation",

--- a/src/webchat_adapter/approval_policy.py
+++ b/src/webchat_adapter/approval_policy.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from .types import PendingApproval
+
+ApprovalDecisionReason = Literal[
+    "recipient_allowed",
+    "recipient_denied",
+    "manual_required_for_unknown_recipient",
+    "unknown_recipient_denied",
+    "read_only_auto_approve_disabled",
+    "read_only_auto_approved",
+]
+APPROVAL_DECISION_REASONS: tuple[ApprovalDecisionReason, ...] = (
+    "recipient_allowed",
+    "recipient_denied",
+    "manual_required_for_unknown_recipient",
+    "unknown_recipient_denied",
+    "read_only_auto_approve_disabled",
+    "read_only_auto_approved",
+)
+
+
+def _optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _required_recipient(value: Any) -> str:
+    if not isinstance(value, str):
+        raise TypeError("recipient must be a string")
+    recipient = value.strip()
+    if not recipient:
+        raise ValueError("recipient must not be empty")
+    return recipient
+
+
+def _normalize_recipients(value: Any, field_name: str) -> frozenset[str]:
+    if value is None:
+        return frozenset()
+    if isinstance(value, str):
+        raise TypeError(f"{field_name} must be an iterable of strings")
+    try:
+        iterator = iter(value)
+    except TypeError as error:
+        raise TypeError(f"{field_name} must be an iterable of strings") from error
+
+    recipients = []
+    for recipient in iterator:
+        try:
+            recipients.append(_required_recipient(recipient))
+        except (TypeError, ValueError) as error:
+            raise type(error)(f"{field_name} contains invalid recipient: {error}") from error
+    return frozenset(recipients)
+
+
+def _metadata_preview(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TypeError("metadata_preview must be a dict")
+    return copy.deepcopy(value)
+
+
+@dataclass
+class ApprovalDecision:
+    allowed: bool
+    reason: ApprovalDecisionReason
+    recipient: str | None = None
+    manual_required: bool = False
+    metadata_preview: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.allowed, bool):
+            raise TypeError("allowed must be a bool")
+        reason = _optional_str(self.reason)
+        if reason not in APPROVAL_DECISION_REASONS:
+            raise ValueError(f"unsupported approval decision reason: {self.reason!r}")
+        self.reason = reason
+        self.recipient = _optional_str(self.recipient)
+        if not isinstance(self.manual_required, bool):
+            raise TypeError("manual_required must be a bool")
+        self.metadata_preview = _metadata_preview(self.metadata_preview)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "ApprovalDecision":
+        if not isinstance(payload, dict):
+            raise TypeError("approval decision payload must be a dict")
+        return cls(
+            allowed=payload.get("allowed"),
+            reason=payload.get("reason"),
+            recipient=payload.get("recipient"),
+            manual_required=payload.get("manual_required", False),
+            metadata_preview=payload.get("metadata_preview"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "recipient": self.recipient,
+            "manual_required": self.manual_required,
+            "metadata_preview": copy.deepcopy(self.metadata_preview),
+        }
+
+
+@dataclass(frozen=True)
+class ApprovalPolicy:
+    allowed_recipients: frozenset[str] = field(default_factory=frozenset)
+    denied_recipients: frozenset[str] = field(default_factory=frozenset)
+    auto_approve_read_only: bool = False
+    require_manual_for_unknown: bool = True
+
+    def __post_init__(self) -> None:
+        allowed_recipients = _normalize_recipients(
+            self.allowed_recipients,
+            "allowed_recipients",
+        )
+        denied_recipients = _normalize_recipients(
+            self.denied_recipients,
+            "denied_recipients",
+        )
+        overlap = allowed_recipients & denied_recipients
+        if overlap:
+            joined = ", ".join(sorted(overlap))
+            raise ValueError(f"recipients cannot be both allowed and denied: {joined}")
+
+        if not isinstance(self.auto_approve_read_only, bool):
+            raise TypeError("auto_approve_read_only must be a bool")
+        if not isinstance(self.require_manual_for_unknown, bool):
+            raise TypeError("require_manual_for_unknown must be a bool")
+
+        object.__setattr__(self, "allowed_recipients", allowed_recipients)
+        object.__setattr__(self, "denied_recipients", denied_recipients)
+
+    def evaluate(self, approval: PendingApproval) -> ApprovalDecision:
+        if not isinstance(approval, PendingApproval):
+            raise TypeError("approval must be a PendingApproval")
+
+        recipient = approval.recipient
+        if recipient in self.denied_recipients:
+            return ApprovalDecision(
+                allowed=False,
+                reason="recipient_denied",
+                recipient=recipient,
+                manual_required=False,
+            )
+
+        if recipient in self.allowed_recipients:
+            return ApprovalDecision(
+                allowed=True,
+                reason="recipient_allowed",
+                recipient=recipient,
+                manual_required=False,
+            )
+
+        if self.require_manual_for_unknown:
+            return ApprovalDecision(
+                allowed=False,
+                reason="manual_required_for_unknown_recipient",
+                recipient=recipient,
+                manual_required=True,
+            )
+
+        return ApprovalDecision(
+            allowed=False,
+            reason="unknown_recipient_denied",
+            recipient=recipient,
+            manual_required=False,
+        )
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "ApprovalPolicy":
+        if not isinstance(payload, dict):
+            raise TypeError("approval policy payload must be a dict")
+        return cls(
+            allowed_recipients=payload.get("allowed_recipients"),
+            denied_recipients=payload.get("denied_recipients"),
+            auto_approve_read_only=payload.get("auto_approve_read_only", False),
+            require_manual_for_unknown=payload.get("require_manual_for_unknown", True),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed_recipients": sorted(self.allowed_recipients),
+            "denied_recipients": sorted(self.denied_recipients),
+            "auto_approve_read_only": self.auto_approve_read_only,
+            "require_manual_for_unknown": self.require_manual_for_unknown,
+        }

--- a/tests/test_approval_policy.py
+++ b/tests/test_approval_policy.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+import webchat_adapter
+from webchat_adapter import ApprovalDecision, ApprovalPolicy, PendingApproval
+from webchat_adapter.approval_policy import APPROVAL_DECISION_REASONS
+
+
+def _approval(recipient: str = "python") -> PendingApproval:
+    return PendingApproval(
+        tool_message_id="tool-msg",
+        target_message_id="target-node",
+        recipient=recipient,
+    )
+
+
+def test_approval_decision_accepts_known_reasons() -> None:
+    for reason in APPROVAL_DECISION_REASONS:
+        decision = ApprovalDecision(allowed=False, reason=reason)
+        assert decision.reason == reason
+
+
+def test_approval_decision_requires_bool_allowed() -> None:
+    with pytest.raises(TypeError, match="allowed must be a bool"):
+        ApprovalDecision(allowed="false", reason="recipient_allowed")
+
+
+def test_approval_decision_requires_known_reason() -> None:
+    with pytest.raises(ValueError, match="unsupported approval decision reason"):
+        ApprovalDecision(allowed=False, reason="unknown")
+
+
+def test_approval_decision_normalizes_recipient_and_reason() -> None:
+    decision = ApprovalDecision(
+        allowed=True,
+        reason=" recipient_allowed ",
+        recipient=" python ",
+    )
+
+    assert decision.reason == "recipient_allowed"
+    assert decision.recipient == "python"
+
+
+def test_approval_decision_manual_required_is_strict_bool() -> None:
+    assert ApprovalDecision(
+        allowed=False,
+        reason="manual_required_for_unknown_recipient",
+        manual_required=True,
+    ).manual_required is True
+
+    with pytest.raises(TypeError, match="manual_required must be a bool"):
+        ApprovalDecision(
+            allowed=False,
+            reason="manual_required_for_unknown_recipient",
+            manual_required="true",
+        )
+
+
+def test_approval_decision_metadata_none_becomes_empty_dict() -> None:
+    decision = ApprovalDecision(
+        allowed=False,
+        reason="recipient_denied",
+        metadata_preview=None,
+    )
+
+    assert decision.metadata_preview == {}
+
+
+def test_approval_decision_rejects_non_dict_metadata() -> None:
+    with pytest.raises(TypeError, match="metadata_preview must be a dict"):
+        ApprovalDecision(
+            allowed=False,
+            reason="recipient_denied",
+            metadata_preview="bad",
+        )
+
+
+def test_approval_decision_deep_copies_metadata_on_construction() -> None:
+    metadata = {"nested": {"value": 1}}
+    decision = ApprovalDecision(
+        allowed=False,
+        reason="recipient_denied",
+        metadata_preview=metadata,
+    )
+
+    metadata["nested"]["value"] = 2
+
+    assert decision.metadata_preview == {"nested": {"value": 1}}
+
+
+def test_approval_decision_to_dict_deep_copies_metadata() -> None:
+    decision = ApprovalDecision(
+        allowed=False,
+        reason="recipient_denied",
+        metadata_preview={"nested": {"value": 1}},
+    )
+
+    payload = decision.to_dict()
+    payload["metadata_preview"]["nested"]["value"] = 2
+
+    assert decision.metadata_preview == {"nested": {"value": 1}}
+
+
+def test_approval_decision_from_dict_roundtrip() -> None:
+    decision = ApprovalDecision(
+        allowed=False,
+        reason="manual_required_for_unknown_recipient",
+        recipient="python",
+        manual_required=True,
+        metadata_preview={"safe": True},
+    )
+
+    assert ApprovalDecision.from_dict(decision.to_dict()) == decision
+
+
+def test_approval_decision_from_dict_rejects_non_dict_payload() -> None:
+    with pytest.raises(TypeError, match="approval decision payload must be a dict"):
+        ApprovalDecision.from_dict(None)
+
+
+def test_approval_policy_defaults_deny_unknown_manual_required() -> None:
+    policy = ApprovalPolicy()
+
+    assert policy.allowed_recipients == frozenset()
+    assert policy.denied_recipients == frozenset()
+    assert policy.auto_approve_read_only is False
+    assert policy.require_manual_for_unknown is True
+
+    decision = policy.evaluate(_approval("python"))
+    assert decision.allowed is False
+    assert decision.reason == "manual_required_for_unknown_recipient"
+    assert decision.recipient == "python"
+    assert decision.manual_required is True
+
+
+def test_approval_policy_normalizes_allowed_and_denied_recipients() -> None:
+    policy = ApprovalPolicy(
+        allowed_recipients={" python ", "python", "browser"},
+        denied_recipients=[" shell "],
+    )
+
+    assert policy.allowed_recipients == frozenset({"python", "browser"})
+    assert policy.denied_recipients == frozenset({"shell"})
+
+
+@pytest.mark.parametrize(
+    ("field_name", "kwargs"),
+    [
+        ("allowed_recipients", {"allowed_recipients": {""}}),
+        ("denied_recipients", {"denied_recipients": {"  "}}),
+    ],
+)
+def test_approval_policy_rejects_empty_recipient(
+    field_name: str,
+    kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match=f"{field_name} contains invalid recipient"):
+        ApprovalPolicy(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "kwargs"),
+    [
+        ("allowed_recipients", {"allowed_recipients": {1}}),
+        ("denied_recipients", {"denied_recipients": {object()}}),
+    ],
+)
+def test_approval_policy_rejects_non_string_recipient(
+    field_name: str,
+    kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(TypeError, match=f"{field_name} contains invalid recipient"):
+        ApprovalPolicy(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("field_name", "kwargs"),
+    [
+        ("allowed_recipients", {"allowed_recipients": "python"}),
+        ("denied_recipients", {"denied_recipients": "browser"}),
+    ],
+)
+def test_approval_policy_rejects_plain_string_recipient_collections(
+    field_name: str,
+    kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(TypeError, match=f"{field_name} must be an iterable of strings"):
+        ApprovalPolicy(**kwargs)
+
+
+def test_approval_policy_rejects_allowed_denied_conflict() -> None:
+    with pytest.raises(ValueError, match="recipients cannot be both allowed and denied"):
+        ApprovalPolicy(
+            allowed_recipients={"python", "browser"},
+            denied_recipients={"browser"},
+        )
+
+
+def test_approval_policy_rejects_non_bool_flags() -> None:
+    with pytest.raises(TypeError, match="auto_approve_read_only must be a bool"):
+        ApprovalPolicy(auto_approve_read_only="false")
+    with pytest.raises(TypeError, match="require_manual_for_unknown must be a bool"):
+        ApprovalPolicy(require_manual_for_unknown="true")
+
+
+def test_approval_policy_is_frozen() -> None:
+    policy = ApprovalPolicy()
+
+    with pytest.raises(FrozenInstanceError):
+        policy.require_manual_for_unknown = False
+
+
+def test_approval_policy_stores_frozensets() -> None:
+    policy = ApprovalPolicy(allowed_recipients={"python"})
+
+    assert isinstance(policy.allowed_recipients, frozenset)
+    assert isinstance(policy.denied_recipients, frozenset)
+
+
+def test_approval_policy_to_dict_sorts_recipients() -> None:
+    policy = ApprovalPolicy(
+        allowed_recipients={"python", "browser"},
+        denied_recipients={"shell", "bio"},
+        auto_approve_read_only=True,
+        require_manual_for_unknown=False,
+    )
+
+    assert policy.to_dict() == {
+        "allowed_recipients": ["browser", "python"],
+        "denied_recipients": ["bio", "shell"],
+        "auto_approve_read_only": True,
+        "require_manual_for_unknown": False,
+    }
+
+
+def test_approval_policy_from_dict_roundtrip() -> None:
+    policy = ApprovalPolicy(
+        allowed_recipients={"python"},
+        denied_recipients={"browser"},
+        auto_approve_read_only=True,
+        require_manual_for_unknown=False,
+    )
+
+    assert ApprovalPolicy.from_dict(policy.to_dict()) == policy
+
+
+def test_approval_policy_from_dict_rejects_non_dict_payload() -> None:
+    with pytest.raises(TypeError, match="approval policy payload must be a dict"):
+        ApprovalPolicy.from_dict(None)
+
+
+def test_approval_policy_denied_recipient_denies() -> None:
+    policy = ApprovalPolicy(denied_recipients={"browser"})
+
+    decision = policy.evaluate(_approval("browser"))
+
+    assert decision.allowed is False
+    assert decision.reason == "recipient_denied"
+    assert decision.recipient == "browser"
+    assert decision.manual_required is False
+
+
+def test_approval_policy_allowed_recipient_allows() -> None:
+    policy = ApprovalPolicy(allowed_recipients={"python"})
+
+    decision = policy.evaluate(_approval("python"))
+
+    assert decision.allowed is True
+    assert decision.reason == "recipient_allowed"
+    assert decision.recipient == "python"
+    assert decision.manual_required is False
+
+
+def test_approval_policy_unknown_recipient_requires_manual_by_default() -> None:
+    policy = ApprovalPolicy()
+
+    decision = policy.evaluate(_approval("python"))
+
+    assert decision.allowed is False
+    assert decision.reason == "manual_required_for_unknown_recipient"
+    assert decision.recipient == "python"
+    assert decision.manual_required is True
+
+
+def test_approval_policy_unknown_recipient_with_manual_disabled_is_still_denied() -> None:
+    policy = ApprovalPolicy(require_manual_for_unknown=False)
+
+    decision = policy.evaluate(_approval("python"))
+
+    assert decision.allowed is False
+    assert decision.reason == "unknown_recipient_denied"
+    assert decision.recipient == "python"
+    assert decision.manual_required is False
+
+
+def test_approval_policy_auto_approve_read_only_does_not_allow_without_evidence() -> None:
+    policy = ApprovalPolicy(auto_approve_read_only=True)
+
+    decision = policy.evaluate(_approval("python"))
+
+    assert decision.allowed is False
+    assert decision.reason == "manual_required_for_unknown_recipient"
+    assert decision.manual_required is True
+
+
+def test_approval_policy_evaluate_rejects_non_pending_approval() -> None:
+    with pytest.raises(TypeError, match="approval must be a PendingApproval"):
+        ApprovalPolicy().evaluate("bad")
+
+
+def test_approval_policy_types_are_exported_from_public_package() -> None:
+    assert webchat_adapter.ApprovalDecision is ApprovalDecision
+    assert webchat_adapter.ApprovalPolicy is ApprovalPolicy
+    assert "ApprovalDecision" in webchat_adapter.__all__
+    assert "ApprovalPolicy" in webchat_adapter.__all__


### PR DESCRIPTION
## Summary

- Add `ApprovalDecision` for explainable policy outcomes.
- Add immutable `ApprovalPolicy` with allowed/denied recipient gates.
- Normalize recipients into frozen sets.
- Reject unsafe or ambiguous policy configuration.
- Keep the default policy manual-required and non-auto-approving.
- Add deterministic serialization helpers.

## Scope

- No integration with `approve_pending_action()`.
- No integration with `wait_and_approve_pending_actions()`.
- No integration with `send_and_auto_approve()`.
- No approval mutation behavior changes.
- No read-only classifier yet.
- No CLI or README changes.

## Tests

- Cover defaults, recipient normalization, conflicts, policy evaluation, strict decision validation, serialization, immutability, and public exports.

Not run locally from this environment. CI runs `pytest -q` and package build.