### PR TITLE
PR7.5: Align repository metadata after rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+- docs: aligned repository metadata after the `chatgpt-web-adapter` rename
 - docs: defined stable vs experimental SDK surface and compatibility policy
 - docs: clarified approval helpers as experimental and unstable
 - docs: added SDK positioning, failure model, live smoke checklist, release checklist, architecture notes, and build-on-top guidance

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# webchat-adapter
+# chatgpt-web-adapter
 
-[![CI](https://github.com/kymuco/webchat-adapter/actions/workflows/ci.yml/badge.svg)](https://github.com/kymuco/webchat-adapter/actions/workflows/ci.yml)
+[![CI](https://github.com/kymuco/chatgpt-web-adapter/actions/workflows/ci.yml/badge.svg)](https://github.com/kymuco/chatgpt-web-adapter/actions/workflows/ci.yml)
 
 Python SDK for controlling existing ChatGPT web sessions without browser UI.
 
@@ -10,6 +10,8 @@ Python SDK for controlling existing ChatGPT web sessions without browser UI.
 > Web backend behavior may change.
 
 `webchat-adapter` is a small, dependency-free Python SDK for sending prompts, continuing conversations, reading conversation state, uploading images, and handling selected ChatGPT web workflows from Python.
+
+The repository is named `chatgpt-web-adapter`; the current distribution package and Python import path remain `webchat-adapter` and `webchat_adapter` until the planned package/import rename.
 
 It is designed for tools that already have valid ChatGPT web-session auth data and want to avoid driving the browser UI.
 
@@ -278,9 +280,9 @@ Operational docs:
 - [docs/architecture.md](docs/architecture.md)
 - [docs/building_on_top.md](docs/building_on_top.md)
 
-## Future Rename
+## Future Package Rename
 
-The project may later move to the clearer name `chatgpt-web-adapter`, with Python package import `chatgpt_web_adapter`.
+The repository is already named `chatgpt-web-adapter`. The Python distribution package and import package may later move to `chatgpt-web-adapter` and `chatgpt_web_adapter`.
 
 The current `webchat_adapter` import remains the only supported import today. See [docs/rename_compatibility.md](docs/rename_compatibility.md).
 

--- a/docs/rename_compatibility.md
+++ b/docs/rename_compatibility.md
@@ -1,14 +1,14 @@
 # Rename Compatibility Plan
 
-This project may later move to the clearer public name `chatgpt-web-adapter`, with the Python import package `chatgpt_web_adapter`.
+The repository is now named `chatgpt-web-adapter`. The Python distribution package and import package have not been renamed yet.
 
-The rename is planned for a future milestone. It is not implemented today.
+This document tracks the remaining package/import rename plan and the compatibility policy for the existing `webchat_adapter` import.
 
 ## Current Name
 
-Today, only the current package exists:
+Today, the repository has the new public name, while the install/import surface remains unchanged:
 
-- Repository: `webchat-adapter`
+- Repository: `chatgpt-web-adapter`
 - Distribution package: `webchat-adapter`
 - Python import package: `webchat_adapter`
 
@@ -20,7 +20,7 @@ from webchat_adapter import ChatGPTWebClient
 
 ## Future Name
 
-The future naming target is:
+The future package naming target is:
 
 - Repository: `chatgpt-web-adapter`
 - Distribution package: `chatgpt-web-adapter`
@@ -36,7 +36,7 @@ That future import is not available yet.
 
 ## Compatibility Import
 
-The existing `webchat_adapter` import path will remain the compatibility import after the future rename:
+The existing `webchat_adapter` import path will remain the compatibility import after the future package/import rename:
 
 ```python
 from webchat_adapter import ChatGPTWebClient
@@ -46,8 +46,8 @@ The compatibility import should remain available for multiple minor releases aft
 
 ## Policy
 
-- Do not rename before the SDK has enough user-facing value.
-- Do not rename before the early value milestones are complete.
+- Do not rename the distribution package or import package before the SDK has enough user-facing value.
+- Do not rename the distribution package or import package before the early value milestones are complete.
 - Keep `webchat_adapter` as the old compatibility import after the future rename.
 - Do not remove `webchat_adapter` without a documented deprecation period.
 - Do not add deprecation warnings until `chatgpt_web_adapter` exists and migration is actually possible.
@@ -57,7 +57,7 @@ The compatibility import should remain available for multiple minor releases aft
 
 ### Phase 0 - Current
 
-Only `webchat_adapter` exists. Documentation and examples must continue to use:
+The repository is already `chatgpt-web-adapter`, but only `webchat_adapter` exists as an import package. Documentation and examples must continue to use:
 
 ```python
 from webchat_adapter import ChatGPTWebClient
@@ -65,7 +65,7 @@ from webchat_adapter import ChatGPTWebClient
 
 ### Phase 1 - Dual Import
 
-After the future rename package is introduced, both imports should work:
+After the future import package is introduced, both imports should work:
 
 ```python
 from chatgpt_web_adapter import ChatGPTWebClient
@@ -97,6 +97,6 @@ If removal is ever considered, it should require:
 
 ## Out of Scope for the Current Milestone
 
-This plan does not rename the repository, package, distribution metadata, source directory, examples, or documentation imports.
+This plan does not rename the distribution package, source directory, examples, documentation imports, or Python import package.
 
 For now, use `webchat_adapter`.

--- a/docs/rename_compatibility.md
+++ b/docs/rename_compatibility.md
@@ -2,6 +2,8 @@
 
 The repository is now named `chatgpt-web-adapter`. The Python distribution package and import package have not been renamed yet.
 
+The rename is planned for a future milestone. In this document, "the rename" now means the remaining distribution package and Python import package rename, not the already-completed repository rename.
+
 This document tracks the remaining package/import rename plan and the compatibility policy for the existing `webchat_adapter` import.
 
 ## Current Name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 keywords = ["chatgpt", "adapter", "sdk", "webchat"]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3:: Only",
+  "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 keywords = ["chatgpt", "adapter", "sdk", "webchat"]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3:: Only",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -27,10 +27,10 @@ classifiers = [
 dependencies = []
 
 [project.urls]
-Homepage = "https://github.com/kymuco/webchat-adapter"
-Repository = "https://github.com/kymuco/webchat-adapter"
-Issues = "https://github.com/kymuco/webchat-adapter/issues"
-Changelog = "https://github.com/kymuco/webchat-adapter/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/kymuco/chatgpt-web-adapter"
+Repository = "https://github.com/kymuco/chatgpt-web-adapter"
+Issues = "https://github.com/kymuco/chatgpt-web-adapter/issues"
+Changelog = "https://github.com/kymuco/chatgpt-web-adapter/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 test = ["pytest>=8"]


### PR DESCRIPTION
## Summary

- Update README title and CI badge to use the new `chatgpt-web-adapter` repository slug.
- Update package metadata URLs in `pyproject.toml` to point at `kymuco/chatgpt-web-adapter`.
- Refresh `docs/rename_compatibility.md` to reflect that only the repository has been renamed so far.
- Add an Unreleased changelog note for the metadata/docs alignment.

## Compatibility

- Keeps the distribution package name as `webchat-adapter`.
- Keeps the supported Python import as `webchat_adapter`.
- Does not introduce `chatgpt_web_adapter` yet.
- Does not change runtime behavior.

## Tests

Not run locally from this environment. This PR only changes docs/package metadata; CI runs the full test/build matrix.