### PR TITLE
PR6 — release 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+## 0.1.5 - 2026-06-24
+
 - feat: added experimental required-action detection for connector OAuth/linking cards such as Gmail connect prompts
+- docs: documented required-action handling and its distinction from browserless tool approvals
 
 ## 0.1.4 - 2026-06-24
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatgpt-web-adapter"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python SDK for controlling existing ChatGPT web sessions without browser UI."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Prepares `chatgpt-web-adapter` 0.1.5 for release.

## Changes
- bump package version to `0.1.5`
- move required-action detection entry from `Unreleased` into the `0.1.5` changelog section
- document that this release contains connector OAuth/linking detection, e.g. Gmail connect prompts

## Validation
GitHub Actions should run the full test matrix and package build.

No runtime code changes are included here; the required-action implementation landed in the previous merged PR.