### PR TITLE
PR6.3: Add structured RequestError diagnostics

### DIFF
--- a/src/webchat_adapter/diagnostic_metrics.py
+++ b/src/webchat_adapter/diagnostic_metrics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 from typing import Any, Callable
 
+from .exceptions import RequestError
 from .types import ChatMetrics
 
 
@@ -31,12 +32,29 @@ def _is_stream_request(
     return headers.get("accept") == "text/event-stream"
 
 
+def _fill_request_error(
+    error: RequestError,
+    *,
+    status_code: int | None,
+    endpoint: str | None,
+    request_stage: str | None,
+) -> None:
+    if error.status_code is None and status_code is not None:
+        error.status_code = status_code
+    if error.endpoint is None and endpoint is not None:
+        error.endpoint = endpoint
+    if error.request_stage is None and request_stage is not None:
+        error.request_stage = request_stage
+
+
 def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..., Any]:
     def send(self: Any, *args: Any, **kwargs: Any) -> Any:
         on_event = kwargs.pop("on_event", None)
         on_token = kwargs.get("on_token")
         requirements_latency: float | None = None
         backend_status: int | None = None
+        stream_endpoint: str | None = None
+        request_stage: str | None = None
         stream_started = False
         first_token_seen = False
         request_started_at = time.perf_counter()
@@ -45,7 +63,8 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
         original_build_curl_command = self._build_curl_command
 
         def timed_get_ready_requirements() -> tuple[dict[str, Any], str | None]:
-            nonlocal requirements_latency
+            nonlocal requirements_latency, request_stage
+            request_stage = "chat_requirements"
             started_at = time.perf_counter()
             requirements, proof_header = original_get_ready_requirements()
             requirements_latency = time.perf_counter() - started_at
@@ -76,7 +95,7 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
             no_buffer: bool = False,
             follow_redirects: bool = False,
         ) -> list[str]:
-            nonlocal stream_started
+            nonlocal request_stage, stream_endpoint, stream_started
             command = original_build_curl_command(
                 method,
                 url,
@@ -87,6 +106,8 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
                 follow_redirects=follow_redirects,
             )
             if not stream_started and _is_stream_request(headers, no_buffer):
+                request_stage = "conversation_stream"
+                stream_endpoint = url
                 stream_started = True
                 _emit_event(
                     on_event,
@@ -120,11 +141,22 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
         try:
             response = original_send(self, *args, **kwargs)
         except Exception as error:
+            if isinstance(error, RequestError):
+                _fill_request_error(
+                    error,
+                    status_code=backend_status,
+                    endpoint=stream_endpoint,
+                    request_stage=request_stage,
+                )
             _emit_event(
                 on_event,
                 "error",
                 error_type=type(error).__name__,
                 message=str(error),
+                status_code=getattr(error, "status_code", None),
+                endpoint=getattr(error, "endpoint", None),
+                body_preview=getattr(error, "body_preview", None),
+                request_stage=getattr(error, "request_stage", None),
             )
             raise
         finally:

--- a/src/webchat_adapter/diagnostic_metrics.py
+++ b/src/webchat_adapter/diagnostic_metrics.py
@@ -41,7 +41,7 @@ def _fill_request_error(
 ) -> None:
     if error.status_code is None and status_code is not None:
         error.status_code = status_code
-    if error.endpoint is None and endpoint is not None:
+    if endpoint is not None:
         error.endpoint = endpoint
     if error.request_stage is None and request_stage is not None:
         error.request_stage = request_stage

--- a/src/webchat_adapter/exceptions.py
+++ b/src/webchat_adapter/exceptions.py
@@ -12,6 +12,7 @@ class AuthError(WebChatAdapterError):
     """Authentication or auth-data loading failure."""
 
 
+
 def _optional_str(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
@@ -109,10 +110,14 @@ class RequestError(WebChatAdapterError):
     ) -> None:
         message = str(message)
         inferred_stage = _request_stage_from_message(message)
-        self.status_code = _optional_status_code(status_code) or _status_code_from_message(message)
+        self.status_code = (
+            _optional_status_code(status_code) or _status_code_from_message(message)
+        )
         self.request_stage = _optional_str(request_stage) or inferred_stage
         self.endpoint = _optional_str(endpoint) or _endpoint_from_stage(self.request_stage)
-        self.body_preview = _body_preview(body_preview) or _body_preview_from_message(message)
+        self.body_preview = _body_preview(body_preview) or _body_preview_from_message(
+            message
+        )
         super().__init__(message)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/webchat_adapter/exceptions.py
+++ b/src/webchat_adapter/exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 
@@ -11,8 +12,117 @@ class AuthError(WebChatAdapterError):
     """Authentication or auth-data loading failure."""
 
 
+def _optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _optional_status_code(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        status_code = int(value)
+    except (TypeError, ValueError):
+        return None
+    return status_code if status_code > 0 else None
+
+
+def _body_preview(value: Any, *, limit: int = 300) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        text = value.decode("utf-8", errors="replace")
+    else:
+        text = str(value)
+    text = text.strip()
+    if not text:
+        return None
+    return text[:limit]
+
+
+def _status_code_from_message(message: str) -> int | None:
+    match = re.search(r"\bstatus=(\d+)\b", message)
+    if match is None:
+        return None
+    return _optional_status_code(match.group(1))
+
+
+def _body_preview_from_message(message: str) -> str | None:
+    if "status=" not in message or ":" not in message:
+        return None
+    _prefix, body = message.split(":", 1)
+    return _body_preview(body)
+
+
+def _request_stage_from_message(message: str) -> str | None:
+    if message.startswith("chat-requirements"):
+        return "chat_requirements"
+    if message.startswith("backend status="):
+        return "conversation_stream"
+    if message.startswith("conversation prepare"):
+        return "conversation_prepare"
+    if message.startswith("conversation status="):
+        return "conversation_fetch"
+    if message.startswith("conversations status="):
+        return "conversation_list"
+    if message.startswith("Create file"):
+        return "file_create"
+    if message.startswith("Upload file"):
+        return "file_upload"
+    if message.startswith("Finalize file"):
+        return "file_finalize"
+    if message.startswith("curl failed"):
+        return "transport"
+    return None
+
+
+def _endpoint_from_stage(request_stage: str | None) -> str | None:
+    if request_stage is None:
+        return None
+    endpoints = {
+        "chat_requirements": "chat-requirements",
+        "conversation_stream": "conversation",
+        "conversation_prepare": "conversation/prepare",
+        "conversation_fetch": "conversation",
+        "conversation_list": "conversations",
+        "file_create": "files",
+        "file_upload": "file-upload-url",
+        "file_finalize": "files/uploaded",
+        "transport": None,
+    }
+    return endpoints.get(request_stage)
+
+
 class RequestError(WebChatAdapterError):
     """HTTP transport or backend request failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        endpoint: str | None = None,
+        body_preview: Any = None,
+        request_stage: str | None = None,
+    ) -> None:
+        message = str(message)
+        inferred_stage = _request_stage_from_message(message)
+        self.status_code = _optional_status_code(status_code) or _status_code_from_message(message)
+        self.request_stage = _optional_str(request_stage) or inferred_stage
+        self.endpoint = _optional_str(endpoint) or _endpoint_from_stage(self.request_stage)
+        self.body_preview = _body_preview(body_preview) or _body_preview_from_message(message)
+        super().__init__(message)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "message": str(self),
+            "status_code": self.status_code,
+            "endpoint": self.endpoint,
+            "body_preview": self.body_preview,
+            "request_stage": self.request_stage,
+        }
 
 
 class MediaError(WebChatAdapterError):

--- a/tests/test_request_error.py
+++ b/tests/test_request_error.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from webchat_adapter import RequestError
+
+
+def test_request_error_preserves_string_message() -> None:
+    error = RequestError(
+        "backend status=500: internal failure",
+        status_code=502,
+        endpoint="https://example.test/backend",
+        body_preview="full backend body",
+        request_stage="conversation_stream",
+    )
+
+    assert str(error) == "backend status=500: internal failure"
+    assert error.status_code == 502
+    assert error.endpoint == "https://example.test/backend"
+    assert error.body_preview == "full backend body"
+    assert error.request_stage == "conversation_stream"
+    assert error.to_dict() == {
+        "message": "backend status=500: internal failure",
+        "status_code": 502,
+        "endpoint": "https://example.test/backend",
+        "body_preview": "full backend body",
+        "request_stage": "conversation_stream",
+    }
+
+
+def test_request_error_infers_fields_from_legacy_backend_message() -> None:
+    error = RequestError("backend status=429: rate limited")
+
+    assert str(error) == "backend status=429: rate limited"
+    assert error.status_code == 429
+    assert error.endpoint == "conversation"
+    assert error.body_preview == "rate limited"
+    assert error.request_stage == "conversation_stream"
+
+
+def test_request_error_infers_fields_from_legacy_requirements_message() -> None:
+    error = RequestError("chat-requirements status=403")
+
+    assert error.status_code == 403
+    assert error.endpoint == "chat-requirements"
+    assert error.body_preview is None
+    assert error.request_stage == "chat_requirements"
+
+
+def test_request_error_defaults_structured_fields_to_none() -> None:
+    error = RequestError("custom failure")
+
+    assert error.status_code is None
+    assert error.endpoint is None
+    assert error.body_preview is None
+    assert error.request_stage is None

--- a/tests/test_send_metrics.py
+++ b/tests/test_send_metrics.py
@@ -225,8 +225,16 @@ def test_send_emits_error_event_on_failure(monkeypatch: pytest.MonkeyPatch) -> N
 
     with _serve(_make_metrics_handler(state)) as base_url:
         _patch_chat_endpoints(monkeypatch, base_url)
-        with pytest.raises(adapter.RequestError, match="backend status=500"):
+        with pytest.raises(adapter.RequestError, match="backend status=500") as exc_info:
             client.send("hello", model="gpt-4o-mini", on_event=events.append)
+
+    error = exc_info.value
+    assert str(error).startswith("backend status=500")
+    assert error.status_code == 500
+    assert error.endpoint.endswith("/backend-api/f/conversation")
+    assert error.body_preview is not None
+    assert "backend failed" in error.body_preview
+    assert error.request_stage == "conversation_stream"
 
     event_types = [event["type"] for event in events]
     assert event_types == [
@@ -237,3 +245,7 @@ def test_send_emits_error_event_on_failure(monkeypatch: pytest.MonkeyPatch) -> N
     ]
     assert events[-1]["error_type"] == "RequestError"
     assert "backend status=500" in events[-1]["message"]
+    assert events[-1]["status_code"] == 500
+    assert events[-1]["endpoint"].endswith("/backend-api/f/conversation")
+    assert events[-1]["request_stage"] == "conversation_stream"
+    assert "backend failed" in events[-1]["body_preview"]


### PR DESCRIPTION
## Summary

- Extend `RequestError` with structured diagnostic fields:
  - `status_code`
  - `endpoint`
  - `body_preview`
  - `request_stage`
- Keep `str(error)` backward-compatible with the original message.
- Add safe inference for existing legacy error strings such as `backend status=...` and `chat-requirements status=...`.
- Enrich `send()` failures with the current request stage and exact stream endpoint when available.
- Include structured error fields in the `on_event` `error` payload.

## Scope

- No transport-layer refactor.
- No change to existing exception message text.
- No broad rewrite of all RequestError call sites yet.

## Tests

- Cover direct structured `RequestError` construction.
- Cover inference from legacy backend and chat-requirements messages.
- Cover default `None` fields for custom messages.
- Cover `client.send(..., on_event=...)` backend failure diagnostics.

Local pytest was not run because this environment cannot clone the repository from GitHub; CI will run the full matrix.