### PR TITLE
PR5.1: Add experimental payload builder

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -15,6 +15,7 @@ from .exceptions import (
 )
 from .export import export_conversation as _export_conversation
 from .messages import get_messages as _get_messages
+from .payload_builder import PayloadBuilder
 from .policy_approval import ApprovalDeniedError
 from .policy_approval import approve_pending_action as _policy_approve_pending_action
 from .policy_approval import send_and_auto_approve as _policy_send_and_auto_approve
@@ -79,6 +80,7 @@ __all__ = [
     "MediaError",
     "MediaItem",
     "MediaSource",
+    "PayloadBuilder",
     "PendingApproval",
     "RequestError",
     "WaitResult",

--- a/src/webchat_adapter/payload_builder.py
+++ b/src/webchat_adapter/payload_builder.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import copy
+import time
+import uuid
+from typing import Any
+
+from .client import DEFAULT_MODEL, MODEL_ALIASES
+from .types import ChatConversation
+
+
+def _optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _required_str(value: Any, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    value = value.strip()
+    if not value:
+        raise ValueError(f"{field_name} must not be empty")
+    return value
+
+
+def _normalize_model(model: str) -> str:
+    model_name = _required_str(model, "model")
+    return MODEL_ALIASES.get(model_name, model_name)
+
+
+def _normalize_reasoning_effort(reasoning_effort: str | None) -> str | None:
+    normalized = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
+    if normalized in {"", "off", "none", "-"}:
+        normalized = None
+    if normalized not in {None, "standard", "extended"}:
+        raise ValueError("reasoning_effort must be one of: standard, extended, off/none/-")
+    return normalized
+
+
+def _message_metadata(metadata: dict[str, Any] | None, *, system_hints: list[str] | None = None) -> dict[str, Any]:
+    if metadata is not None and not isinstance(metadata, dict):
+        raise TypeError("metadata must be a dict or None")
+
+    result: dict[str, Any] = {
+        "serialization_metadata": {"custom_symbol_offsets": []},
+    }
+    if metadata:
+        copied = copy.deepcopy(metadata)
+        serialization_metadata = copied.pop("serialization_metadata", None)
+        result.update(copied)
+        if serialization_metadata is not None:
+            if not isinstance(serialization_metadata, dict):
+                raise TypeError("metadata.serialization_metadata must be a dict")
+            result["serialization_metadata"].update(copy.deepcopy(serialization_metadata))
+    if system_hints:
+        result["system_hints"] = list(system_hints)
+    return result
+
+
+def _conversation_to_dict(
+    conversation: ChatConversation | dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if isinstance(conversation, ChatConversation):
+        return conversation.to_dict()
+    if isinstance(conversation, dict):
+        return copy.deepcopy(conversation)
+    return None
+
+
+def _base_payload(
+    *,
+    prompt: str,
+    model: str,
+    parent_message_id: str,
+    system: str | None = None,
+    web_search: bool = False,
+    temporary: bool = False,
+    reasoning_effort: str | None = None,
+    conversation_id: str | None = None,
+) -> dict[str, Any]:
+    normalized_effort = _normalize_reasoning_effort(reasoning_effort)
+    system_hints = ["search"] if web_search else None
+    messages: list[dict[str, Any]] = []
+    if system is not None and system.strip():
+        messages.append(PayloadBuilder.text_message(system.strip(), role="system"))
+    messages.append(
+        PayloadBuilder.text_message(
+            prompt,
+            role="user",
+            metadata={"system_hints": system_hints} if system_hints else None,
+        )
+    )
+
+    payload: dict[str, Any] = {
+        "action": "next",
+        "parent_message_id": parent_message_id,
+        "model": _normalize_model(model),
+        "conversation_mode": {"kind": "primary_assistant"},
+        "enable_message_followups": False,
+        "supports_buffering": True,
+        "supported_encodings": ["v1"],
+        "messages": messages,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    if temporary:
+        payload["history_and_training_disabled"] = True
+    if system_hints:
+        payload["system_hints"] = system_hints
+    if normalized_effort is not None:
+        payload["thinking_effort"] = normalized_effort
+    return payload
+
+
+class PayloadBuilder:
+    """Experimental helpers for constructing ChatGPT web backend payload dicts."""
+
+    @staticmethod
+    def text_message(
+        text: Any,
+        *,
+        role: str = "user",
+        message_id: str | None = None,
+        create_time: float | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        role_name = _required_str(role, "role")
+        message_id_value = _optional_str(message_id) or str(uuid.uuid4())
+        create_time_value = float(time.time() if create_time is None else create_time)
+        return {
+            "id": message_id_value,
+            "author": {"role": role_name},
+            "content": {
+                "content_type": "text",
+                "parts": ["" if text is None else str(text)],
+            },
+            "metadata": _message_metadata(metadata),
+            "create_time": create_time_value,
+        }
+
+    @staticmethod
+    def new_chat(
+        prompt: Any,
+        *,
+        model: str = DEFAULT_MODEL,
+        system: str | None = None,
+        web_search: bool = False,
+        temporary: bool = False,
+        reasoning_effort: str | None = None,
+        parent_message_id: str | None = None,
+    ) -> dict[str, Any]:
+        parent = _optional_str(parent_message_id) or str(uuid.uuid4())
+        return _base_payload(
+            prompt="" if prompt is None else str(prompt),
+            model=model,
+            parent_message_id=parent,
+            system=system,
+            web_search=web_search,
+            temporary=temporary,
+            reasoning_effort=reasoning_effort,
+        )
+
+    @staticmethod
+    def continue_chat(
+        prompt: Any,
+        *,
+        conversation: ChatConversation | dict[str, Any] | None = None,
+        conversation_id: str | None = None,
+        parent_message_id: str | None = None,
+        model: str = DEFAULT_MODEL,
+        web_search: bool = False,
+        reasoning_effort: str | None = None,
+    ) -> dict[str, Any]:
+        conversation_dict = _conversation_to_dict(conversation)
+        resolved_conversation_id = _optional_str(conversation_id)
+        resolved_parent_message_id = _optional_str(parent_message_id)
+        if isinstance(conversation_dict, dict):
+            resolved_conversation_id = resolved_conversation_id or _optional_str(
+                conversation_dict.get("conversation_id")
+            )
+            resolved_parent_message_id = (
+                resolved_parent_message_id
+                or _optional_str(conversation_dict.get("parent_message_id"))
+                or _optional_str(conversation_dict.get("message_id"))
+            )
+
+        if not resolved_conversation_id:
+            raise ValueError("conversation_id is required")
+        if not resolved_parent_message_id:
+            raise ValueError("parent_message_id is required")
+
+        return _base_payload(
+            prompt="" if prompt is None else str(prompt),
+            model=model,
+            parent_message_id=resolved_parent_message_id,
+            web_search=web_search,
+            reasoning_effort=reasoning_effort,
+            conversation_id=resolved_conversation_id,
+        )

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import pytest
+
+import webchat_adapter
+from webchat_adapter import ChatConversation, PayloadBuilder
+
+
+def test_text_message_builds_web_text_message_shape() -> None:
+    message = PayloadBuilder.text_message(
+        "hello",
+        message_id="msg-1",
+        create_time=123.0,
+    )
+
+    assert message == {
+        "id": "msg-1",
+        "author": {"role": "user"},
+        "content": {"content_type": "text", "parts": ["hello"]},
+        "metadata": {
+            "serialization_metadata": {"custom_symbol_offsets": []},
+        },
+        "create_time": 123.0,
+    }
+
+
+def test_text_message_uses_explicit_role_message_id_and_create_time() -> None:
+    message = PayloadBuilder.text_message(
+        "system prompt",
+        role="system",
+        message_id="system-msg",
+        create_time=42,
+    )
+
+    assert message["author"] == {"role": "system"}
+    assert message["id"] == "system-msg"
+    assert message["create_time"] == 42.0
+
+
+def test_text_message_generates_message_id_and_create_time() -> None:
+    message = PayloadBuilder.text_message("hello")
+
+    assert isinstance(message["id"], str)
+    assert message["id"]
+    assert isinstance(message["create_time"], float)
+
+
+def test_text_message_rejects_empty_role() -> None:
+    with pytest.raises(ValueError, match="role must not be empty"):
+        PayloadBuilder.text_message("hello", role="  ")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, ""),
+        (123, "123"),
+        ("hello", "hello"),
+    ],
+)
+def test_text_message_converts_text_to_string(value: object, expected: str) -> None:
+    message = PayloadBuilder.text_message(value)
+
+    assert message["content"]["parts"] == [expected]
+
+
+def test_text_message_deep_copies_metadata() -> None:
+    metadata = {"nested": {"value": 1}}
+    message = PayloadBuilder.text_message("hello", metadata=metadata)
+
+    metadata["nested"]["value"] = 2
+
+    assert message["metadata"]["nested"] == {"value": 1}
+
+
+def test_text_message_preserves_serialization_metadata_default() -> None:
+    message = PayloadBuilder.text_message("hello", metadata={"foo": "bar"})
+
+    assert message["metadata"] == {
+        "serialization_metadata": {"custom_symbol_offsets": []},
+        "foo": "bar",
+    }
+
+
+def test_text_message_merges_serialization_metadata() -> None:
+    message = PayloadBuilder.text_message(
+        "hello",
+        metadata={"serialization_metadata": {"extra": True}},
+    )
+
+    assert message["metadata"] == {
+        "serialization_metadata": {
+            "custom_symbol_offsets": [],
+            "extra": True,
+        },
+    }
+
+
+def test_text_message_rejects_invalid_metadata() -> None:
+    with pytest.raises(TypeError, match="metadata must be a dict or None"):
+        PayloadBuilder.text_message("hello", metadata="bad")
+    with pytest.raises(TypeError, match="metadata.serialization_metadata must be a dict"):
+        PayloadBuilder.text_message(
+            "hello",
+            metadata={"serialization_metadata": "bad"},
+        )
+
+
+def test_new_chat_builds_minimal_payload() -> None:
+    payload = PayloadBuilder.new_chat(
+        "hello",
+        model="gpt-4o-mini",
+        parent_message_id="parent-1",
+    )
+
+    assert payload["action"] == "next"
+    assert payload["parent_message_id"] == "parent-1"
+    assert payload["model"] == "gpt-4o-mini"
+    assert payload["conversation_mode"] == {"kind": "primary_assistant"}
+    assert payload["enable_message_followups"] is False
+    assert payload["supports_buffering"] is True
+    assert payload["supported_encodings"] == ["v1"]
+    assert "conversation_id" not in payload
+    assert len(payload["messages"]) == 1
+    assert payload["messages"][0]["author"] == {"role": "user"}
+    assert payload["messages"][0]["content"]["parts"] == ["hello"]
+
+
+def test_new_chat_generates_parent_message_id() -> None:
+    payload = PayloadBuilder.new_chat("hello")
+
+    assert isinstance(payload["parent_message_id"], str)
+    assert payload["parent_message_id"]
+
+
+def test_new_chat_adds_system_message_before_user_message() -> None:
+    payload = PayloadBuilder.new_chat(
+        "hello",
+        system="You are concise",
+        parent_message_id="parent-1",
+    )
+
+    assert [message["author"]["role"] for message in payload["messages"]] == [
+        "system",
+        "user",
+    ]
+    assert payload["messages"][0]["content"]["parts"] == ["You are concise"]
+    assert payload["messages"][1]["content"]["parts"] == ["hello"]
+
+
+def test_new_chat_web_search_adds_system_hints() -> None:
+    payload = PayloadBuilder.new_chat(
+        "search",
+        web_search=True,
+        parent_message_id="parent-1",
+    )
+
+    assert payload["system_hints"] == ["search"]
+    assert payload["messages"][-1]["metadata"]["system_hints"] == ["search"]
+
+
+def test_new_chat_temporary_sets_history_disabled() -> None:
+    payload = PayloadBuilder.new_chat(
+        "private",
+        temporary=True,
+        parent_message_id="parent-1",
+    )
+
+    assert payload["history_and_training_disabled"] is True
+
+
+@pytest.mark.parametrize("reasoning_effort", ["standard", "extended"])
+def test_new_chat_reasoning_effort(reasoning_effort: str) -> None:
+    payload = PayloadBuilder.new_chat(
+        "think",
+        reasoning_effort=reasoning_effort,
+        parent_message_id="parent-1",
+    )
+
+    assert payload["thinking_effort"] == reasoning_effort
+
+
+@pytest.mark.parametrize("reasoning_effort", [None, "", "off", "none", "-"])
+def test_new_chat_reasoning_effort_off_omits_field(reasoning_effort: str | None) -> None:
+    payload = PayloadBuilder.new_chat(
+        "think",
+        reasoning_effort=reasoning_effort,
+        parent_message_id="parent-1",
+    )
+
+    assert "thinking_effort" not in payload
+
+
+def test_new_chat_invalid_reasoning_effort_raises() -> None:
+    with pytest.raises(ValueError, match="reasoning_effort must be one of"):
+        PayloadBuilder.new_chat("hello", reasoning_effort="maximum")
+
+
+def test_new_chat_rejects_invalid_model() -> None:
+    with pytest.raises(ValueError, match="model must not be empty"):
+        PayloadBuilder.new_chat("hello", model=" ")
+
+
+def test_continue_chat_builds_payload_from_chat_conversation() -> None:
+    conversation = ChatConversation(
+        conversation_id="conv-1",
+        message_id="msg-1",
+    )
+
+    payload = PayloadBuilder.continue_chat(
+        "continue",
+        conversation=conversation,
+    )
+
+    assert payload["conversation_id"] == "conv-1"
+    assert payload["parent_message_id"] == "msg-1"
+    assert len(payload["messages"]) == 1
+    assert payload["messages"][0]["content"]["parts"] == ["continue"]
+
+
+def test_continue_chat_builds_payload_from_dict_conversation() -> None:
+    payload = PayloadBuilder.continue_chat(
+        "continue",
+        conversation={"conversation_id": "conv-1", "message_id": "msg-1"},
+    )
+
+    assert payload["conversation_id"] == "conv-1"
+    assert payload["parent_message_id"] == "msg-1"
+
+
+def test_continue_chat_explicit_conversation_id_wins() -> None:
+    payload = PayloadBuilder.continue_chat(
+        "continue",
+        conversation={"conversation_id": "old", "message_id": "msg-1"},
+        conversation_id="new",
+    )
+
+    assert payload["conversation_id"] == "new"
+
+
+def test_continue_chat_explicit_parent_message_id_wins() -> None:
+    payload = PayloadBuilder.continue_chat(
+        "continue",
+        conversation={"conversation_id": "conv-1", "parent_message_id": "old", "message_id": "msg"},
+        parent_message_id="explicit-parent",
+    )
+
+    assert payload["parent_message_id"] == "explicit-parent"
+
+
+def test_continue_chat_uses_parent_message_id_before_message_id() -> None:
+    payload = PayloadBuilder.continue_chat(
+        "continue",
+        conversation={
+            "conversation_id": "conv-1",
+            "parent_message_id": "parent-msg",
+            "message_id": "msg",
+        },
+    )
+
+    assert payload["parent_message_id"] == "parent-msg"
+
+
+def test_continue_chat_requires_conversation_id() -> None:
+    with pytest.raises(ValueError, match="conversation_id is required"):
+        PayloadBuilder.continue_chat(
+            "continue",
+            conversation={"message_id": "msg-1"},
+        )
+
+
+def test_continue_chat_requires_parent_message_id() -> None:
+    with pytest.raises(ValueError, match="parent_message_id is required"):
+        PayloadBuilder.continue_chat(
+            "continue",
+            conversation={"conversation_id": "conv-1"},
+        )
+
+
+def test_continue_chat_does_not_include_system_message() -> None:
+    payload = PayloadBuilder.continue_chat(
+        "continue",
+        conversation={"conversation_id": "conv-1", "message_id": "msg-1"},
+    )
+
+    assert [message["author"]["role"] for message in payload["messages"]] == ["user"]
+
+
+def test_continue_chat_web_search_adds_system_hints() -> None:
+    payload = PayloadBuilder.continue_chat(
+        "search",
+        conversation={"conversation_id": "conv-1", "message_id": "msg-1"},
+        web_search=True,
+    )
+
+    assert payload["system_hints"] == ["search"]
+    assert payload["messages"][0]["metadata"]["system_hints"] == ["search"]
+
+
+def test_continue_chat_does_not_mutate_input_conversation() -> None:
+    conversation = {"conversation_id": "conv-1", "message_id": "msg-1"}
+
+    PayloadBuilder.continue_chat("continue", conversation=conversation)
+
+    assert conversation == {"conversation_id": "conv-1", "message_id": "msg-1"}
+
+
+def test_payload_builder_is_exported_from_public_package() -> None:
+    assert webchat_adapter.PayloadBuilder is PayloadBuilder
+    assert "PayloadBuilder" in webchat_adapter.__all__


### PR DESCRIPTION
## Summary

- Add `PayloadBuilder` for constructing experimental ChatGPT web payload dicts.
- Add `text_message()`, `new_chat()`, and `continue_chat()` helpers.
- Mirror the current high-level `send()` payload defaults where appropriate.
- Normalize model aliases and reasoning effort.
- Export `PayloadBuilder` from the public package.

## Scope

- No `send_payload()` yet.
- No network behavior changes.
- No raw payload validation framework yet.
- No media payload builder.
- No docs yet.
- No changes to `send()`.

## Tests

- Cover text message shape, new-chat payloads, continue-chat payloads, metadata copying, model/reasoning normalization, error cases, and public exports.

Not run locally from this environment. CI runs `pytest -q` and package build.