### PR TITLE
PR4.4: Normalize approval event stream

### DIFF
--- a/src/webchat_adapter/approval_events.py
+++ b/src/webchat_adapter/approval_events.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .approval_policy import ApprovalDecision
+from .approval_types import ApprovalEvent, ApprovalEventType
+from .types import PendingApproval
+
+
+def make_approval_event(
+    event_type: ApprovalEventType,
+    *,
+    conversation_id: str | None = None,
+    round_index: int | None = None,
+    approval: PendingApproval | None = None,
+    decision: ApprovalDecision | None = None,
+    message_id: str | None = None,
+    error: str | None = None,
+    metadata_preview: dict[str, Any] | None = None,
+) -> ApprovalEvent:
+    """Build a canonical approval event with a stable public payload shape."""
+
+    metadata = dict(metadata_preview or {})
+    if decision is not None:
+        metadata["decision"] = decision.to_dict()
+    if message_id is not None:
+        metadata["message_id"] = message_id
+    if error is not None:
+        metadata["error"] = error
+
+    return ApprovalEvent(
+        type=event_type,
+        conversation_id=conversation_id,
+        round_index=round_index,
+        tool_message_id=approval.tool_message_id if approval is not None else None,
+        target_message_id=approval.target_message_id if approval is not None else None,
+        recipient=approval.recipient if approval is not None else None,
+        allowed=decision.allowed if decision is not None else None,
+        reason=decision.reason if decision is not None else error,
+        metadata_preview=metadata,
+    )
+
+
+def emit_approval_event(
+    emit_event: Callable[..., None],
+    on_event: Callable[[dict[str, Any]], None] | None,
+    event: ApprovalEvent,
+) -> None:
+    """Emit an ApprovalEvent through the existing dict-based on_event callback."""
+
+    payload = event.to_dict()
+    event_type = payload.pop("type")
+    emit_event(on_event, event_type, **payload)

--- a/src/webchat_adapter/policy_approval.py
+++ b/src/webchat_adapter/policy_approval.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from typing import Any, Callable, Sequence
 
+from .approval_events import emit_approval_event, make_approval_event
 from .approval_policy import ApprovalPolicy
 from .exceptions import RequestError
 from .types import ChatConversation, ChatMetrics, ChatResponse, MediaItem, PendingApproval
@@ -47,35 +48,112 @@ def approve_pending_action(original: Callable[..., ChatResponse]) -> Callable[..
         *,
         policy: ApprovalPolicy | None = None,
         on_event: Callable[[dict[str, Any]], None] | None = None,
+        _approval_round_index: int | None = None,
         **kwargs: Any,
     ) -> ChatResponse:
         if policy is None:
             return original(self, conversation, on_event=on_event, **kwargs)
         approval_policy = _resolve_policy(policy)
         original_finder = self._latest_confirm_action_leaf
+        approval_state: dict[str, Any] = {}
+
+        def emit_canonical(event_type: str, **event_kwargs: Any) -> None:
+            event = make_approval_event(
+                event_type,
+                round_index=_approval_round_index,
+                **event_kwargs,
+            )
+            emit_approval_event(self._emit_event, on_event, event)
 
         def guarded_finder(payload: dict[str, Any]) -> tuple[str | None, str | None, str | None]:
             tool_id, target_message_id, recipient = original_finder(payload)
             if not (tool_id and target_message_id and recipient):
                 return tool_id, target_message_id, recipient
+            conversation_id = payload.get("conversation_id")
+            if not isinstance(conversation_id, str):
+                conversation_id = None
             approval = _pending_approval(tool_id, target_message_id, recipient)
             decision = approval_policy.evaluate(approval)
-            event_payload = {
-                "pending_tool_id": tool_id,
-                "target_message_id": target_message_id,
-                "recipient": recipient,
-                "approval": approval.to_dict(),
-                "decision": decision.to_dict(),
-            }
+            approval_state["approval"] = approval
+            approval_state["decision"] = decision
+            approval_state["conversation_id"] = conversation_id
+
+            emit_canonical(
+                "approval_detected",
+                conversation_id=conversation_id,
+                approval=approval,
+            )
             if not decision.allowed:
-                self._emit_event(on_event, "approval_policy_denied", **event_payload)
+                emit_canonical(
+                    "approval_denied",
+                    conversation_id=conversation_id,
+                    approval=approval,
+                    decision=decision,
+                )
                 raise ApprovalDeniedError(approval=approval, decision=decision)
-            self._emit_event(on_event, "approval_policy_allowed", **event_payload)
+            emit_canonical(
+                "approval_allowed",
+                conversation_id=conversation_id,
+                approval=approval,
+                decision=decision,
+            )
             return tool_id, target_message_id, recipient
+
+        def normalized_on_event(event: dict[str, Any]) -> None:
+            if not isinstance(event, dict):
+                if on_event is not None:
+                    on_event(event)
+                return
+            event_type = event.get("type")
+            if event_type in {
+                "pending_approval_detected",
+                "approval_policy_allowed",
+                "approval_policy_denied",
+            }:
+                return
+
+            approval = approval_state.get("approval")
+            conversation_id = event.get("conversation_id")
+            if not isinstance(conversation_id, str):
+                conversation_id = approval_state.get("conversation_id")
+            if event_type == "approval_sent" and isinstance(approval, PendingApproval):
+                emit_canonical(
+                    "approval_sent",
+                    conversation_id=conversation_id,
+                    approval=approval,
+                    metadata_preview={"legacy_event": dict(event)},
+                )
+                return
+            if event_type == "approval_completed" and isinstance(approval, PendingApproval):
+                message_id = event.get("message_id")
+                if not isinstance(message_id, str):
+                    message_id = None
+                emit_canonical(
+                    "approval_completed",
+                    conversation_id=conversation_id,
+                    approval=approval,
+                    message_id=message_id,
+                    metadata_preview={"legacy_event": dict(event)},
+                )
+                return
+            if on_event is not None:
+                on_event(event)
 
         self._latest_confirm_action_leaf = guarded_finder
         try:
-            return original(self, conversation, on_event=on_event, **kwargs)
+            return original(self, conversation, on_event=normalized_on_event, **kwargs)
+        except ApprovalDeniedError:
+            raise
+        except Exception as error:
+            approval = approval_state.get("approval")
+            if isinstance(approval, PendingApproval):
+                emit_canonical(
+                    "approval_failed",
+                    conversation_id=approval_state.get("conversation_id"),
+                    approval=approval,
+                    error=str(error),
+                )
+            raise
         finally:
             self._latest_confirm_action_leaf = original_finder
 
@@ -140,6 +218,7 @@ def wait_and_approve_pending_actions(
                 policy=approval_policy,
                 on_token=on_token,
                 on_event=on_event,
+                _approval_round_index=round_index,
             )
             conversation_dict = last_response.conversation.to_dict()
             conversation_id = str(last_response.conversation.conversation_id or conversation_id)

--- a/tests/test_policy_aware_approval.py
+++ b/tests/test_policy_aware_approval.py
@@ -14,6 +14,7 @@ from webchat_adapter import (
     ChatMetrics,
     ChatResponse,
 )
+from webchat_adapter.approval_types import APPROVAL_EVENT_TYPES
 
 
 def _confirm_action_payload(*, recipient: str = "python") -> dict[str, Any]:
@@ -85,6 +86,10 @@ def _client_with_pending_payload(payload: dict[str, Any]) -> ChatGPTWebClient:
     return client
 
 
+def _canonical_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [event for event in events if event.get("type") in APPROVAL_EVENT_TYPES]
+
+
 def test_approval_denied_error_is_exported() -> None:
     assert webchat_adapter.ApprovalDeniedError is ApprovalDeniedError
     assert "ApprovalDeniedError" in webchat_adapter.__all__
@@ -111,8 +116,13 @@ def test_wait_and_approve_pending_actions_default_policy_blocks_before_prepare_o
     assert exc_info.value.decision.reason == "manual_required_for_unknown_recipient"
     assert [event["type"] for event in events] == [
         "approval_round_started",
-        "approval_policy_denied",
+        "approval_detected",
+        "approval_denied",
     ]
+    denied_event = events[-1]
+    assert denied_event["recipient"] == "python"
+    assert denied_event["allowed"] is False
+    assert denied_event["reason"] == "manual_required_for_unknown_recipient"
 
 
 def test_approve_pending_action_allowed_policy_reaches_existing_send_flow() -> None:
@@ -140,14 +150,23 @@ def test_approve_pending_action_allowed_policy_reaches_existing_send_flow() -> N
 
     assert calls == ["prepare", "stream"]
     assert response.text == "Approved"
-    event_types = [event["type"] for event in events]
-    assert "approval_policy_allowed" in event_types
-    assert "approval_sent" in event_types
-    assert events[0]["decision"]["allowed"] is True
+    canonical_types = [event["type"] for event in _canonical_events(events)]
+    assert canonical_types == [
+        "approval_detected",
+        "approval_allowed",
+        "approval_sent",
+        "approval_completed",
+    ]
+    assert "approval_policy_allowed" not in [event["type"] for event in events]
+    assert "pending_approval_detected" not in [event["type"] for event in events]
+    allowed_event = _canonical_events(events)[1]
+    assert allowed_event["allowed"] is True
+    assert allowed_event["reason"] == "recipient_allowed"
 
 
 def test_approve_pending_action_denied_policy_blocks_before_prepare_or_stream() -> None:
     client = _client_with_pending_payload(_confirm_action_payload(recipient="browser"))
+    events: list[dict[str, Any]] = []
     client._json_request = lambda *_args, **_kwargs: pytest.fail("prepare must not run")
     client._stream_backend_payload = lambda *_args, **_kwargs: pytest.fail("stream must not run")
 
@@ -155,10 +174,12 @@ def test_approve_pending_action_denied_policy_blocks_before_prepare_or_stream() 
         client.approve_pending_action(
             ChatConversation(conversation_id="conversation-1"),
             policy=ApprovalPolicy(denied_recipients={"browser"}),
+            on_event=events.append,
         )
 
     assert exc_info.value.decision.reason == "recipient_denied"
     assert exc_info.value.decision.manual_required is False
+    assert [event["type"] for event in events] == ["approval_detected", "approval_denied"]
 
 
 def test_approve_pending_action_unknown_manual_disabled_still_blocks_when_policy_is_explicit() -> None:
@@ -268,3 +289,66 @@ def test_send_and_auto_approve_passes_policy_to_wait_helper() -> None:
 
     assert captured == [policy]
     assert response.text == "waited"
+
+
+def test_policy_aware_approval_failed_event_on_prepare_failure() -> None:
+    client = _client_with_pending_payload(_confirm_action_payload(recipient="python"))
+    events: list[dict[str, Any]] = []
+    client._json_request = lambda *_args, **_kwargs: (500, {"error": "prepare failed"})
+    client._stream_backend_payload = lambda *_args, **_kwargs: pytest.fail("stream must not run")
+
+    with pytest.raises(Exception):
+        client.approve_pending_action(
+            ChatConversation(conversation_id="conversation-1"),
+            policy=ApprovalPolicy(allowed_recipients={"python"}),
+            on_event=events.append,
+        )
+
+    canonical_types = [event["type"] for event in _canonical_events(events)]
+    assert canonical_types == [
+        "approval_detected",
+        "approval_allowed",
+        "approval_failed",
+    ]
+    failed_event = _canonical_events(events)[-1]
+    assert failed_event["allowed"] is None
+    assert "prepare" in failed_event["reason"]
+
+
+def test_canonical_approval_events_have_stable_shape() -> None:
+    client = _client_with_pending_payload(_confirm_action_payload(recipient="python"))
+    events: list[dict[str, Any]] = []
+
+    def fake_json_request(*_args: Any, **_kwargs: Any) -> tuple[int, dict[str, str]]:
+        return 200, {"status": "ok", "conduit_token": "conduit-token"}
+
+    def fake_stream(*_args: Any, **_kwargs: Any) -> tuple[str, str, str]:
+        return "conversation-1", "message-1", "Approved"
+
+    client._json_request = fake_json_request
+    client._stream_backend_payload = fake_stream
+
+    client.approve_pending_action(
+        ChatConversation(conversation_id="conversation-1"),
+        poll=False,
+        policy=ApprovalPolicy(allowed_recipients={"python"}),
+        on_event=events.append,
+    )
+
+    expected_keys = {
+        "type",
+        "conversation_id",
+        "round_index",
+        "tool_message_id",
+        "target_message_id",
+        "recipient",
+        "allowed",
+        "reason",
+        "metadata_preview",
+    }
+    for event in _canonical_events(events):
+        assert set(event) == expected_keys
+        assert event["conversation_id"] == "conversation-1"
+        assert event["tool_message_id"] == "tool-msg"
+        assert event["target_message_id"] == "target-node"
+        assert event["recipient"] == "python"


### PR DESCRIPTION
## Summary

- Add canonical approval event helpers built on `ApprovalEvent`.
- Normalize policy-aware approval event names to:
  - `approval_detected`
  - `approval_allowed`
  - `approval_denied`
  - `approval_sent`
  - `approval_completed`
  - `approval_failed`
- Emit canonical approval events from policy-aware approval paths.
- Normalize `approval_sent` and `approval_completed` payloads from existing helper events.
- Add `approval_failed` emission for policy-allowed approval flow failures.

## Scope

- No approval policy behavior changes.
- No read-only classifier.
- No `ApprovalResult` return-type integration yet.
- No CLI or README changes.
- No unsafe allow-all API.
- Direct manual `approve_pending_action(..., policy=None)` compatibility is preserved.

## Tests

- Cover canonical allowed, denied, sent, completed, and failed event sequences.
- Cover stable canonical event payload shape.
- Cover absence of legacy policy event names in policy-aware paths.
- Preserve existing policy propagation and default-deny coverage.

Not run locally from this environment. CI runs `pytest -q` and package build.