### PR TITLE
PR5.2: Add experimental send_payload

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -20,6 +20,7 @@ from .policy_approval import ApprovalDeniedError
 from .policy_approval import approve_pending_action as _policy_approve_pending_action
 from .policy_approval import send_and_auto_approve as _policy_send_and_auto_approve
 from .policy_approval import wait_and_approve_pending_actions as _policy_wait_and_approve_pending_actions
+from .raw_payload import send_payload as _send_payload
 from .status import get_pending_approval as _get_pending_approval
 from .status import get_status as _get_status
 from .types import (
@@ -52,6 +53,7 @@ ChatGPTWebClient.get_status = _get_status
 ChatGPTWebClient.send_and_auto_approve = _policy_send_and_auto_approve(
     _original_send_and_auto_approve
 )
+ChatGPTWebClient.send_payload = _send_payload
 ChatGPTWebClient.send_to_conversation = _send_to_conversation
 ChatGPTWebClient.wait_and_approve_pending_actions = _policy_wait_and_approve_pending_actions
 ChatGPTWebClient.wait_until_completed = _wait_until_completed

--- a/src/webchat_adapter/raw_payload.py
+++ b/src/webchat_adapter/raw_payload.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import copy
+import time
+from typing import Any, Callable
+
+from .types import ChatConversation, ChatMetrics, ChatResponse
+
+
+def send_payload(
+    self: Any,
+    payload: dict[str, Any],
+    *,
+    on_token: Callable[[str], None] | None = None,
+    on_event: Callable[[dict[str, Any]], None] | None = None,
+) -> ChatResponse:
+    """Send a raw ChatGPT web backend payload.
+
+    Experimental. This is not an official or stable API. The ChatGPT web
+    backend may change at any time. The payload creates real ChatGPT web
+    conversations and messages. Use at your own risk.
+    """
+
+    if not isinstance(payload, dict):
+        raise TypeError("payload must be a dict")
+
+    payload_copy = copy.deepcopy(payload)
+    requirements, proof_header = self._get_ready_requirements()
+    chat_token = requirements.get("token") if isinstance(requirements, dict) else None
+    if not isinstance(chat_token, str) or not chat_token:
+        from .exceptions import RequestError
+
+        raise RequestError("chat-requirements token is missing")
+
+    headers = self._build_headers(
+        {
+            "accept": "text/event-stream",
+            "content-type": "application/json",
+            "openai-sentinel-chat-requirements-token": chat_token,
+            "openai-sentinel-proof-token": proof_header,
+            "openai-sentinel-turnstile-token": self.auth.turnstile_token
+            if (requirements.get("turnstile") or {}).get("required")
+            else None,
+        }
+    )
+
+    started_at = time.perf_counter()
+    observed_conversation_id, observed_message_id, text = self._stream_backend_payload(
+        payload_copy,
+        headers,
+        on_token=on_token,
+        on_event=on_event,
+    )
+    total_latency = time.perf_counter() - started_at
+
+    fallback_conversation_id = payload_copy.get("conversation_id")
+    if not isinstance(fallback_conversation_id, str) or not fallback_conversation_id:
+        fallback_conversation_id = None
+    fallback_message_id = payload_copy.get("parent_message_id")
+    if not isinstance(fallback_message_id, str) or not fallback_message_id:
+        fallback_message_id = None
+
+    conversation_id = observed_conversation_id or fallback_conversation_id
+    message_id = observed_message_id or fallback_message_id
+    response = ChatResponse(
+        text=text,
+        conversation=ChatConversation(
+            conversation_id=conversation_id,
+            message_id=message_id,
+            parent_message_id=message_id,
+            finish_reason="stop",
+            is_thinking=False,
+        ),
+        metrics=ChatMetrics(total=total_latency),
+    )
+
+    messages = payload_copy.get("messages")
+    self._emit_event(
+        on_event,
+        "raw_payload_sent",
+        experimental=True,
+        conversation_id=response.conversation.conversation_id,
+        message_id=response.conversation.message_id,
+        message_count=len(messages) if isinstance(messages, list) else None,
+    )
+    return response

--- a/tests/test_send_payload.py
+++ b/tests/test_send_payload.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from webchat_adapter import ChatGPTWebClient, ChatResponse, RequestError
+
+
+def _client() -> ChatGPTWebClient:
+    client = object.__new__(ChatGPTWebClient)
+    client.auth = SimpleNamespace(turnstile_token="turnstile-token")
+    return client
+
+
+def _install_requirements(
+    client: ChatGPTWebClient,
+    *,
+    token: str = "requirements-token",
+    proof: str = "proof-token",
+    turnstile_required: bool = False,
+) -> list[dict[str, Any]]:
+    header_inputs: list[dict[str, Any]] = []
+    client._get_ready_requirements = lambda: (
+        {"token": token, "turnstile": {"required": turnstile_required}},
+        proof,
+    )
+
+    def build_headers(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+        payload = dict(extra or {})
+        header_inputs.append(payload)
+        return payload
+
+    client._build_headers = build_headers
+    return header_inputs
+
+
+def test_send_payload_method_is_available_on_client() -> None:
+    assert hasattr(ChatGPTWebClient, "send_payload")
+
+
+def test_send_payload_rejects_non_dict_payload_before_network() -> None:
+    client = _client()
+    client._get_ready_requirements = lambda: pytest.fail("requirements must not be fetched")
+
+    with pytest.raises(TypeError, match="payload must be a dict"):
+        client.send_payload("bad")
+
+
+def test_send_payload_deep_copies_payload_before_transport() -> None:
+    client = _client()
+    _install_requirements(client)
+    payload = {"messages": [{"content": {"parts": ["hello"]}}]}
+    original = copy.deepcopy(payload)
+    observed_payloads: list[dict[str, Any]] = []
+
+    def fake_stream(
+        stream_payload: dict[str, Any],
+        _headers: dict[str, Any],
+        **_kwargs: Any,
+    ) -> tuple[str, str, str]:
+        observed_payloads.append(stream_payload)
+        stream_payload["messages"][0]["content"]["parts"][0] = "mutated"
+        return "conv-1", "msg-1", "ok"
+
+    client._stream_backend_payload = fake_stream
+
+    client.send_payload(payload)
+
+    assert payload == original
+    assert observed_payloads[0] is not payload
+
+
+def test_send_payload_gets_requirements_and_builds_stream_headers() -> None:
+    client = _client()
+    header_inputs = _install_requirements(
+        client,
+        token="requirements-token",
+        proof="proof-token",
+        turnstile_required=True,
+    )
+    client._stream_backend_payload = lambda *_args, **_kwargs: ("conv-1", "msg-1", "ok")
+
+    client.send_payload({"messages": []})
+
+    assert header_inputs == [
+        {
+            "accept": "text/event-stream",
+            "content-type": "application/json",
+            "openai-sentinel-chat-requirements-token": "requirements-token",
+            "openai-sentinel-proof-token": "proof-token",
+            "openai-sentinel-turnstile-token": "turnstile-token",
+        }
+    ]
+
+
+def test_send_payload_omits_turnstile_header_when_not_required() -> None:
+    client = _client()
+    header_inputs = _install_requirements(client, turnstile_required=False)
+    client._stream_backend_payload = lambda *_args, **_kwargs: ("conv-1", "msg-1", "ok")
+
+    client.send_payload({"messages": []})
+
+    assert header_inputs[0]["openai-sentinel-turnstile-token"] is None
+
+
+def test_send_payload_requires_chat_requirements_token() -> None:
+    client = _client()
+    client._get_ready_requirements = lambda: ({"token": ""}, "proof-token")
+    client._build_headers = lambda extra=None: dict(extra or {})
+    client._stream_backend_payload = lambda *_args, **_kwargs: pytest.fail("stream must not run")
+
+    with pytest.raises(RequestError, match="chat-requirements token is missing"):
+        client.send_payload({"messages": []})
+
+
+def test_send_payload_calls_stream_backend_with_payload_headers_and_callbacks() -> None:
+    client = _client()
+    _install_requirements(client)
+    tokens: list[str] = []
+    events: list[dict[str, Any]] = []
+    payload = {"messages": [{"id": "msg"}]}
+    observed: dict[str, Any] = {}
+
+    def fake_stream(
+        stream_payload: dict[str, Any],
+        headers: dict[str, Any],
+        *,
+        on_token: Any = None,
+        on_event: Any = None,
+    ) -> tuple[str, str, str]:
+        observed["payload"] = stream_payload
+        observed["headers"] = headers
+        observed["on_token"] = on_token
+        observed["on_event"] = on_event
+        return "conv-1", "msg-1", "hello"
+
+    client._stream_backend_payload = fake_stream
+
+    response = client.send_payload(payload, on_token=tokens.append, on_event=events.append)
+
+    assert observed["payload"] == payload
+    assert observed["payload"] is not payload
+    assert observed["headers"]["openai-sentinel-chat-requirements-token"] == "requirements-token"
+    assert observed["on_token"] is tokens.append
+    assert observed["on_event"] is events.append
+    assert response.text == "hello"
+
+
+def test_send_payload_returns_chat_response() -> None:
+    client = _client()
+    _install_requirements(client)
+    client._stream_backend_payload = lambda *_args, **_kwargs: ("conv-1", "msg-1", "hello")
+
+    response = client.send_payload({"messages": []})
+
+    assert isinstance(response, ChatResponse)
+    assert response.text == "hello"
+    assert response.conversation.conversation_id == "conv-1"
+    assert response.conversation.message_id == "msg-1"
+    assert response.conversation.parent_message_id == "msg-1"
+    assert response.conversation.finish_reason == "stop"
+    assert response.conversation.is_thinking is False
+    assert response.metrics.total is not None
+
+
+def test_send_payload_uses_payload_id_fallbacks_when_stream_returns_none() -> None:
+    client = _client()
+    _install_requirements(client)
+    client._stream_backend_payload = lambda *_args, **_kwargs: (None, None, "hello")
+
+    response = client.send_payload(
+        {
+            "conversation_id": "conv-existing",
+            "parent_message_id": "parent-1",
+            "messages": [],
+        }
+    )
+
+    assert response.conversation.conversation_id == "conv-existing"
+    assert response.conversation.message_id == "parent-1"
+    assert response.conversation.parent_message_id == "parent-1"
+
+
+def test_send_payload_emits_raw_payload_sent_on_success() -> None:
+    client = _client()
+    _install_requirements(client)
+    events: list[dict[str, Any]] = []
+    client._stream_backend_payload = lambda *_args, **_kwargs: ("conv-1", "msg-1", "hello")
+
+    client.send_payload({"messages": [{"id": "m1"}]}, on_event=events.append)
+
+    assert events[-1] == {
+        "type": "raw_payload_sent",
+        "experimental": True,
+        "conversation_id": "conv-1",
+        "message_id": "msg-1",
+        "message_count": 1,
+    }
+
+
+def test_send_payload_does_not_emit_success_event_on_stream_error() -> None:
+    client = _client()
+    _install_requirements(client)
+    events: list[dict[str, Any]] = []
+
+    def fake_stream(*_args: Any, **_kwargs: Any) -> tuple[str, str, str]:
+        raise RequestError("backend failed")
+
+    client._stream_backend_payload = fake_stream
+
+    with pytest.raises(RequestError, match="backend failed"):
+        client.send_payload({"messages": []}, on_event=events.append)
+
+    assert events == []

--- a/tests/test_send_payload.py
+++ b/tests/test_send_payload.py
@@ -121,6 +121,8 @@ def test_send_payload_calls_stream_backend_with_payload_headers_and_callbacks() 
     _install_requirements(client)
     tokens: list[str] = []
     events: list[dict[str, Any]] = []
+    on_token = tokens.append
+    on_event = events.append
     payload = {"messages": [{"id": "msg"}]}
     observed: dict[str, Any] = {}
 
@@ -139,13 +141,13 @@ def test_send_payload_calls_stream_backend_with_payload_headers_and_callbacks() 
 
     client._stream_backend_payload = fake_stream
 
-    response = client.send_payload(payload, on_token=tokens.append, on_event=events.append)
+    response = client.send_payload(payload, on_token=on_token, on_event=on_event)
 
     assert observed["payload"] == payload
     assert observed["payload"] is not payload
     assert observed["headers"]["openai-sentinel-chat-requirements-token"] == "requirements-token"
-    assert observed["on_token"] is tokens.append
-    assert observed["on_event"] is events.append
+    assert observed["on_token"] is on_token
+    assert observed["on_event"] is on_event
     assert response.text == "hello"
 
 


### PR DESCRIPTION
## Summary

- Add experimental `client.send_payload(payload)`.
- Send raw payload dicts through the existing ChatGPT web backend stream transport.
- Return a normal `ChatResponse`.
- Deep-copy payloads before transport.
- Emit `raw_payload_sent` on successful transport.
- Add explicit experimental warning in the docstring.

## Scope

- No changes to `send()`.
- No changes to `PayloadBuilder`.
- No full payload validation yet.
- No docs page yet.
- No media-specific raw payload helpers.

## Tests

- Cover dict-only guard, payload copying, headers/requirements, stream transport call, response construction, fallback ids, success event emission, error propagation, and method availability.

Not run locally from this environment. CI runs `pytest -q` and package build.