### PR TITLE
PR5 — detect required connector action states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+- feat: added experimental required-action detection for connector OAuth/linking cards such as Gmail connect prompts
+
 ## 0.1.4 - 2026-06-24
 
 - breaking: renamed the canonical Python import package to `chatgpt_web_adapter` and removed the old `webchat_adapter` import path

--- a/docs/required_actions.md
+++ b/docs/required_actions.md
@@ -1,0 +1,58 @@
+# Required Actions
+
+ChatGPT web can stop a conversation on UI-only cards that are not normal assistant text and are not browserless tool approvals.
+
+The first supported case is connector OAuth/linking, for example asking a conversation to use Gmail before Gmail is connected. The ChatGPT web UI renders this as a card such as "Connect Gmail" / "Not now". In the raw conversation payload this appears as `jit_plugin_data.from_server.type = "oauth_required"`.
+
+Without explicit detection, SDK consumers can see an empty response or a conversation that appears to stop unexpectedly.
+
+## Inspect a Conversation
+
+Use `get_required_action()` after a send or when inspecting an existing conversation:
+
+```python
+from chatgpt_web_adapter import ChatGPTWebClient
+
+client = ChatGPTWebClient(auth_file="auth_data.json")
+
+response = client.send("What is my latest Gmail message?")
+
+if response.conversation.conversation_id:
+    action = client.get_required_action(response.conversation)
+    if action is not None:
+        print(f"required action: {action.type}")
+        print(f"reason: {action.reason}")
+        print(f"path: {action.path}")
+```
+
+For a Gmail connector that is not linked yet, the action may look like:
+
+```python
+RequiredAction(
+    type="oauth_required",
+    reason="missing_link",
+    connector_id="connector_...",
+    path="/connector_.../search_emails",
+    actions=("oauth_redirect", "deny"),
+)
+```
+
+## What This Does Not Do
+
+`get_required_action()` does not connect Gmail, follow OAuth redirects, or click approval buttons. It only exposes the pending UI state so applications can tell the user what happened.
+
+For CLI tools, the recommended behavior is to print a clear message such as:
+
+```text
+The conversation requires connecting Gmail in ChatGPT web.
+Open the conversation in the browser and click Connect Gmail, or ask again without Gmail.
+```
+
+## Relationship to Tool Approvals
+
+`RequiredAction` is separate from `PendingApproval`.
+
+- `PendingApproval` describes tool execution cards that may be approved browserlessly with experimental approval helpers.
+- `RequiredAction` describes UI-only states such as connector OAuth/linking that currently require user action in the web UI.
+
+This surface is experimental because connector card payloads are undocumented and can change with ChatGPT web behavior.

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -25,6 +25,8 @@ from .policy_approval import approve_pending_action as _policy_approve_pending_a
 from .policy_approval import send_and_auto_approve as _policy_send_and_auto_approve
 from .policy_approval import wait_and_approve_pending_actions as _policy_wait_and_approve_pending_actions
 from .raw_payload import send_payload as _send_payload
+from .required_action import RequiredAction, find_required_action
+from .required_action import get_required_action as _get_required_action
 from .status import get_pending_approval as _get_pending_approval
 from .status import get_status as _get_status
 from .types import (
@@ -54,6 +56,7 @@ ChatGPTWebClient.attach_conversation = _attach_conversation
 ChatGPTWebClient.export_conversation = _export_conversation
 ChatGPTWebClient.get_messages = _get_messages
 ChatGPTWebClient.get_pending_approval = _get_pending_approval
+ChatGPTWebClient.get_required_action = _get_required_action
 ChatGPTWebClient.get_status = _get_status
 ChatGPTWebClient.send = _send_with_expanded_metrics(_original_send)
 ChatGPTWebClient.send_and_auto_approve = _policy_send_and_auto_approve(
@@ -107,6 +110,11 @@ EXPERIMENTAL_APPROVAL_EXPORTS = [
     "ApprovalRound",
 ]
 
+EXPERIMENTAL_REQUIRED_ACTION_EXPORTS = [
+    "RequiredAction",
+    "find_required_action",
+]
+
 EXPERIMENTAL_RAW_PAYLOAD_EXPORTS = [
     "PayloadBuilder",
     "validate_payload",
@@ -124,6 +132,7 @@ __all__ = [
     *ADVANCED_HELPERS,
     *MEDIA_EXPORTS,
     *EXPERIMENTAL_APPROVAL_EXPORTS,
+    *EXPERIMENTAL_REQUIRED_ACTION_EXPORTS,
     *EXPERIMENTAL_RAW_PAYLOAD_EXPORTS,
     *SUPPORT_EXPORTS,
 ]

--- a/src/chatgpt_web_adapter/required_action.py
+++ b/src/chatgpt_web_adapter/required_action.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .types import ChatConversation, ConversationRef
+
+REQUIRED_ACTION_TYPES = {
+    "oauth_required",
+}
+
+
+def _optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+@dataclass(frozen=True)
+class RequiredAction:
+    """Action that must be completed outside the text stream.
+
+    ChatGPT web can stop on UI-only cards such as connector OAuth prompts. Those
+    states are not normal assistant text and are not tool approvals that can be
+    allowed browserlessly. This descriptor exposes the card metadata so CLI and
+    SDK consumers can surface a clear next step instead of treating the response
+    as empty.
+    """
+
+    type: str
+    tool_message_id: str
+    reason: str | None = None
+    connector_id: str | None = None
+    domain: str | None = None
+    path: str | None = None
+    target_message_id: str | None = None
+    actions: tuple[str, ...] = field(default_factory=tuple)
+    is_consequential: bool | None = None
+    is_read_only: bool | None = None
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "RequiredAction | None":
+        if not isinstance(payload, dict):
+            return None
+        action_type = _optional_str(payload.get("type"))
+        tool_message_id = _optional_str(payload.get("tool_message_id"))
+        if action_type is None or tool_message_id is None:
+            return None
+        raw_actions = payload.get("actions")
+        actions: tuple[str, ...] = ()
+        if isinstance(raw_actions, (list, tuple)):
+            actions = tuple(
+                item for item in (_optional_str(value) for value in raw_actions) if item
+            )
+        return cls(
+            type=action_type,
+            tool_message_id=tool_message_id,
+            reason=_optional_str(payload.get("reason")),
+            connector_id=_optional_str(payload.get("connector_id")),
+            domain=_optional_str(payload.get("domain")),
+            path=_optional_str(payload.get("path")),
+            target_message_id=_optional_str(payload.get("target_message_id")),
+            actions=actions,
+            is_consequential=payload.get("is_consequential")
+            if isinstance(payload.get("is_consequential"), bool)
+            else None,
+            is_read_only=payload.get("is_read_only")
+            if isinstance(payload.get("is_read_only"), bool)
+            else None,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "tool_message_id": self.tool_message_id,
+            "reason": self.reason,
+            "connector_id": self.connector_id,
+            "domain": self.domain,
+            "path": self.path,
+            "target_message_id": self.target_message_id,
+            "actions": list(self.actions),
+            "is_consequential": self.is_consequential,
+            "is_read_only": self.is_read_only,
+        }
+
+
+def _conversation_mapping(payload: dict[str, Any]) -> dict[str, Any]:
+    mapping = payload.get("mapping")
+    return mapping if isinstance(mapping, dict) else {}
+
+
+def _current_branch_nodes(payload: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    mapping = _conversation_mapping(payload)
+    node_id = _optional_str(payload.get("current_node"))
+    branch: list[tuple[str, dict[str, Any]]] = []
+    seen: set[str] = set()
+
+    while node_id:
+        if node_id in seen:
+            break
+        seen.add(node_id)
+        node = mapping.get(node_id)
+        if not isinstance(node, dict):
+            break
+        branch.append((node_id, node))
+        node_id = _optional_str(node.get("parent"))
+
+    branch.reverse()
+    return branch
+
+
+def _message_from_node(node: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(node, dict):
+        return None
+    message = node.get("message")
+    return message if isinstance(message, dict) else None
+
+
+def _message_role(message: dict[str, Any] | None) -> str | None:
+    if not isinstance(message, dict):
+        return None
+    author = message.get("author")
+    if not isinstance(author, dict):
+        return None
+    return _optional_str(author.get("role"))
+
+
+def _message_metadata(message: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(message, dict):
+        return {}
+    metadata = message.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _action_types(actions: Any) -> tuple[str, ...]:
+    if not isinstance(actions, list):
+        return ()
+    result: list[str] = []
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        action_type = _optional_str(action.get("type"))
+        if action_type:
+            result.append(action_type)
+    return tuple(result)
+
+
+def _target_message_id(actions: Any) -> str | None:
+    if not isinstance(actions, list):
+        return None
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        for key in ("oauth_redirect", "deny", "allow"):
+            block = action.get(key)
+            if not isinstance(block, dict):
+                continue
+            target_message_id = _optional_str(block.get("target_message_id"))
+            if target_message_id:
+                return target_message_id
+    return None
+
+
+def _required_action_from_message(message: dict[str, Any]) -> RequiredAction | None:
+    if _message_role(message) != "tool":
+        return None
+    tool_message_id = _optional_str(message.get("id"))
+    if tool_message_id is None:
+        return None
+
+    jit_plugin_data = _message_metadata(message).get("jit_plugin_data")
+    if not isinstance(jit_plugin_data, dict):
+        return None
+    from_server = jit_plugin_data.get("from_server")
+    if not isinstance(from_server, dict):
+        return None
+    action_type = _optional_str(from_server.get("type"))
+    if action_type not in REQUIRED_ACTION_TYPES:
+        return None
+
+    body = from_server.get("body")
+    if not isinstance(body, dict):
+        body = {}
+    actions = body.get("actions")
+    params = body.get("params")
+    if not isinstance(params, dict):
+        params = {}
+
+    return RequiredAction(
+        type=action_type,
+        tool_message_id=tool_message_id,
+        reason=_optional_str(body.get("auth_reason")),
+        connector_id=_optional_str(body.get("connector_id")),
+        domain=_optional_str(body.get("domain")),
+        path=_optional_str(params.get("path")) or _optional_str(body.get("path")),
+        target_message_id=_target_message_id(actions),
+        actions=_action_types(actions),
+        is_consequential=body.get("is_consequential")
+        if isinstance(body.get("is_consequential"), bool)
+        else None,
+        is_read_only=body.get("is_read_only")
+        if isinstance(body.get("is_read_only"), bool)
+        else None,
+    )
+
+
+def find_required_action(payload: dict[str, Any]) -> RequiredAction | None:
+    """Return the latest required UI action from a conversation payload."""
+
+    candidates: list[tuple[float, RequiredAction]] = []
+    for _node_id, node in _current_branch_nodes(payload):
+        message = _message_from_node(node)
+        if not isinstance(message, dict):
+            continue
+        required_action = _required_action_from_message(message)
+        if required_action is None:
+            continue
+        create_time = message.get("create_time")
+        try:
+            sortable_create_time = float(create_time or 0)
+        except (TypeError, ValueError):
+            sortable_create_time = 0.0
+        candidates.append((sortable_create_time, required_action))
+    if not candidates:
+        return None
+    _create_time, required_action = max(candidates, key=lambda item: item[0])
+    return required_action
+
+
+def get_required_action(
+    self: Any,
+    url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
+) -> RequiredAction | None:
+    """Inspect a conversation for a pending non-text UI action.
+
+    This is primarily for connector OAuth/linking cards, for example a Gmail
+    connect prompt. It does not perform the action; it only exposes the state so
+    callers can tell the user what happened.
+    """
+
+    ref = ConversationRef.from_any(url_or_id)
+    payload = self._get_conversation_payload(ref.conversation_id)
+    if not isinstance(payload, dict):
+        return None
+    return find_required_action(payload)

--- a/tests/test_required_action.py
+++ b/tests/test_required_action.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Any
+
+import chatgpt_web_adapter as adapter
+
+
+def _oauth_required_payload() -> dict[str, Any]:
+    return {
+        "conversation_id": "conv-123",
+        "current_node": "tool-oauth",
+        "mapping": {
+            "user-1": {
+                "parent": None,
+                "children": ["assistant-tool-call"],
+                "message": {
+                    "id": "user-1",
+                    "author": {"role": "user"},
+                    "content": {"content_type": "text", "parts": ["check my latest email"]},
+                },
+            },
+            "assistant-tool-call": {
+                "parent": "user-1",
+                "children": ["tool-oauth"],
+                "message": {
+                    "id": "assistant-tool-call",
+                    "author": {"role": "assistant"},
+                    "recipient": "api_tool.call_tool",
+                    "content": {"content_type": "code", "text": "{}"},
+                },
+            },
+            "tool-oauth": {
+                "parent": "assistant-tool-call",
+                "children": [],
+                "message": {
+                    "id": "tool-oauth",
+                    "author": {"role": "tool", "name": "api_tool.call_tool"},
+                    "recipient": "assistant",
+                    "create_time": 1782289694.5,
+                    "content": {
+                        "content_type": "text",
+                        "parts": [
+                            "The user has not logged into this tool. Eliciting user login."
+                        ],
+                    },
+                    "metadata": {
+                        "jit_plugin_data": {
+                            "from_server": {
+                                "type": "oauth_required",
+                                "body": {
+                                    "actions": [
+                                        {
+                                            "type": "oauth_redirect",
+                                            "oauth_redirect": {
+                                                "connector_id": "connector-gmail",
+                                                "domain": "call_tool",
+                                                "gizmo_action_id": "call_tool",
+                                                "gizmo_id": "FAKE_CONNECTOR_GIZMO",
+                                                "target_message_id": "assistant-tool-call",
+                                            },
+                                        },
+                                        {
+                                            "type": "deny",
+                                            "name": "deny",
+                                            "style": "secondary",
+                                            "deny": {
+                                                "target_message_id": "assistant-tool-call"
+                                            },
+                                        },
+                                    ],
+                                    "auth_reason": "missing_link",
+                                    "connector_id": "connector-gmail",
+                                    "domain": "call_tool",
+                                    "is_consequential": True,
+                                    "is_read_only": None,
+                                    "params": {
+                                        "args": {"max_results": 1, "query": ""},
+                                        "path": "/connector-gmail/search_emails",
+                                    },
+                                },
+                            }
+                        }
+                    },
+                },
+            },
+        },
+    }
+
+
+def test_find_required_action_detects_oauth_required_connector_card() -> None:
+    action = adapter.find_required_action(_oauth_required_payload())
+
+    assert action is not None
+    assert action.type == "oauth_required"
+    assert action.tool_message_id == "tool-oauth"
+    assert action.reason == "missing_link"
+    assert action.connector_id == "connector-gmail"
+    assert action.domain == "call_tool"
+    assert action.path == "/connector-gmail/search_emails"
+    assert action.target_message_id == "assistant-tool-call"
+    assert action.actions == ("oauth_redirect", "deny")
+    assert action.is_consequential is True
+    assert action.is_read_only is None
+
+
+def test_required_action_roundtrips_dict() -> None:
+    action = adapter.find_required_action(_oauth_required_payload())
+    assert action is not None
+
+    restored = adapter.RequiredAction.from_dict(action.to_dict())
+
+    assert restored == action
+
+
+def test_find_required_action_ignores_confirm_action_approvals() -> None:
+    payload = _oauth_required_payload()
+    tool_message = payload["mapping"]["tool-oauth"]["message"]
+    tool_message["metadata"]["jit_plugin_data"]["from_server"] = {
+        "type": "confirm_action",
+        "body": {
+            "actions": [
+                {
+                    "type": "allow",
+                    "allow": {"target_message_id": "assistant-tool-call"},
+                }
+            ]
+        },
+    }
+
+    assert adapter.find_required_action(payload) is None
+
+
+def test_client_get_required_action_fetches_conversation_payload(monkeypatch) -> None:
+    client = object.__new__(adapter.ChatGPTWebClient)
+    seen: list[str] = []
+
+    def fake_get_conversation_payload(conversation_id: str) -> dict[str, Any]:
+        seen.append(conversation_id)
+        return _oauth_required_payload()
+
+    monkeypatch.setattr(client, "_get_conversation_payload", fake_get_conversation_payload)
+
+    action = client.get_required_action("https://chatgpt.com/c/conv-123")
+
+    assert seen == ["conv-123"]
+    assert action is not None
+    assert action.type == "oauth_required"


### PR DESCRIPTION
## Summary

Adds experimental required-action detection for ChatGPT web connector cards that are not normal assistant text and are not browserless tool approvals.

This targets the real Gmail case where the conversation stops on an OAuth/linking card (`oauth_required`, `auth_reason=missing_link`) and the terminal currently sees an empty or confusing result.

## Changes

- add `RequiredAction` descriptor
- add `find_required_action(payload)` for raw conversation payloads
- add `client.get_required_action(...)` for existing conversations
- detect `jit_plugin_data.from_server.type = "oauth_required"`
- extract connector/action metadata such as `reason`, `connector_id`, `path`, `target_message_id`, and action types
- document required actions in `docs/required_actions.md`
- add tests using a live-like Gmail OAuth payload shape

## Notes

This PR deliberately does not try to complete OAuth or click the web UI card from the SDK. It only exposes the state so CLI/app consumers can show a clear next step.

A follow-up `gptty` PR can use `client.get_required_action(response.conversation)` to print a terminal message like: open the ChatGPT conversation and connect Gmail, or retry without that connector.

## Validation

GitHub Actions should run the existing test matrix plus the new required-action tests.