### PR TITLE
PR7.4: Add Examples Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,18 @@ Other common APIs:
 - approve selected tool flows with `client.send_and_auto_approve(...)`
 - inspect request latency with [examples/diagnose_latency.py](examples/diagnose_latency.py)
 
+## Examples
+
+- [examples/basic_send.py](examples/basic_send.py) - send one prompt and print response metadata
+- [examples/continue_saved.py](examples/continue_saved.py) - save `ChatConversation` metadata and continue later
+- [examples/attach_existing.py](examples/attach_existing.py) - attach to an existing conversation URL or id
+- [examples/read_messages.py](examples/read_messages.py) - read messages from an existing conversation
+- [examples/status_polling.py](examples/status_polling.py) - poll conversation lifecycle status
+- [examples/approve_tools.py](examples/approve_tools.py) - approve pending tool actions after review
+- [examples/raw_payload.py](examples/raw_payload.py) - send an experimental raw web backend payload
+- [examples/diagnose_latency.py](examples/diagnose_latency.py) - print request and streaming diagnostics
+- [examples/github_auto_approve.py](examples/github_auto_approve.py) - specialized GitHub connector approval demo
+
 ## Experimental Features
 
 The SDK includes experimental browserless helpers for web-agent/tool approval flows:

--- a/examples/approve_tools.py
+++ b/examples/approve_tools.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Approve pending tool actions from a ChatGPT web conversation.
+
+This example approves pending tool actions. Review the target conversation before
+using it, and add your own allowlist checks for repositories, files, or actions.
+"""
+
+import argparse
+from typing import Any
+
+from webchat_adapter import ChatConversation, ChatGPTWebClient
+
+
+def print_event(event: dict[str, Any]) -> None:
+    event_type = event.get("type", "event")
+    if event_type == "assistant_token":
+        return
+    print(f"[event] {event_type}: {event}")
+
+
+def print_token(token: str) -> None:
+    print(token, end="", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Approve pending tool actions through an existing ChatGPT web session.",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--prompt", help="Send a prompt and auto-approve follow-up tool actions.")
+    mode.add_argument("--conversation", help="Watch an existing conversation URL or id for pending approvals.")
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--model", default="gpt-5-5-thinking")
+    parser.add_argument("--reasoning-effort", default="extended")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--pending-poll-interval", type=float, default=3.0)
+    parser.add_argument("--settle-delay", type=float, default=2.0)
+    parser.add_argument("--max-rounds", type=int, default=0)
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+
+    if args.prompt:
+        response = client.send_and_auto_approve(
+            args.prompt,
+            model=args.model,
+            reasoning_effort=args.reasoning_effort,
+            pending_poll_interval=args.pending_poll_interval,
+            settle_delay=args.settle_delay,
+            max_rounds=args.max_rounds,
+            on_token=print_token,
+            on_event=print_event,
+        )
+    else:
+        attached = client.attach_conversation(args.conversation)
+        response = client.wait_and_approve_pending_actions(
+            attached.conversation,
+            model=args.model,
+            reasoning_effort=args.reasoning_effort,
+            pending_poll_interval=args.pending_poll_interval,
+            settle_delay=args.settle_delay,
+            max_rounds=args.max_rounds,
+            on_token=print_token,
+            on_event=print_event,
+        )
+
+    print()
+    print("conversation_id:", response.conversation.conversation_id)
+    print("message_id:", response.conversation.message_id)
+    print(response.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/attach_existing.py
+++ b/examples/attach_existing.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import argparse
+
+from webchat_adapter import ChatGPTWebClient
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Attach to an existing ChatGPT web conversation by URL or id.",
+    )
+    parser.add_argument("conversation", help="ChatGPT conversation URL or raw conversation id")
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--timeout", type=int, default=120)
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    attached = client.attach_conversation(args.conversation)
+
+    print("conversation_id:", attached.conversation_id)
+    print("current_node:", attached.current_node)
+    print("detected_model:", attached.detected_model)
+    print("title:", attached.title)
+    print("message_id:", attached.conversation.message_id)
+    print("finish_reason:", attached.conversation.finish_reason)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/basic_send.py
+++ b/examples/basic_send.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import argparse
+
+from webchat_adapter import ChatGPTWebClient
+
+
+DEFAULT_PROMPT = "Reply with one short sentence and nothing else."
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Send one prompt through a ChatGPT web session.")
+    parser.add_argument("prompt", nargs="?", default=DEFAULT_PROMPT)
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--model", default="gpt-4o-mini")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--no-stream", action="store_true")
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    tokens: list[str] = []
+
+    def on_token(token: str) -> None:
+        tokens.append(token)
+        if not args.no_stream:
+            print(token, end="", flush=True)
+
+    response = client.send(
+        args.prompt,
+        model=args.model,
+        on_token=on_token,
+    )
+
+    if not args.no_stream:
+        print()
+
+    print("text:", response.text)
+    print("conversation_id:", response.conversation.conversation_id)
+    print("message_id:", response.conversation.message_id)
+    print("total_latency:", response.metrics.total)
+    print("tokens_seen:", len(tokens))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/continue_saved.py
+++ b/examples/continue_saved.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from webchat_adapter import ChatConversation, ChatGPTWebClient
+
+
+DEFAULT_FIRST_PROMPT = "Start a short conversation about SQLite."
+DEFAULT_FOLLOW_UP = "Continue from the saved conversation and compare it with PostgreSQL."
+
+
+def _load_conversation(path: Path) -> ChatConversation | None:
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return ChatConversation.from_dict(payload)
+
+
+def _save_conversation(path: Path, conversation: ChatConversation) -> None:
+    path.write_text(
+        json.dumps(conversation.to_dict(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Save ChatConversation metadata and continue it later.",
+    )
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--model", default="gpt-4o-mini")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--state-file", default="conversation_state.json")
+    parser.add_argument("--first-prompt", default=DEFAULT_FIRST_PROMPT)
+    parser.add_argument("--follow-up", default=DEFAULT_FOLLOW_UP)
+    parser.add_argument("--reset", action="store_true", help="Ignore any existing state file.")
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    state_path = Path(args.state_file)
+    conversation = None if args.reset else _load_conversation(state_path)
+
+    if conversation is None:
+        first = client.send(args.first_prompt, model=args.model)
+        conversation = first.conversation
+        _save_conversation(state_path, conversation)
+        print("started conversation")
+        print("conversation_id:", conversation.conversation_id)
+        print("message_id:", conversation.message_id)
+        print(first.text)
+
+    follow_up = client.send(
+        args.follow_up,
+        model=args.model,
+        conversation=conversation,
+    )
+    _save_conversation(state_path, follow_up.conversation)
+
+    print("continued conversation")
+    print("conversation_id:", follow_up.conversation.conversation_id)
+    print("message_id:", follow_up.conversation.message_id)
+    print(follow_up.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/raw_payload.py
+++ b/examples/raw_payload.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Experimental raw ChatGPT web backend payload example.
+
+Not the official OpenAI API. Web backend behavior may change. This creates real
+ChatGPT web messages in the account behind your existing web-session auth data.
+"""
+
+import argparse
+from typing import Any
+
+from webchat_adapter import ChatGPTWebClient, PayloadBuilder, validate_payload
+
+
+DEFAULT_PROMPT = "Reply with one short sentence from a raw payload."
+
+
+def print_event(event: dict[str, Any]) -> None:
+    event_type = event.get("type", "event")
+    if event_type == "assistant_token":
+        return
+    print(f"[event] {event_type}: {event}")
+
+
+def print_token(token: str) -> None:
+    print(token, end="", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Send an experimental raw ChatGPT web backend payload.",
+    )
+    parser.add_argument("prompt", nargs="?", default=DEFAULT_PROMPT)
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--model", default="gpt-4o-mini")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--temporary", action="store_true")
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    payload = PayloadBuilder.new_chat(
+        args.prompt,
+        model=args.model,
+        temporary=args.temporary,
+    )
+    validate_payload(payload)
+
+    response = client.send_payload(
+        payload,
+        on_token=print_token,
+        on_event=print_event,
+    )
+
+    print()
+    print("conversation_id:", response.conversation.conversation_id)
+    print("message_id:", response.conversation.message_id)
+    print(response.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/read_messages.py
+++ b/examples/read_messages.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+
+from webchat_adapter import ChatGPTWebClient
+
+
+def _preview(text: str, *, max_chars: int = 500) -> str:
+    text = text.strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3] + "..."
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Read messages from the current branch of a ChatGPT web conversation.",
+    )
+    parser.add_argument("conversation", help="ChatGPT conversation URL or raw conversation id")
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--role", action="append", dest="roles")
+    parser.add_argument("--include-empty", action="store_true")
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    messages = client.get_messages(
+        args.conversation,
+        limit=args.limit,
+        roles=args.roles,
+        include_empty=args.include_empty,
+    )
+
+    print("message_count:", len(messages))
+    for message in messages:
+        print("---")
+        print("role:", message.role)
+        print("message_id:", message.message_id)
+        print("node_id:", message.node_id)
+        print("model:", message.model)
+        print("finish_reason:", message.finish_reason)
+        print(_preview(message.text))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/status_polling.py
+++ b/examples/status_polling.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import time
+
+from webchat_adapter import ChatGPTWebClient
+
+TERMINAL_STATUSES = {"completed", "awaiting_tool_approval", "user_last_message"}
+
+
+def _print_status(client: ChatGPTWebClient, conversation: str) -> str:
+    status = client.get_status(conversation)
+    approval = client.get_pending_approval(conversation)
+
+    print("status:", status.status)
+    print("node_id:", status.node_id)
+    print("message_id:", status.message_id)
+    print("role:", status.role)
+    print("recipient:", status.recipient)
+    print("async_status:", status.async_status)
+    print("finish_reason:", status.finish_reason)
+    print("pending_approval:", status.pending_approval)
+
+    if approval is not None:
+        print("approval_tool_message_id:", approval.tool_message_id)
+        print("approval_target_message_id:", approval.target_message_id)
+        print("approval_recipient:", approval.recipient)
+
+    return status.status
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Poll the lifecycle status of an existing ChatGPT web conversation.",
+    )
+    parser.add_argument("conversation", help="ChatGPT conversation URL or raw conversation id")
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--interval", type=float, default=2.0)
+    parser.add_argument("--max-polls", type=int, default=30)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    polls = 1 if args.once else max(1, args.max_polls)
+
+    for index in range(polls):
+        print("poll:", index + 1)
+        status = _print_status(client, args.conversation)
+        if args.once or status in TERMINAL_STATUSES:
+            break
+        time.sleep(max(0.1, args.interval))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_examples_pack.py
+++ b/tests/test_examples_pack.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import py_compile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "examples"
+README = ROOT / "README.md"
+
+REQUIRED_EXAMPLES = [
+    "basic_send.py",
+    "continue_saved.py",
+    "attach_existing.py",
+    "read_messages.py",
+    "status_polling.py",
+    "approve_tools.py",
+    "raw_payload.py",
+]
+
+
+def test_examples_pack_files_exist() -> None:
+    for filename in REQUIRED_EXAMPLES:
+        assert (EXAMPLES / filename).is_file()
+
+
+def test_examples_compile() -> None:
+    for path in sorted(EXAMPLES.glob("*.py")):
+        py_compile.compile(str(path), doraise=True)
+
+
+def test_required_examples_use_script_entrypoint() -> None:
+    for filename in REQUIRED_EXAMPLES:
+        text = (EXAMPLES / filename).read_text(encoding="utf-8")
+
+        assert "def main() -> None:" in text
+        assert 'if __name__ == "__main__":' in text
+        assert "main()" in text
+
+
+def test_examples_use_public_package_imports_only() -> None:
+    for path in sorted(EXAMPLES.glob("*.py")):
+        text = path.read_text(encoding="utf-8")
+
+        assert "from webchat_adapter." not in text
+        assert "import webchat_adapter." not in text
+
+
+def test_dangerous_examples_warn_about_risk() -> None:
+    approve_text = (EXAMPLES / "approve_tools.py").read_text(encoding="utf-8").lower()
+    raw_payload_text = (EXAMPLES / "raw_payload.py").read_text(encoding="utf-8").lower()
+
+    assert "approves pending tool actions" in approve_text
+    assert "review the target conversation" in approve_text
+    assert "not the official openai api" in raw_payload_text
+    assert "web backend behavior may change" in raw_payload_text
+    assert "creates real" in raw_payload_text
+
+
+def test_readme_links_to_examples_pack() -> None:
+    text = README.read_text(encoding="utf-8")
+
+    for filename in REQUIRED_EXAMPLES:
+        assert f"examples/{filename}" in text


### PR DESCRIPTION
## Summary

- add seven runnable public API examples:
  - `examples/basic_send.py`
  - `examples/continue_saved.py`
  - `examples/attach_existing.py`
  - `examples/read_messages.py`
  - `examples/status_polling.py`
  - `examples/approve_tools.py`
  - `examples/raw_payload.py`
- link the examples pack from README while keeping existing diagnostics and GitHub approval examples
- add `tests/test_examples_pack.py` to check required files, compile all examples, enforce public imports, require script entrypoints, and preserve warnings for approval/raw payload examples

## Why

PR7.4 turns the M7 public API cleanup into practical runnable documentation. A new user can now start from basic send, continue saved conversations, attach/read/status existing chats, inspect approvals, and see the raw payload escape hatch without reading internal modules.

## Notes

The approval and raw payload examples include explicit warnings because they can approve real tool actions or create real ChatGPT web messages through the account behind the existing web-session auth data.

## Validation

- checked GitHub compare for the branch diff
- inspected the high-risk examples and examples smoke test through the GitHub connector
- attempted to download the branch zip for local `py_compile`, but GitHub codeload returned `403 Forbidden` in this environment

Full validation is covered by the added CI test, which compiles all examples and checks the examples pack contract.