### PR TITLE
PR5.3: Add lightweight payload validation

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -10,12 +10,14 @@ from .exceptions import (
     AuthError,
     ConversationTimeoutError,
     MediaError,
+    PayloadValidationError,
     RequestError,
     WebChatAdapterError,
 )
 from .export import export_conversation as _export_conversation
 from .messages import get_messages as _get_messages
 from .payload_builder import PayloadBuilder
+from .payload_validation import validate_payload
 from .policy_approval import ApprovalDeniedError
 from .policy_approval import approve_pending_action as _policy_approve_pending_action
 from .policy_approval import send_and_auto_approve as _policy_send_and_auto_approve
@@ -83,10 +85,12 @@ __all__ = [
     "MediaItem",
     "MediaSource",
     "PayloadBuilder",
+    "PayloadValidationError",
     "PendingApproval",
     "RequestError",
     "WaitResult",
     "WebChatAdapterError",
     "WebChatClient",
     "load_auth_data",
+    "validate_payload",
 ]

--- a/src/webchat_adapter/exceptions.py
+++ b/src/webchat_adapter/exceptions.py
@@ -19,6 +19,10 @@ class MediaError(WebChatAdapterError):
     """Media normalization, download, or upload failure."""
 
 
+class PayloadValidationError(WebChatAdapterError):
+    """Raw payload failed lightweight validation."""
+
+
 class ConversationTimeoutError(WebChatAdapterError):
     """Conversation did not reach a terminal wait state before timeout."""
 

--- a/src/webchat_adapter/payload_validation.py
+++ b/src/webchat_adapter/payload_validation.py
@@ -42,7 +42,9 @@ def validate_payload(payload: dict[str, Any]) -> None:
 
     if "conversation_id" in payload:
         conversation_id = payload.get("conversation_id")
-        if not isinstance(conversation_id, str) or not conversation_id.strip():
+        if conversation_id is not None and (
+            not isinstance(conversation_id, str) or not conversation_id.strip()
+        ):
             raise PayloadValidationError(
-                "conversation_id must be a non-empty string when present"
+                "conversation_id must be None or a non-empty string when present"
             )

--- a/src/webchat_adapter/payload_validation.py
+++ b/src/webchat_adapter/payload_validation.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .exceptions import PayloadValidationError
+
+
+def _required_non_empty_string(payload: dict[str, Any], field_name: str) -> str:
+    if field_name not in payload:
+        raise PayloadValidationError(f"{field_name} is required")
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise PayloadValidationError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def validate_payload(payload: dict[str, Any]) -> None:
+    """Lightly validate a raw ChatGPT web backend payload.
+
+    This validates only obvious top-level guardrails for the experimental raw
+    payload API. It is not a complete backend schema validator and does not
+    validate message content, tool payloads, media payloads, or metadata.
+    """
+
+    if not isinstance(payload, dict):
+        raise PayloadValidationError("payload must be a dict")
+
+    _required_non_empty_string(payload, "action")
+    _required_non_empty_string(payload, "parent_message_id")
+    _required_non_empty_string(payload, "model")
+
+    if "messages" not in payload:
+        raise PayloadValidationError("messages is required")
+    messages = payload.get("messages")
+    if isinstance(messages, str) or not isinstance(messages, list):
+        raise PayloadValidationError("messages must be a list")
+    if not messages:
+        raise PayloadValidationError("messages must not be empty")
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            raise PayloadValidationError(f"messages[{index}] must be a dict")
+
+    if "conversation_id" in payload:
+        conversation_id = payload.get("conversation_id")
+        if not isinstance(conversation_id, str) or not conversation_id.strip():
+            raise PayloadValidationError(
+                "conversation_id must be a non-empty string when present"
+            )

--- a/src/webchat_adapter/raw_payload.py
+++ b/src/webchat_adapter/raw_payload.py
@@ -4,6 +4,7 @@ import copy
 import time
 from typing import Any, Callable
 
+from .payload_validation import validate_payload
 from .types import ChatConversation, ChatMetrics, ChatResponse
 
 
@@ -21,8 +22,7 @@ def send_payload(
     conversations and messages. Use at your own risk.
     """
 
-    if not isinstance(payload, dict):
-        raise TypeError("payload must be a dict")
+    validate_payload(payload)
 
     payload_copy = copy.deepcopy(payload)
     requirements, proof_header = self._get_ready_requirements()

--- a/tests/test_payload_validation.py
+++ b/tests/test_payload_validation.py
@@ -27,6 +27,10 @@ def test_validate_payload_accepts_conversation_id_when_non_empty() -> None:
     validate_payload(_valid_payload(conversation_id="conv-1"))
 
 
+def test_validate_payload_accepts_null_conversation_id_for_new_chat_payloads() -> None:
+    validate_payload(_valid_payload(conversation_id=None))
+
+
 def test_validate_payload_accepts_payload_builder_new_chat() -> None:
     validate_payload(
         PayloadBuilder.new_chat(
@@ -114,10 +118,10 @@ def test_validate_payload_rejects_non_dict_message_items(message: object) -> Non
         validate_payload(_valid_payload(messages=[message]))
 
 
-@pytest.mark.parametrize("conversation_id", ["", "   ", None, 123])
+@pytest.mark.parametrize("conversation_id", ["", "   ", 123])
 def test_validate_payload_rejects_invalid_conversation_id(conversation_id: object) -> None:
     with pytest.raises(
         PayloadValidationError,
-        match="conversation_id must be a non-empty string when present",
+        match="conversation_id must be None or a non-empty string when present",
     ):
         validate_payload(_valid_payload(conversation_id=conversation_id))

--- a/tests/test_payload_validation.py
+++ b/tests/test_payload_validation.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+import webchat_adapter
+from webchat_adapter import PayloadBuilder, PayloadValidationError, validate_payload
+
+
+def _valid_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "action": "next",
+        "parent_message_id": "parent-1",
+        "model": "gpt-4o-mini",
+        "messages": [{"id": "msg-1"}],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_validate_payload_accepts_minimal_valid_payload() -> None:
+    validate_payload(_valid_payload())
+
+
+def test_validate_payload_accepts_conversation_id_when_non_empty() -> None:
+    validate_payload(_valid_payload(conversation_id="conv-1"))
+
+
+def test_validate_payload_accepts_payload_builder_new_chat() -> None:
+    validate_payload(
+        PayloadBuilder.new_chat(
+            "hello",
+            model="gpt-4o-mini",
+            parent_message_id="parent-1",
+        )
+    )
+
+
+def test_validate_payload_accepts_payload_builder_continue_chat() -> None:
+    validate_payload(
+        PayloadBuilder.continue_chat(
+            "continue",
+            conversation={"conversation_id": "conv-1", "message_id": "msg-1"},
+            model="gpt-4o-mini",
+        )
+    )
+
+
+def test_validate_payload_does_not_mutate_payload() -> None:
+    payload = _valid_payload(messages=[{"nested": {"value": 1}}])
+    original = copy.deepcopy(payload)
+
+    validate_payload(payload)
+
+    assert payload == original
+
+
+def test_payload_validation_exports() -> None:
+    assert webchat_adapter.PayloadValidationError is PayloadValidationError
+    assert webchat_adapter.validate_payload is validate_payload
+    assert "PayloadValidationError" in webchat_adapter.__all__
+    assert "validate_payload" in webchat_adapter.__all__
+
+
+def test_validate_payload_rejects_non_dict() -> None:
+    with pytest.raises(PayloadValidationError, match="payload must be a dict"):
+        validate_payload("bad")
+
+
+@pytest.mark.parametrize("field_name", ["action", "parent_message_id", "model"])
+def test_validate_payload_requires_top_level_string_fields(field_name: str) -> None:
+    payload = _valid_payload()
+    payload.pop(field_name)
+
+    with pytest.raises(PayloadValidationError, match=f"{field_name} is required"):
+        validate_payload(payload)
+
+
+@pytest.mark.parametrize("field_name", ["action", "parent_message_id", "model"])
+@pytest.mark.parametrize("value", ["", "   ", None, 123])
+def test_validate_payload_rejects_invalid_top_level_string_fields(
+    field_name: str,
+    value: object,
+) -> None:
+    payload = _valid_payload(**{field_name: value})
+
+    with pytest.raises(PayloadValidationError, match=f"{field_name} must be a non-empty string"):
+        validate_payload(payload)
+
+
+def test_validate_payload_requires_messages() -> None:
+    payload = _valid_payload()
+    payload.pop("messages")
+
+    with pytest.raises(PayloadValidationError, match="messages is required"):
+        validate_payload(payload)
+
+
+@pytest.mark.parametrize("messages", ["bad", None, 123, {"id": "msg"}])
+def test_validate_payload_rejects_non_list_messages(messages: object) -> None:
+    with pytest.raises(PayloadValidationError, match="messages must be a list"):
+        validate_payload(_valid_payload(messages=messages))
+
+
+def test_validate_payload_rejects_empty_messages() -> None:
+    with pytest.raises(PayloadValidationError, match="messages must not be empty"):
+        validate_payload(_valid_payload(messages=[]))
+
+
+@pytest.mark.parametrize("message", ["bad", None, 123, ["bad"]])
+def test_validate_payload_rejects_non_dict_message_items(message: object) -> None:
+    with pytest.raises(PayloadValidationError, match="messages\[0\] must be a dict"):
+        validate_payload(_valid_payload(messages=[message]))
+
+
+@pytest.mark.parametrize("conversation_id", ["", "   ", None, 123])
+def test_validate_payload_rejects_invalid_conversation_id(conversation_id: object) -> None:
+    with pytest.raises(
+        PayloadValidationError,
+        match="conversation_id must be a non-empty string when present",
+    ):
+        validate_payload(_valid_payload(conversation_id=conversation_id))

--- a/tests/test_send_payload.py
+++ b/tests/test_send_payload.py
@@ -6,7 +6,12 @@ from typing import Any
 
 import pytest
 
-from webchat_adapter import ChatGPTWebClient, ChatResponse, RequestError
+from webchat_adapter import (
+    ChatGPTWebClient,
+    ChatResponse,
+    PayloadValidationError,
+    RequestError,
+)
 
 
 def _client() -> ChatGPTWebClient:
@@ -15,23 +20,28 @@ def _client() -> ChatGPTWebClient:
     return client
 
 
-def _install_requirements(
-    client: ChatGPTWebClient,
-    *,
-    token: str = "requirements-token",
-    proof: str = "proof-token",
-    turnstile_required: bool = False,
-) -> list[dict[str, Any]]:
+def _payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "action": "next",
+        "parent_message_id": "parent-1",
+        "model": "gpt-4o-mini",
+        "messages": [{"id": "msg-1"}],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _install_requirements(client: ChatGPTWebClient, *, turnstile_required: bool = False) -> list[dict[str, Any]]:
     header_inputs: list[dict[str, Any]] = []
     client._get_ready_requirements = lambda: (
-        {"token": token, "turnstile": {"required": turnstile_required}},
-        proof,
+        {"token": "requirements-token", "turnstile": {"required": turnstile_required}},
+        "proof-token",
     )
 
     def build_headers(extra: dict[str, Any] | None = None) -> dict[str, Any]:
-        payload = dict(extra or {})
-        header_inputs.append(payload)
-        return payload
+        headers = dict(extra or {})
+        header_inputs.append(headers)
+        return headers
 
     client._build_headers = build_headers
     return header_inputs
@@ -45,22 +55,32 @@ def test_send_payload_rejects_non_dict_payload_before_network() -> None:
     client = _client()
     client._get_ready_requirements = lambda: pytest.fail("requirements must not be fetched")
 
-    with pytest.raises(TypeError, match="payload must be a dict"):
+    with pytest.raises(PayloadValidationError, match="payload must be a dict"):
         client.send_payload("bad")
+
+
+def test_send_payload_validates_before_requirements() -> None:
+    client = _client()
+    client._get_ready_requirements = lambda: pytest.fail("requirements must not be fetched")
+
+    with pytest.raises(PayloadValidationError, match="model is required"):
+        client.send_payload(
+            {
+                "action": "next",
+                "parent_message_id": "parent-1",
+                "messages": [{"id": "msg-1"}],
+            }
+        )
 
 
 def test_send_payload_deep_copies_payload_before_transport() -> None:
     client = _client()
     _install_requirements(client)
-    payload = {"messages": [{"content": {"parts": ["hello"]}}]}
+    payload = _payload(messages=[{"content": {"parts": ["hello"]}}])
     original = copy.deepcopy(payload)
     observed_payloads: list[dict[str, Any]] = []
 
-    def fake_stream(
-        stream_payload: dict[str, Any],
-        _headers: dict[str, Any],
-        **_kwargs: Any,
-    ) -> tuple[str, str, str]:
+    def fake_stream(stream_payload: dict[str, Any], *_args: Any, **_kwargs: Any) -> tuple[str, str, str]:
         observed_payloads.append(stream_payload)
         stream_payload["messages"][0]["content"]["parts"][0] = "mutated"
         return "conv-1", "msg-1", "ok"
@@ -75,15 +95,10 @@ def test_send_payload_deep_copies_payload_before_transport() -> None:
 
 def test_send_payload_gets_requirements_and_builds_stream_headers() -> None:
     client = _client()
-    header_inputs = _install_requirements(
-        client,
-        token="requirements-token",
-        proof="proof-token",
-        turnstile_required=True,
-    )
+    header_inputs = _install_requirements(client, turnstile_required=True)
     client._stream_backend_payload = lambda *_args, **_kwargs: ("conv-1", "msg-1", "ok")
 
-    client.send_payload({"messages": []})
+    client.send_payload(_payload())
 
     assert header_inputs == [
         {
@@ -98,10 +113,10 @@ def test_send_payload_gets_requirements_and_builds_stream_headers() -> None:
 
 def test_send_payload_omits_turnstile_header_when_not_required() -> None:
     client = _client()
-    header_inputs = _install_requirements(client, turnstile_required=False)
+    header_inputs = _install_requirements(client)
     client._stream_backend_payload = lambda *_args, **_kwargs: ("conv-1", "msg-1", "ok")
 
-    client.send_payload({"messages": []})
+    client.send_payload(_payload())
 
     assert header_inputs[0]["openai-sentinel-turnstile-token"] is None
 
@@ -113,7 +128,7 @@ def test_send_payload_requires_chat_requirements_token() -> None:
     client._stream_backend_payload = lambda *_args, **_kwargs: pytest.fail("stream must not run")
 
     with pytest.raises(RequestError, match="chat-requirements token is missing"):
-        client.send_payload({"messages": []})
+        client.send_payload(_payload())
 
 
 def test_send_payload_calls_stream_backend_with_payload_headers_and_callbacks() -> None:
@@ -123,7 +138,7 @@ def test_send_payload_calls_stream_backend_with_payload_headers_and_callbacks() 
     events: list[dict[str, Any]] = []
     on_token = tokens.append
     on_event = events.append
-    payload = {"messages": [{"id": "msg"}]}
+    payload = _payload(messages=[{"id": "msg"}])
     observed: dict[str, Any] = {}
 
     def fake_stream(
@@ -133,10 +148,12 @@ def test_send_payload_calls_stream_backend_with_payload_headers_and_callbacks() 
         on_token: Any = None,
         on_event: Any = None,
     ) -> tuple[str, str, str]:
-        observed["payload"] = stream_payload
-        observed["headers"] = headers
-        observed["on_token"] = on_token
-        observed["on_event"] = on_event
+        observed.update(
+            payload=stream_payload,
+            headers=headers,
+            on_token=on_token,
+            on_event=on_event,
+        )
         return "conv-1", "msg-1", "hello"
 
     client._stream_backend_payload = fake_stream
@@ -156,7 +173,7 @@ def test_send_payload_returns_chat_response() -> None:
     _install_requirements(client)
     client._stream_backend_payload = lambda *_args, **_kwargs: ("conv-1", "msg-1", "hello")
 
-    response = client.send_payload({"messages": []})
+    response = client.send_payload(_payload())
 
     assert isinstance(response, ChatResponse)
     assert response.text == "hello"
@@ -173,13 +190,7 @@ def test_send_payload_uses_payload_id_fallbacks_when_stream_returns_none() -> No
     _install_requirements(client)
     client._stream_backend_payload = lambda *_args, **_kwargs: (None, None, "hello")
 
-    response = client.send_payload(
-        {
-            "conversation_id": "conv-existing",
-            "parent_message_id": "parent-1",
-            "messages": [],
-        }
-    )
+    response = client.send_payload(_payload(conversation_id="conv-existing"))
 
     assert response.conversation.conversation_id == "conv-existing"
     assert response.conversation.message_id == "parent-1"
@@ -192,7 +203,7 @@ def test_send_payload_emits_raw_payload_sent_on_success() -> None:
     events: list[dict[str, Any]] = []
     client._stream_backend_payload = lambda *_args, **_kwargs: ("conv-1", "msg-1", "hello")
 
-    client.send_payload({"messages": [{"id": "m1"}]}, on_event=events.append)
+    client.send_payload(_payload(messages=[{"id": "m1"}]), on_event=events.append)
 
     assert events[-1] == {
         "type": "raw_payload_sent",
@@ -209,11 +220,11 @@ def test_send_payload_does_not_emit_success_event_on_stream_error() -> None:
     events: list[dict[str, Any]] = []
 
     def fake_stream(*_args: Any, **_kwargs: Any) -> tuple[str, str, str]:
-        raise RequestError("backend failed")
+        raise RequestError("transport failed")
 
     client._stream_backend_payload = fake_stream
 
-    with pytest.raises(RequestError, match="backend failed"):
-        client.send_payload({"messages": []}, on_event=events.append)
+    with pytest.raises(RequestError, match="transport failed"):
+        client.send_payload(_payload(), on_event=events.append)
 
     assert events == []


### PR DESCRIPTION
## Summary

- Add `PayloadValidationError`.
- Add lightweight `validate_payload(payload)` for raw payloads.
- Validate required raw payload fields:
  - `action`
  - `parent_message_id`
  - `model`
  - `messages`
- Validate optional `conversation_id` when present.
- Integrate validation into `client.send_payload()` before requirements/network work.

## Scope

- No full backend schema framework.
- No message-content schema validation.
- No media/tool/multimodal payload validation.
- No `send()` changes.
- No docs page yet.

## Tests

- Cover valid minimal payloads.
- Cover PayloadBuilder payload compatibility.
- Cover missing/invalid required fields.
- Cover optional `conversation_id`.
- Cover `send_payload()` validation before network.

Not run locally from this environment. CI runs `pytest -q` and package build.