### PR TITLE
PR7.7: Add live conversation watcher and stream handoff diagnostics

### DIFF
--- a/src/chatgpt_web_adapter/attach.py
+++ b/src/chatgpt_web_adapter/attach.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from .model_detection import detect_model_from_conversation_payload
+from .model_detection import (
+    detect_model_from_conversation_payload,
+    detect_reasoning_effort_from_conversation_payload,
+)
 from .types import AttachedConversation, ChatConversation, ConversationRef
 
 
@@ -65,4 +68,5 @@ def attach_conversation(
         payload,
         conversation=conversation,
         detected_model=detect_model_from_conversation_payload(payload),
+        detected_reasoning_effort=detect_reasoning_effort_from_conversation_payload(payload),
     )

--- a/src/chatgpt_web_adapter/conversation_send.py
+++ b/src/chatgpt_web_adapter/conversation_send.py
@@ -19,6 +19,22 @@ def _resolve_send_model(
     return DEFAULT_MODEL
 
 
+def _resolve_reasoning_effort(
+    *,
+    attached: AttachedConversation,
+    preserve_model: bool,
+    model: str | None,
+    reasoning_effort: str | None,
+) -> str | None:
+    if reasoning_effort is not None:
+        return reasoning_effort
+    if model is not None:
+        return None
+    if preserve_model and attached.detected_model and attached.detected_reasoning_effort:
+        return attached.detected_reasoning_effort
+    return None
+
+
 def send_to_conversation(
     self: Any,
     url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
@@ -41,13 +57,19 @@ def send_to_conversation(
         preserve_model=preserve_model,
         model=model,
     )
+    resolved_reasoning_effort = _resolve_reasoning_effort(
+        attached=attached,
+        preserve_model=preserve_model,
+        model=model,
+        reasoning_effort=reasoning_effort,
+    )
     return self.send(
         prompt,
         model=resolved_model,
         system=system,
         web_search=web_search,
         temporary=temporary,
-        reasoning_effort=reasoning_effort,
+        reasoning_effort=resolved_reasoning_effort,
         conversation=attached.conversation,
         media=media,
         on_token=on_token,

--- a/src/chatgpt_web_adapter/model_detection.py
+++ b/src/chatgpt_web_adapter/model_detection.py
@@ -18,6 +18,10 @@ NESTED_MODEL_KEYS = (
     "name",
     "id",
 )
+REASONING_EFFORT_KEYS = (
+    "thinking_effort",
+    "reasoning_effort",
+)
 
 
 def _clean_model(value: Any) -> str | None:
@@ -45,6 +49,16 @@ def _model_from_mapping(value: Any) -> str | None:
             if model:
                 return model
 
+    return None
+
+
+def _reasoning_effort_from_mapping(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    for key in REASONING_EFFORT_KEYS:
+        effort = _clean_model(value.get(key))
+        if effort:
+            return effort
     return None
 
 
@@ -149,6 +163,12 @@ def _model_from_message(message: dict[str, Any] | None) -> str | None:
     return _model_from_mapping(message.get("metadata"))
 
 
+def _reasoning_effort_from_message(message: dict[str, Any] | None) -> str | None:
+    if not isinstance(message, dict):
+        return None
+    return _reasoning_effort_from_mapping(message.get("metadata"))
+
+
 def detect_model_from_conversation_payload(payload: Any) -> str | None:
     """Best-effort model extraction from a chatgpt.com conversation payload.
 
@@ -178,3 +198,28 @@ def detect_model_from_conversation_payload(payload: Any) -> str | None:
         return model
 
     return _model_from_mapping(payload)
+
+
+def detect_reasoning_effort_from_conversation_payload(payload: Any) -> str | None:
+    """Best-effort reasoning-effort extraction from a chatgpt.com payload."""
+
+    if not isinstance(payload, dict):
+        return None
+
+    branch_messages = _current_branch_messages(payload)
+    for message in (
+        _current_message(payload),
+        _latest_message(branch_messages, role="assistant"),
+        _latest_message(branch_messages),
+        _latest_message(_all_messages(payload), role="assistant"),
+        _latest_message(_all_messages(payload)),
+    ):
+        effort = _reasoning_effort_from_message(message)
+        if effort:
+            return effort
+
+    effort = _reasoning_effort_from_mapping(payload.get("metadata"))
+    if effort:
+        return effort
+
+    return _reasoning_effort_from_mapping(payload)

--- a/src/chatgpt_web_adapter/types.py
+++ b/src/chatgpt_web_adapter/types.py
@@ -269,6 +269,7 @@ class AttachedConversation:
     conversation: ChatConversation
     current_node: str | None = None
     detected_model: str | None = None
+    detected_reasoning_effort: str | None = None
     title: str | None = None
     raw_status: dict[str, Any] = field(default_factory=dict)
 
@@ -281,6 +282,7 @@ class AttachedConversation:
         self.conversation = ChatConversation.from_dict(conversation_dict)
         self.current_node = _optional_str(self.current_node)
         self.detected_model = _optional_str(self.detected_model)
+        self.detected_reasoning_effort = _optional_str(self.detected_reasoning_effort)
         self.title = _optional_str(self.title)
         if self.raw_status is None:
             self.raw_status = {}
@@ -301,6 +303,7 @@ class AttachedConversation:
         *,
         conversation: ChatConversation | None = None,
         detected_model: str | None = None,
+        detected_reasoning_effort: str | None = None,
         title: str | None = None,
         raw_status: dict[str, Any] | None = None,
     ) -> "AttachedConversation":
@@ -333,6 +336,7 @@ class AttachedConversation:
             conversation=conversation,
             current_node=_optional_str(payload.get("current_node")),
             detected_model=detected_model,
+            detected_reasoning_effort=detected_reasoning_effort,
             title=title if title is not None else _optional_str(payload.get("title")),
             raw_status=raw_status
             if raw_status is not None
@@ -356,6 +360,7 @@ class AttachedConversation:
             "conversation_id": self.conversation_id,
             "current_node": self.current_node,
             "detected_model": self.detected_model,
+            "detected_reasoning_effort": self.detected_reasoning_effort,
             "title": self.title,
             "raw_status": dict(self.raw_status),
         }

--- a/tests/test_attach_conversation.py
+++ b/tests/test_attach_conversation.py
@@ -143,6 +143,28 @@ def test_attach_conversation_detects_model_from_current_message_metadata() -> No
     assert attached.detected_model == "gpt-5-5-thinking"
 
 
+def test_attach_conversation_detects_reasoning_effort_from_current_message_metadata() -> None:
+    client, _calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "current_node": "assistant-1",
+            "mapping": {
+                "assistant-1": _message_node(
+                    "assistant-1",
+                    metadata={
+                        "model_slug": "gpt-5-5-thinking",
+                        "thinking_effort": "extended",
+                    },
+                ),
+            },
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert attached.detected_reasoning_effort == "extended"
+
+
 def test_attach_conversation_detects_model_from_latest_assistant_metadata() -> None:
     client, _calls = _client_with_payload(
         {
@@ -176,6 +198,20 @@ def test_attach_conversation_detects_model_from_payload_metadata() -> None:
     attached = client.attach_conversation(CONVERSATION_ID)
 
     assert attached.detected_model == "gpt-4.1-mini"
+
+
+def test_attach_conversation_detects_reasoning_effort_from_payload_metadata() -> None:
+    client, _calls = _client_with_payload(
+        {
+            "conversation_id": CONVERSATION_ID,
+            "mapping": {},
+            "metadata": {"thinking_effort": "standard"},
+        }
+    )
+
+    attached = client.attach_conversation(CONVERSATION_ID)
+
+    assert attached.detected_reasoning_effort == "standard"
 
 
 def test_attach_conversation_uses_hardened_nested_model_detection() -> None:

--- a/tests/test_attached_conversation.py
+++ b/tests/test_attached_conversation.py
@@ -129,6 +129,7 @@ def test_attached_conversation_to_dict_includes_convenience_conversation_id() ->
         "conversation_id": CONVERSATION_ID,
         "current_node": "node-current",
         "detected_model": "gpt-5-5-thinking",
+        "detected_reasoning_effort": None,
         "title": "Existing chat",
         "raw_status": {"async_status": None},
     }

--- a/tests/test_send_to_conversation.py
+++ b/tests/test_send_to_conversation.py
@@ -11,7 +11,11 @@ from chatgpt_web_adapter.client import DEFAULT_MODEL
 CONVERSATION_ID = "conv-123"
 
 
-def _attached(*, detected_model: str | None = "gpt-5-5-thinking") -> adapter.AttachedConversation:
+def _attached(
+    *,
+    detected_model: str | None = "gpt-5-5-thinking",
+    detected_reasoning_effort: str | None = None,
+) -> adapter.AttachedConversation:
     return adapter.AttachedConversation(
         conversation=adapter.ChatConversation(
             conversation_id=CONVERSATION_ID,
@@ -19,6 +23,7 @@ def _attached(*, detected_model: str | None = "gpt-5-5-thinking") -> adapter.Att
             parent_message_id="message-123",
         ),
         detected_model=detected_model,
+        detected_reasoning_effort=detected_reasoning_effort,
     )
 
 
@@ -122,13 +127,22 @@ def test_send_to_conversation_unknown_detected_model_uses_default_model() -> Non
     assert send_calls[0]["model"] == DEFAULT_MODEL
 
 
-def test_send_to_conversation_default_reasoning_effort_stays_none() -> None:
+def test_send_to_conversation_default_reasoning_effort_stays_none_when_not_detected() -> None:
     attached = _attached()
     client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
 
     client.send_to_conversation(CONVERSATION_ID, "РџСЂРѕРґРѕР»Р¶Рё")
 
     assert send_calls[0]["reasoning_effort"] is None
+
+
+def test_send_to_conversation_preserves_detected_reasoning_effort() -> None:
+    attached = _attached(detected_reasoning_effort="extended")
+    client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
+
+    client.send_to_conversation(CONVERSATION_ID, "Р СџРЎР‚Р С•Р Т‘Р С•Р В»Р В¶Р С‘")
+
+    assert send_calls[0]["reasoning_effort"] == "extended"
 
 
 def test_send_to_conversation_passes_explicit_reasoning_effort() -> None:
@@ -142,6 +156,38 @@ def test_send_to_conversation_passes_explicit_reasoning_effort() -> None:
     )
 
     assert send_calls[0]["reasoning_effort"] == "extended"
+
+
+def test_send_to_conversation_explicit_model_does_not_carry_detected_reasoning_effort() -> None:
+    attached = _attached(
+        detected_model="gpt-5-5-thinking",
+        detected_reasoning_effort="extended",
+    )
+    client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
+
+    client.send_to_conversation(
+        CONVERSATION_ID,
+        "Р СџРЎР‚Р С•Р Т‘Р С•Р В»Р В¶Р С‘",
+        model="gpt-4.1",
+    )
+
+    assert send_calls[0]["reasoning_effort"] is None
+
+
+def test_send_to_conversation_preserve_model_false_does_not_carry_detected_reasoning_effort() -> None:
+    attached = _attached(
+        detected_model="gpt-5-5-thinking",
+        detected_reasoning_effort="extended",
+    )
+    client, _attach_calls, send_calls, _response = _client_with_attach_and_send(attached)
+
+    client.send_to_conversation(
+        CONVERSATION_ID,
+        "Р СџРЎР‚Р С•Р Т‘Р С•Р В»Р В¶Р С‘",
+        preserve_model=False,
+    )
+
+    assert send_calls[0]["reasoning_effort"] is None
 
 
 def test_send_to_conversation_passes_send_options_through() -> None:


### PR DESCRIPTION
## Summary

Adds a live conversation watcher and improves runtime observability for ChatGPT web stream handoff flows.

## Changes

- Add `examples/watch_conversation.py` for inspecting raw SSE events, websocket handoff, polling, approvals, assistant tokens, reasoning fragments, and tool activity from the terminal.
- Add optional terminal color output, raw websocket frame display, live content rendering, `--preserve-model`, `--show-tokens`, and `--show-live-content`.
- Add stream handoff diagnostics for resume tokens, topic ids, websocket URL metadata, transport preference, and recovery mode.
- Add websocket-topic handoff support path plus safe fallback through conversation polling when direct stream recovery is unavailable.
- Emit additional lifecycle events for handoff, websocket probe, websocket subscription, poll attempts, poll completion, and poll timeout.
- Extend request diagnostics with resume/handoff/websocket fields.
- Add tests for stream handoff event emission, websocket-topic recovery, polling fallback, and watcher fragment extraction.

## Notes

This is still best-effort behavior against ChatGPT web internals. The PR improves debuggability and recovery, but does not make the web backend schema stable.