### PR TITLE
PR7.1: Stabilize Public API Surface

### DIFF
--- a/src/webchat_adapter/__init__.py
+++ b/src/webchat_adapter/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from . import errors
 from .approval_policy import ApprovalDecision, ApprovalPolicy
 from .approval_types import ApprovalEvent, ApprovalResult, ApprovalRound
 from .attach import attach_conversation as _attach_conversation
@@ -65,35 +66,43 @@ ChatGPTWebClient.wait_until_completed = _wait_until_completed
 WebChatClient = ChatGPTWebClient
 
 __all__ = [
+    # Stable core API
+    "ChatGPTWebClient",
+    "WebChatClient",
+    "ChatConversation",
+    "AttachedConversation",
+    "ChatMessage",
+    "ConversationStatus",
+    "PendingApproval",
+    "ChatResponse",
+    "ChatMetrics",
+    "AuthData",
+    "errors",
+    # Stable errors, kept for direct-import compatibility
+    "WebChatAdapterError",
+    "AuthError",
+    "ConversationTimeoutError",
+    "MediaError",
+    "PayloadValidationError",
+    "RequestError",
+    # Advanced conversation/status helpers
+    "ConversationRef",
+    "WaitResult",
+    # Media types
+    "MediaItem",
+    "MediaSource",
+    # Experimental approvals
     "ApprovalDecision",
     "ApprovalDeniedError",
     "ApprovalEvent",
     "ApprovalPolicy",
     "ApprovalResult",
     "ApprovalRound",
-    "AttachedConversation",
-    "AuthData",
-    "AuthError",
-    "ChatConversation",
-    "ChatGPTWebClient",
-    "ChatMessage",
-    "ChatMetrics",
-    "ChatResponse",
-    "ConversationRef",
-    "ConversationStatus",
-    "ConversationTimeoutError",
+    # Experimental raw payload
+    "PayloadBuilder",
+    "validate_payload",
+    # Support helpers/constants
     "DEFAULT_AUTH_FILE",
     "DEFAULT_MODEL",
-    "MediaError",
-    "MediaItem",
-    "MediaSource",
-    "PayloadBuilder",
-    "PayloadValidationError",
-    "PendingApproval",
-    "RequestError",
-    "WaitResult",
-    "WebChatAdapterError",
-    "WebChatClient",
     "load_auth_data",
-    "validate_payload",
 ]

--- a/src/webchat_adapter/errors.py
+++ b/src/webchat_adapter/errors.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from .exceptions import (
+    AuthError,
+    ConversationTimeoutError,
+    MediaError,
+    PayloadValidationError,
+    RequestError,
+    WebChatAdapterError,
+)
+
+__all__ = [
+    "WebChatAdapterError",
+    "AuthError",
+    "ConversationTimeoutError",
+    "MediaError",
+    "PayloadValidationError",
+    "RequestError",
+]

--- a/tests/test_public_api_surface.py
+++ b/tests/test_public_api_surface.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import webchat_adapter as adapter
+
+
+CORE_PUBLIC_API = [
+    "ChatGPTWebClient",
+    "WebChatClient",
+    "ChatConversation",
+    "AttachedConversation",
+    "ChatMessage",
+    "ConversationStatus",
+    "PendingApproval",
+    "ChatResponse",
+    "ChatMetrics",
+    "AuthData",
+    "errors",
+]
+
+
+ERROR_EXPORTS = [
+    "WebChatAdapterError",
+    "AuthError",
+    "ConversationTimeoutError",
+    "MediaError",
+    "PayloadValidationError",
+    "RequestError",
+]
+
+
+def test_core_public_api_is_ordered_first() -> None:
+    assert adapter.__all__[: len(CORE_PUBLIC_API)] == CORE_PUBLIC_API
+
+
+def test_public_api_exports_are_available() -> None:
+    assert len(adapter.__all__) == len(set(adapter.__all__))
+    for name in adapter.__all__:
+        assert hasattr(adapter, name)
+
+
+def test_webchat_client_alias_remains_compatible() -> None:
+    assert adapter.WebChatClient is adapter.ChatGPTWebClient
+
+
+def test_errors_namespace_matches_direct_error_exports() -> None:
+    assert adapter.errors.__all__ == ERROR_EXPORTS
+    for name in ERROR_EXPORTS:
+        assert getattr(adapter.errors, name) is getattr(adapter, name)


### PR DESCRIPTION
## Summary

- add a public `webchat_adapter.errors` namespace that re-exports the existing exception classes
- reorder `webchat_adapter.__all__` so the stable core API appears first in the requested order
- keep existing direct exports for errors, approvals, raw payload helpers, media types, and support constants for compatibility
- add public API surface tests covering the ordered core prefix, duplicate-free exports, the `WebChatClient` alias, and the errors namespace

## Why

PR7.1 prepares the SDK public contract for the M7 cleanup without breaking existing users who already import advanced or experimental names from `webchat_adapter`.

## Validation

- checked GitHub compare for the branch diff
- ran local `ast.parse` sanity checks for the changed Python files

I could not run the full test suite locally because this environment blocks direct GitHub cloning and does not have a local checkout of the repository.