### PR TITLE
PR7.2: Add Rename Compatibility Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ second = client.send(
 
 This repository only consumes existing auth data. If you still need browser-based capture, generate `auth_data.json` with `webchat-openai-cli` first and then reuse it here.
 
+## Future Rename
+
+The project may later move to the clearer name `chatgpt-web-adapter`, with Python package import `chatgpt_web_adapter`.
+
+The current `webchat_adapter` import remains the only supported import today. See [docs/rename_compatibility.md](docs/rename_compatibility.md).
+
 ## Status
 
 Initial SDK baseline. The repository is intentionally small and focused on the transport layer first.

--- a/docs/rename_compatibility.md
+++ b/docs/rename_compatibility.md
@@ -1,0 +1,102 @@
+# Rename Compatibility Plan
+
+This project may later move to the clearer public name `chatgpt-web-adapter`, with the Python import package `chatgpt_web_adapter`.
+
+The rename is planned for a future milestone. It is not implemented today.
+
+## Current Name
+
+Today, only the current package exists:
+
+- Repository: `webchat-adapter`
+- Distribution package: `webchat-adapter`
+- Python import package: `webchat_adapter`
+
+Current supported import:
+
+```python
+from webchat_adapter import ChatGPTWebClient
+```
+
+## Future Name
+
+The future naming target is:
+
+- Repository: `chatgpt-web-adapter`
+- Distribution package: `chatgpt-web-adapter`
+- Python import package: `chatgpt_web_adapter`
+
+Future preferred import:
+
+```python
+from chatgpt_web_adapter import ChatGPTWebClient
+```
+
+That future import is not available yet.
+
+## Compatibility Import
+
+The existing `webchat_adapter` import path will remain the compatibility import after the future rename:
+
+```python
+from webchat_adapter import ChatGPTWebClient
+```
+
+The compatibility import should remain available for multiple minor releases after the new package exists.
+
+## Policy
+
+- Do not rename before the SDK has enough user-facing value.
+- Do not rename before the early value milestones are complete.
+- Keep `webchat_adapter` as the old compatibility import after the future rename.
+- Do not remove `webchat_adapter` without a documented deprecation period.
+- Do not add deprecation warnings until `chatgpt_web_adapter` exists and migration is actually possible.
+- Do not update examples to `chatgpt_web_adapter` before the new import exists.
+
+## Migration Phases
+
+### Phase 0 - Current
+
+Only `webchat_adapter` exists. Documentation and examples must continue to use:
+
+```python
+from webchat_adapter import ChatGPTWebClient
+```
+
+### Phase 1 - Dual Import
+
+After the future rename package is introduced, both imports should work:
+
+```python
+from chatgpt_web_adapter import ChatGPTWebClient
+from webchat_adapter import ChatGPTWebClient
+```
+
+At this phase, `webchat_adapter` should be a thin compatibility layer around the new package.
+
+### Phase 2 - Preferred New Import
+
+Documentation and new examples may move to:
+
+```python
+from chatgpt_web_adapter import ChatGPTWebClient
+```
+
+The old `webchat_adapter` import should remain supported.
+
+### Phase 3 - Long-Term Compatibility
+
+Keep `webchat_adapter` as a compatibility import unless the maintenance cost becomes unreasonable.
+
+If removal is ever considered, it should require:
+
+- a release note;
+- a deprecation warning period;
+- a migration guide;
+- enough time for downstream users to update imports.
+
+## Out of Scope for the Current Milestone
+
+This plan does not rename the repository, package, distribution metadata, source directory, examples, or documentation imports.
+
+For now, use `webchat_adapter`.

--- a/tests/test_rename_compatibility_docs.py
+++ b/tests/test_rename_compatibility_docs.py
@@ -22,9 +22,9 @@ def test_rename_plan_is_explicitly_future_only() -> None:
     lower_text = text.lower()
 
     assert "the rename is planned for a future milestone" in lower_text
-    assert "only `webchat_adapter` exists" in text
-    assert "That future import is not available yet." in text
-    assert "For now, use `webchat_adapter`." in text
+    assert "only `webchat_adapter` exists" in lower_text
+    assert "that future import is not available yet." in lower_text
+    assert "for now, use `webchat_adapter`." in lower_text
 
 
 def test_readme_links_to_rename_compatibility_plan() -> None:

--- a/tests/test_rename_compatibility_docs.py
+++ b/tests/test_rename_compatibility_docs.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "rename_compatibility.md"
+README = ROOT / "README.md"
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def test_rename_compatibility_doc_exists_and_names_future_target() -> None:
+    text = DOC.read_text(encoding="utf-8")
+
+    assert "chatgpt-web-adapter" in text
+    assert "chatgpt_web_adapter" in text
+    assert "webchat_adapter" in text
+    assert "compatibility import" in text.lower()
+
+
+def test_rename_plan_is_explicitly_future_only() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    lower_text = text.lower()
+
+    assert "the rename is planned for a future milestone" in lower_text
+    assert "only `webchat_adapter` exists" in text
+    assert "That future import is not available yet." in text
+    assert "For now, use `webchat_adapter`." in text
+
+
+def test_readme_links_to_rename_compatibility_plan() -> None:
+    text = README.read_text(encoding="utf-8")
+
+    assert "docs/rename_compatibility.md" in text
+    assert "chatgpt-web-adapter" in text
+    assert "chatgpt_web_adapter" in text
+    assert "webchat_adapter" in text
+
+
+def test_package_metadata_is_not_renamed_yet() -> None:
+    text = PYPROJECT.read_text(encoding="utf-8")
+
+    assert 'name = "webchat-adapter"' in text
+    assert 'name = "chatgpt-web-adapter"' not in text


### PR DESCRIPTION
## Summary

- add `docs/rename_compatibility.md` with the planned future repo/package/import names
- document that `webchat_adapter` is the only supported import today
- define the future `webchat_adapter` compatibility-import policy after `chatgpt_web_adapter` exists
- link the plan from README without changing current import examples
- add docs tests that guard the future-only wording and ensure package metadata is not renamed yet

## Why

M7 should prepare the SDK for a future clearer name without breaking current users or implying that the future import path is already available.

## Out of scope

- no repository rename
- no package rename
- no `chatgpt_web_adapter` source package
- no example import changes
- no deprecation warnings

## Validation

- checked GitHub compare for the branch diff
- ran local `ast.parse` sanity check for `tests/test_rename_compatibility_docs.py`

I could not run the full test suite locally because this environment blocks direct GitHub cloning and does not have a local checkout of the repository.