### PR TITLE
PR6.2: Add send event callbacks

### DIFF
--- a/src/webchat_adapter/diagnostic_metrics.py
+++ b/src/webchat_adapter/diagnostic_metrics.py
@@ -12,20 +12,53 @@ def _chars_per_second(text: str, stream_duration: float | None) -> float | None:
     return len(text) / stream_duration
 
 
+def _emit_event(
+    callback: Callable[[dict[str, Any]], None] | None,
+    event_type: str,
+    **payload: Any,
+) -> None:
+    if callback is None:
+        return
+    callback({"type": event_type, **payload})
+
+
+def _is_stream_request(
+    headers: Any,
+    no_buffer: Any,
+) -> bool:
+    if no_buffer is not True or not isinstance(headers, dict):
+        return False
+    return headers.get("accept") == "text/event-stream"
+
+
 def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..., Any]:
     def send(self: Any, *args: Any, **kwargs: Any) -> Any:
+        on_event = kwargs.pop("on_event", None)
+        on_token = kwargs.get("on_token")
         requirements_latency: float | None = None
         backend_status: int | None = None
+        stream_started = False
+        first_token_seen = False
+        request_started_at = time.perf_counter()
         original_get_ready_requirements = self._get_ready_requirements
         original_extract_status_code = self._extract_status_code
+        original_build_curl_command = self._build_curl_command
 
         def timed_get_ready_requirements() -> tuple[dict[str, Any], str | None]:
             nonlocal requirements_latency
             started_at = time.perf_counter()
-            try:
-                return original_get_ready_requirements()
-            finally:
-                requirements_latency = time.perf_counter() - started_at
+            requirements, proof_header = original_get_ready_requirements()
+            requirements_latency = time.perf_counter() - started_at
+            turnstile = requirements.get("turnstile") if isinstance(requirements, dict) else None
+            _emit_event(
+                on_event,
+                "requirements_ready",
+                latency=requirements_latency,
+                token_present=bool(requirements.get("token")) if isinstance(requirements, dict) else False,
+                proof_header_present=bool(proof_header),
+                turnstile_required=bool(turnstile.get("required")) if isinstance(turnstile, dict) else False,
+            )
+            return requirements, proof_header
 
         def capture_status_code(header_text: str) -> int:
             nonlocal backend_status
@@ -33,13 +66,71 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
             backend_status = status if status > 0 else None
             return status
 
+        def emit_stream_started_build_curl_command(
+            method: str,
+            url: str,
+            headers: dict[str, str],
+            header_path: str,
+            body_path: str | None = None,
+            *,
+            no_buffer: bool = False,
+            follow_redirects: bool = False,
+        ) -> list[str]:
+            nonlocal stream_started
+            command = original_build_curl_command(
+                method,
+                url,
+                headers,
+                header_path,
+                body_path,
+                no_buffer=no_buffer,
+                follow_redirects=follow_redirects,
+            )
+            if not stream_started and _is_stream_request(headers, no_buffer):
+                stream_started = True
+                _emit_event(
+                    on_event,
+                    "stream_started",
+                    method=method.upper(),
+                    url=url,
+                )
+            return command
+
+        def eventful_on_token(token: str) -> None:
+            nonlocal first_token_seen
+            elapsed = time.perf_counter() - request_started_at
+            if not first_token_seen:
+                first_token_seen = True
+                _emit_event(on_event, "first_token", token=token, elapsed=elapsed)
+            _emit_event(on_event, "assistant_token", token=token, elapsed=elapsed)
+            if on_token is not None:
+                on_token(token)
+
+        kwargs["on_token"] = eventful_on_token if on_event is not None else on_token
+        _emit_event(
+            on_event,
+            "request_started",
+            model=kwargs.get("model"),
+            has_conversation=kwargs.get("conversation") is not None,
+            has_media=bool(kwargs.get("media")),
+        )
         self._get_ready_requirements = timed_get_ready_requirements
         self._extract_status_code = capture_status_code
+        self._build_curl_command = emit_stream_started_build_curl_command
         try:
             response = original_send(self, *args, **kwargs)
+        except Exception as error:
+            _emit_event(
+                on_event,
+                "error",
+                error_type=type(error).__name__,
+                message=str(error),
+            )
+            raise
         finally:
             self._get_ready_requirements = original_get_ready_requirements
             self._extract_status_code = original_extract_status_code
+            self._build_curl_command = original_build_curl_command
 
         previous_metrics = getattr(response, "metrics", None)
         stream_duration = getattr(previous_metrics, "total", None)
@@ -56,6 +147,21 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
             stream_duration=stream_duration,
             chars_per_second=_chars_per_second(text, stream_duration),
             backend_status=backend_status,
+        )
+        _emit_event(
+            on_event,
+            "stream_done",
+            conversation_id=getattr(response.conversation, "conversation_id", None),
+            message_id=getattr(response.conversation, "message_id", None),
+            text_length=len(text),
+        )
+        _emit_event(
+            on_event,
+            "request_completed",
+            conversation_id=getattr(response.conversation, "conversation_id", None),
+            message_id=getattr(response.conversation, "message_id", None),
+            finish_reason=getattr(response.conversation, "finish_reason", None),
+            total=response.metrics.total,
         )
         return response
 

--- a/tests/test_send_metrics.py
+++ b/tests/test_send_metrics.py
@@ -85,6 +85,9 @@ def _make_metrics_handler(state: dict[str, Any]) -> type[BaseHTTPRequestHandler]
                 state["conversation_payloads"].append(
                     json.loads(self._read_body().decode("utf-8"))
                 )
+                if state.get("backend_status"):
+                    self._write_json(state["backend_status"], {"error": "backend failed"})
+                    return
                 self.send_response(200)
                 self.send_header("Content-Type", "text/event-stream")
                 self.end_headers()
@@ -167,3 +170,70 @@ def test_send_metrics_to_dict_contains_expanded_values(monkeypatch: pytest.Monke
     assert metrics["stream_duration"] == response.metrics.stream_duration
     assert metrics["chars_per_second"] == response.metrics.chars_per_second
     assert metrics["backend_status"] == 200
+
+
+def test_send_emits_event_callback_sequence(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build_client()
+    state: dict[str, Any] = {
+        "requirements_calls": 0,
+        "conversation_payloads": [],
+    }
+    events: list[dict[str, Any]] = []
+    tokens: list[str] = []
+
+    with _serve(_make_metrics_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send(
+            "hello",
+            model="gpt-4o-mini",
+            on_token=tokens.append,
+            on_event=events.append,
+        )
+
+    assert response.text == "Hi there"
+    assert tokens == ["Hi", " there"]
+    event_types = [event["type"] for event in events]
+    assert event_types == [
+        "request_started",
+        "requirements_ready",
+        "stream_started",
+        "first_token",
+        "assistant_token",
+        "assistant_token",
+        "stream_done",
+        "request_completed",
+    ]
+    assert events[0]["model"] == "gpt-4o-mini"
+    assert events[1]["token_present"] is True
+    assert events[3]["token"] == "Hi"
+    assert events[4]["token"] == "Hi"
+    assert events[5]["token"] == " there"
+    assert events[-2]["text_length"] == len("Hi there")
+    assert events[-1]["conversation_id"] == "conv-123"
+    assert events[-1]["message_id"] == "assistant-1"
+    assert events[-1]["finish_reason"] == "stop"
+
+
+def test_send_emits_error_event_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _build_client()
+    state: dict[str, Any] = {
+        "requirements_calls": 0,
+        "conversation_payloads": [],
+        "backend_status": 500,
+    }
+    events: list[dict[str, Any]] = []
+
+    with _serve(_make_metrics_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        with pytest.raises(adapter.RequestError, match="backend status=500"):
+            client.send("hello", model="gpt-4o-mini", on_event=events.append)
+
+    event_types = [event["type"] for event in events]
+    assert event_types == [
+        "request_started",
+        "requirements_ready",
+        "stream_started",
+        "error",
+    ]
+    assert events[-1]["error_type"] == "RequestError"
+    assert "backend status=500" in events[-1]["message"]


### PR DESCRIPTION
## Summary

- Add public `client.send(..., on_event=...)` support through the existing send wrapper.
- Emit lifecycle events for normal send requests:
  - `request_started`
  - `requirements_ready`
  - `stream_started`
  - `first_token`
  - `assistant_token`
  - `stream_done`
  - `request_completed`
  - `error`
- Preserve existing `on_token` behavior while also emitting token events.
- Keep expanded metrics behavior from PR6.1 intact.

## Scope

- No transport-layer refactor.
- No structured `RequestError` redesign.
- No event callback support for approval helper internals beyond existing approval events.
- No docs/example yet.

## Tests

- Cover successful event ordering for `send(..., on_event=...)`.
- Cover compatibility with legacy `on_token`.
- Cover `error` event emission on backend failure.
- Existing expanded metrics tests remain in place.

Local pytest was not run because this environment cannot clone the repository from GitHub; CI will run the full matrix.