### PR TITLE
PR7.8: Add reasoning mode mapping and detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The package intentionally does not include the CLI, localization, auth capture, 
 - streaming assistant tokens into terminal or app UIs
 - reading messages and polling conversation status from Python
 - uploading images through the web-session flow
+- inspecting live SSE, websocket handoff, and polling events in a terminal
 - experimenting with browserless approval workflows
 
 ## When Not To Use This
@@ -108,6 +109,7 @@ The stable core is the main surface intended for building tools on top of an exi
 - experimental browserless tool-approval helpers for web-agent flows
 - experimental raw payload escape hatch for advanced users
 - local `curl`-based transport for compatibility with stock Python
+- example live watcher for SSE, websocket handoff, polling, and approvals
 
 ## Requirements
 
@@ -220,6 +222,7 @@ Other common APIs:
 - wait for completion with `client.wait_until_completed(...)`
 - approve selected tool flows with experimental `client.send_and_auto_approve(...)`
 - inspect request latency with [examples/diagnose_latency.py](examples/diagnose_latency.py)
+- inspect live transport events with [examples/watch_conversation.py](examples/watch_conversation.py)
 
 ## Examples
 
@@ -231,6 +234,7 @@ Other common APIs:
 - [examples/approve_tools.py](examples/approve_tools.py) - approve pending tool actions after review
 - [examples/raw_payload.py](examples/raw_payload.py) - send an experimental raw web backend payload
 - [examples/diagnose_latency.py](examples/diagnose_latency.py) - print request and streaming diagnostics
+- [examples/watch_conversation.py](examples/watch_conversation.py) - watch SSE, websocket handoff, polling, and approvals live
 - [examples/github_auto_approve.py](examples/github_auto_approve.py) - specialized GitHub connector approval demo
 
 ## Experimental Features

--- a/examples/basic_send.py
+++ b/examples/basic_send.py
@@ -20,7 +20,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Send one prompt through a ChatGPT web session.")
     parser.add_argument("prompt", nargs="?", default=DEFAULT_PROMPT)
     parser.add_argument("--auth-file", default="auth_data.json")
-    parser.add_argument("--model", default="gpt-4o-mini")
+    parser.add_argument("--model", default="gpt-5-3-mini")
     parser.add_argument("--timeout", type=int, default=120)
     parser.add_argument("--no-stream", action="store_true")
     args = parser.parse_args()

--- a/examples/watch_conversation.py
+++ b/examples/watch_conversation.py
@@ -72,6 +72,12 @@ REQUEST_EVENT_TYPES = {
     "requirements_ready",
     "request_completed",
 }
+CONTENT_COLORS = {
+    "assistant": "green",
+    "reasoning": "magenta",
+    "tool_call": "blue",
+    "tool_result": "cyan",
+}
 
 
 def _color_enabled(mode: str) -> bool:
@@ -144,6 +150,223 @@ def _print_json_block(label: str, payload: Any, *, color: str, color_enabled: bo
     print(json.dumps(payload, ensure_ascii=False, indent=2))
 
 
+def _clean_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.replace("\r\n", "\n").replace("\r", "\n")
+    if not text.strip():
+        return None
+    return text
+
+
+def _compact_json_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        return text if text and text != "{}" and text != "[]" else None
+    return _clean_text(str(value))
+
+
+def _append_fragment(
+    fragments: list[dict[str, str]],
+    *,
+    kind: str,
+    key: str,
+    text: Any,
+    label: str | None = None,
+) -> None:
+    cleaned = _clean_text(text)
+    if cleaned is None:
+        return
+    fragments.append(
+        {
+            "kind": kind,
+            "key": key,
+            "label": label or kind,
+            "text": cleaned,
+        }
+    )
+
+
+def _extract_reasoning_strings(value: Any, *, prefix: str = "") -> list[tuple[str, str]]:
+    fragments: list[tuple[str, str]] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            path = f"{prefix}.{key}" if prefix else str(key)
+            lower_key = str(key).lower()
+            if isinstance(nested, str) and any(marker in lower_key for marker in ("reason", "thought", "summary")):
+                cleaned = _clean_text(nested)
+                if cleaned is not None:
+                    fragments.append((path, cleaned))
+            elif isinstance(nested, (dict, list)):
+                fragments.extend(_extract_reasoning_strings(nested, prefix=path))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            path = f"{prefix}[{index}]"
+            if isinstance(nested, (dict, list)):
+                fragments.extend(_extract_reasoning_strings(nested, prefix=path))
+    return fragments
+
+
+def _extract_fragments_from_message(message: Any) -> list[dict[str, str]]:
+    if not isinstance(message, dict):
+        return []
+    fragments: list[dict[str, str]] = []
+    author = message.get("author")
+    role = author.get("role") if isinstance(author, dict) else None
+    recipient = message.get("recipient")
+    message_id = message.get("id")
+    content = message.get("content")
+    parts = content.get("parts") if isinstance(content, dict) else None
+    text = "".join(part for part in parts if isinstance(part, str)) if isinstance(parts, list) else ""
+    key_base = str(message_id or recipient or role or "message")
+    if role == "tool":
+        _append_fragment(
+            fragments,
+            kind="tool_result",
+            key=f"tool_result:{key_base}",
+            label=f"tool_result:{message.get('author', {}).get('name') or recipient or 'tool'}",
+            text=text,
+        )
+    elif role == "assistant" and isinstance(recipient, str) and recipient and recipient != "all":
+        _append_fragment(
+            fragments,
+            kind="tool_call",
+            key=f"tool_call:{key_base}:{recipient}",
+            label=f"tool_call:{recipient}",
+            text=text,
+        )
+    metadata = message.get("metadata")
+    if isinstance(metadata, dict):
+        tool_data = metadata.get("jit_plugin_data")
+        tool_preview = _compact_json_text(tool_data)
+        if tool_preview is not None:
+            _append_fragment(
+                fragments,
+                kind="tool_call",
+                key=f"tool_meta:{key_base}",
+                label=f"tool_meta:{recipient or 'assistant'}",
+                text=tool_preview,
+            )
+        for path, reasoning_text in _extract_reasoning_strings(metadata):
+            _append_fragment(
+                fragments,
+                kind="reasoning",
+                key=f"reasoning_meta:{key_base}:{path}",
+                label="reasoning",
+                text=reasoning_text,
+            )
+    return fragments
+
+
+def _extract_fragments_from_stream_payload(payload: Any) -> list[dict[str, str]]:
+    if not isinstance(payload, dict):
+        return []
+    fragments: list[dict[str, str]] = []
+    value = payload.get("v")
+    path = payload.get("p")
+    if isinstance(value, dict):
+        message = value.get("message")
+        if isinstance(message, dict):
+            fragments.extend(_extract_fragments_from_message(message))
+    if isinstance(value, list):
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            item_path = str(item.get("p") or "")
+            item_value = item.get("v")
+            lower_path = item_path.lower()
+            if isinstance(item_value, str) and any(marker in lower_path for marker in ("reason", "thought")):
+                _append_fragment(
+                    fragments,
+                    kind="reasoning",
+                    key=f"path:{item_path}",
+                    label="reasoning",
+                    text=item_value,
+                )
+            elif "jit_plugin_data" in lower_path:
+                preview = _compact_json_text(item_value)
+                if preview is not None:
+                    _append_fragment(
+                        fragments,
+                        kind="tool_call",
+                        key=f"path:{item_path}",
+                        label="tool_meta",
+                        text=preview,
+                    )
+    elif isinstance(value, str) and isinstance(path, str):
+        lower_path = path.lower()
+        if any(marker in lower_path for marker in ("reason", "thought")):
+            _append_fragment(
+                fragments,
+                kind="reasoning",
+                key=f"path:{path}",
+                label="reasoning",
+                text=value,
+            )
+    if payload.get("type") == "server_ste_metadata":
+        metadata = payload.get("metadata")
+        for reasoning_path, reasoning_text in _extract_reasoning_strings(metadata):
+            _append_fragment(
+                fragments,
+                kind="reasoning",
+                key=f"server_ste:{reasoning_path}",
+                label="reasoning",
+                text=reasoning_text,
+            )
+    return fragments
+
+
+def _extract_live_fragments(event: dict[str, Any]) -> list[dict[str, str]]:
+    event_type = str(event.get("type") or "")
+    if event_type == "assistant_token":
+        token = _clean_text(event.get("token"))
+        return [{"kind": "assistant", "key": "assistant", "label": "assistant", "text": token}] if token else []
+    if event_type == "conversation_poll_stream_delta":
+        delta = _clean_text(event.get("delta"))
+        return [{"kind": "assistant", "key": "assistant", "label": "assistant", "text": delta}] if delta else []
+    if event_type in {"raw_sse_event", "raw_ws_event"}:
+        return _extract_fragments_from_stream_payload(event.get("parsed"))
+    return []
+
+
+def _render_live_fragments(
+    event: dict[str, Any],
+    *,
+    started_at: float,
+    color_enabled: bool,
+    state: dict[str, str],
+    render_assistant: bool,
+) -> bool:
+    rendered = False
+    for fragment in _extract_live_fragments(event):
+        kind = fragment["kind"]
+        if kind == "assistant" and not render_assistant:
+            continue
+        key = fragment["key"]
+        text = fragment["text"]
+        if kind != "assistant":
+            previous = state.get(key, "")
+            if previous and text.startswith(previous):
+                text = text[len(previous) :]
+            state[key] = fragment["text"]
+        if not text:
+            continue
+        label = _paint(
+            f"[{_format_elapsed(started_at)}] {fragment['label']}",
+            CONTENT_COLORS.get(kind, "gray"),
+            enabled=color_enabled,
+        )
+        if kind == "assistant":
+            print(_paint(text, CONTENT_COLORS[kind], enabled=color_enabled), end="", flush=True)
+        else:
+            print()
+            print(label, text)
+        rendered = True
+    return rendered
+
+
 def _print_summary(response: Any, *, elapsed: float, color_enabled: bool) -> None:
     print()
     _print_json_block(
@@ -192,7 +415,12 @@ def main() -> None:
     parser.add_argument(
         "--show-tokens",
         action="store_true",
-        help="Print assistant token text inline as it streams.",
+        help="Print assistant token text inline as it streams. Enabled automatically by --show-live-content.",
+    )
+    parser.add_argument(
+        "--show-live-content",
+        action="store_true",
+        help="Best-effort terminal rendering for assistant, reasoning, and tool text.",
     )
     parser.add_argument(
         "--show-raw-frames",
@@ -212,6 +440,9 @@ def main() -> None:
     color_enabled = _color_enabled(args.color)
     started_at = time.perf_counter()
     client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    live_content_enabled = args.show_live_content
+    render_assistant_in_events = args.show_live_content and not args.show_tokens
+    fragment_state: dict[str, str] = {}
 
     def on_token(token: str) -> None:
         if not args.show_tokens:
@@ -220,6 +451,15 @@ def main() -> None:
 
     def on_event(event: dict[str, Any]) -> None:
         event_type = str(event.get("type") or "event")
+        if live_content_enabled and _render_live_fragments(
+            event,
+            started_at=started_at,
+            color_enabled=color_enabled,
+            state=fragment_state,
+            render_assistant=render_assistant_in_events,
+        ):
+            if event_type in {"assistant_token", "conversation_poll_stream_delta"}:
+                return
         if event_type == "assistant_token":
             return
         if event_type == "raw_ws_frame" and not args.show_raw_frames:

--- a/examples/watch_conversation.py
+++ b/examples/watch_conversation.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+"""Watch ChatGPT web request events with optional colorized terminal output.
+
+Purpose: inspect raw SSE, handoff, polling, approvals, and assistant tokens live.
+Surface: stable example built on top of the SDK event callback.
+Prerequisites: valid ``auth_data.json`` from an active ChatGPT web session.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+from chatgpt_web_adapter import ChatGPTWebClient
+
+
+ANSI_RESET = "\x1b[0m"
+ANSI = {
+    "dim": "\x1b[2m",
+    "bold": "\x1b[1m",
+    "red": "\x1b[31m",
+    "green": "\x1b[32m",
+    "yellow": "\x1b[33m",
+    "blue": "\x1b[34m",
+    "magenta": "\x1b[35m",
+    "cyan": "\x1b[36m",
+    "gray": "\x1b[90m",
+}
+
+APPROVAL_EVENT_TYPES = {
+    "approval_detected",
+    "approval_allowed",
+    "approval_denied",
+    "approval_sent",
+    "approval_completed",
+    "approval_failed",
+    "pending_approval_detected",
+    "approval_prepare_succeeded",
+    "approval_round_started",
+    "approval_round_finished",
+    "waiting_for_pending_approval",
+}
+POLL_EVENT_TYPES = {
+    "conversation_poll_started",
+    "conversation_poll_attempt",
+    "conversation_poll_completed",
+    "conversation_poll_timeout",
+    "conversation_poll_error",
+    "conversation_recovery_fetch_error",
+}
+STREAM_EVENT_TYPES = {
+    "stream_started",
+    "stream_completed",
+    "stream_done",
+    "raw_sse_event",
+    "raw_sse_done",
+    "stream_handoff",
+}
+REQUEST_EVENT_TYPES = {
+    "request_started",
+    "request_payload_prepared",
+    "requirements_ready",
+    "request_completed",
+}
+
+
+def _color_enabled(mode: str) -> bool:
+    if mode == "always":
+        return True
+    if mode == "never":
+        return False
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    return sys.stdout.isatty()
+
+
+def _paint(text: str, color: str, *, enabled: bool) -> str:
+    if not enabled:
+        return text
+    code = ANSI.get(color)
+    if not code:
+        return text
+    return f"{code}{text}{ANSI_RESET}"
+
+
+def _event_color(event_type: str) -> str:
+    if event_type == "assistant_token":
+        return "green"
+    if event_type == "error":
+        return "red"
+    if event_type in APPROVAL_EVENT_TYPES:
+        return "blue"
+    if event_type in POLL_EVENT_TYPES:
+        return "yellow"
+    if event_type == "stream_handoff":
+        return "magenta"
+    if event_type in STREAM_EVENT_TYPES:
+        return "cyan"
+    if event_type in REQUEST_EVENT_TYPES:
+        return "gray"
+    if event_type == "first_token":
+        return "green"
+    return "gray"
+
+
+def _format_elapsed(started_at: float) -> str:
+    return f"{time.perf_counter() - started_at:8.3f}s"
+
+
+def _compact_payload(event_type: str, payload: dict[str, Any]) -> Any:
+    if event_type == "raw_sse_event":
+        parsed = payload.get("parsed")
+        if parsed is not None:
+            return parsed
+        return {"raw": payload.get("raw")}
+    if event_type == "request_payload_prepared":
+        return payload.get("payload")
+    return payload
+
+
+def _print_json_block(label: str, payload: Any, *, color: str, color_enabled: bool) -> None:
+    print(_paint(label, color, enabled=color_enabled))
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def _print_summary(response: Any, *, elapsed: float, color_enabled: bool) -> None:
+    print()
+    _print_json_block(
+        "conversation:",
+        response.conversation.to_dict(),
+        color="gray",
+        color_enabled=color_enabled,
+    )
+    print()
+    _print_json_block(
+        "request:",
+        response.request.to_dict(),
+        color="gray",
+        color_enabled=color_enabled,
+    )
+    print()
+    _print_json_block(
+        "metrics:",
+        response.metrics.to_dict(),
+        color="gray",
+        color_enabled=color_enabled,
+    )
+    print()
+    print(_paint("response_text:", "green", enabled=color_enabled))
+    print(response.text)
+    print()
+    print(f"wall_time_seconds: {elapsed:.3f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Watch raw ChatGPT web events while sending a prompt.",
+    )
+    parser.add_argument("prompt", nargs="?", help="Prompt to send.")
+    parser.add_argument("--conversation", help="Existing conversation URL or raw id.")
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--model", default="gpt-5-5-thinking")
+    parser.add_argument("--reasoning-effort", default="high")
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument(
+        "--color",
+        choices=("auto", "always", "never"),
+        default="auto",
+        help="ANSI color mode for terminal output.",
+    )
+    parser.add_argument(
+        "--show-tokens",
+        action="store_true",
+        help="Print assistant token text inline as it streams.",
+    )
+    parser.add_argument(
+        "--preserve-model",
+        action="store_true",
+        help="When continuing a conversation, preserve the detected model instead of forcing --model.",
+    )
+    args = parser.parse_args()
+
+    if not args.prompt:
+        raise SystemExit("prompt is required")
+
+    color_enabled = _color_enabled(args.color)
+    started_at = time.perf_counter()
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+
+    def on_token(token: str) -> None:
+        if not args.show_tokens:
+            return
+        print(_paint(token, "green", enabled=color_enabled), end="", flush=True)
+
+    def on_event(event: dict[str, Any]) -> None:
+        event_type = str(event.get("type") or "event")
+        if event_type == "assistant_token":
+            return
+        payload = {key: value for key, value in event.items() if key != "type"}
+        color = _event_color(event_type)
+        label = _paint(f"[{_format_elapsed(started_at)}] {event_type}", color, enabled=color_enabled)
+        compact = _compact_payload(event_type, payload)
+        if event_type in {"raw_sse_event", "request_payload_prepared"}:
+            print()
+            _print_json_block(label, compact, color=color, color_enabled=color_enabled)
+            return
+        print()
+        print(label, json.dumps(compact, ensure_ascii=False))
+
+    if args.conversation:
+        response = client.send_to_conversation(
+            args.conversation,
+            args.prompt,
+            model=None if args.preserve_model else args.model,
+            reasoning_effort=None if args.preserve_model else args.reasoning_effort,
+            preserve_model=args.preserve_model,
+            on_token=on_token,
+            on_event=on_event,
+        )
+    else:
+        response = client.send(
+            args.prompt,
+            model=args.model,
+            reasoning_effort=args.reasoning_effort,
+            on_token=on_token,
+            on_event=on_event,
+        )
+
+    if args.show_tokens:
+        print()
+    _print_summary(
+        response,
+        elapsed=time.perf_counter() - started_at,
+        color_enabled=color_enabled,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/watch_conversation.py
+++ b/examples/watch_conversation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Watch ChatGPT web request events with optional colorized terminal output.
 
-Purpose: inspect raw SSE, handoff, polling, approvals, and assistant tokens live.
+Purpose: inspect raw SSE, websocket handoff, polling, approvals, and assistant tokens live.
 Surface: stable example built on top of the SDK event callback.
 Prerequisites: valid ``auth_data.json`` from an active ChatGPT web session.
 """
@@ -57,7 +57,14 @@ STREAM_EVENT_TYPES = {
     "stream_done",
     "raw_sse_event",
     "raw_sse_done",
+    "raw_ws_event",
+    "raw_ws_done",
     "stream_handoff",
+    "stream_handoff_transport_probe",
+    "stream_handoff_ws_connected",
+    "stream_handoff_ws_subscribed",
+    "stream_handoff_ws_failed",
+    "stream_handoff_recovery_mode",
 }
 REQUEST_EVENT_TYPES = {
     "request_started",
@@ -97,7 +104,14 @@ def _event_color(event_type: str) -> str:
         return "blue"
     if event_type in POLL_EVENT_TYPES:
         return "yellow"
-    if event_type == "stream_handoff":
+    if event_type in {
+        "stream_handoff",
+        "stream_handoff_transport_probe",
+        "stream_handoff_ws_connected",
+        "stream_handoff_ws_subscribed",
+        "stream_handoff_ws_failed",
+        "stream_handoff_recovery_mode",
+    }:
         return "magenta"
     if event_type in STREAM_EVENT_TYPES:
         return "cyan"
@@ -113,10 +127,12 @@ def _format_elapsed(started_at: float) -> str:
 
 
 def _compact_payload(event_type: str, payload: dict[str, Any]) -> Any:
-    if event_type == "raw_sse_event":
+    if event_type in {"raw_sse_event", "raw_ws_event"}:
         parsed = payload.get("parsed")
         if parsed is not None:
             return parsed
+        return {"raw": payload.get("raw")}
+    if event_type == "raw_ws_frame":
         return {"raw": payload.get("raw")}
     if event_type == "request_payload_prepared":
         return payload.get("payload")
@@ -179,6 +195,11 @@ def main() -> None:
         help="Print assistant token text inline as it streams.",
     )
     parser.add_argument(
+        "--show-raw-frames",
+        action="store_true",
+        help="Print raw websocket frame blobs. Disabled by default because they are noisy.",
+    )
+    parser.add_argument(
         "--preserve-model",
         action="store_true",
         help="When continuing a conversation, preserve the detected model instead of forcing --model.",
@@ -201,11 +222,13 @@ def main() -> None:
         event_type = str(event.get("type") or "event")
         if event_type == "assistant_token":
             return
+        if event_type == "raw_ws_frame" and not args.show_raw_frames:
+            return
         payload = {key: value for key, value in event.items() if key != "type"}
         color = _event_color(event_type)
         label = _paint(f"[{_format_elapsed(started_at)}] {event_type}", color, enabled=color_enabled)
         compact = _compact_payload(event_type, payload)
-        if event_type in {"raw_sse_event", "request_payload_prepared"}:
+        if event_type in {"raw_sse_event", "raw_ws_event", "request_payload_prepared", "raw_ws_frame"}:
             print()
             _print_json_block(label, compact, color=color, color_enabled=color_enabled)
             return

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -35,6 +35,7 @@ from .types import (
     ChatConversation,
     ChatMessage,
     ChatMetrics,
+    ChatRequestDiagnostics,
     ChatResponse,
     ConversationRef,
     ConversationStatus,
@@ -78,6 +79,7 @@ CORE_PUBLIC_API = [
     "PendingApproval",
     "ChatResponse",
     "ChatMetrics",
+    "ChatRequestDiagnostics",
     "AuthData",
     "errors",
 ]

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -19,7 +19,7 @@ from urllib.parse import urlparse
 
 from .auth import CHAT_URL, DEFAULT_AUTH_FILE, build_base_headers, load_auth_data
 from .exceptions import MediaError, RequestError
-from .types import AuthData, ChatConversation, ChatMetrics, ChatResponse, MediaItem
+from .types import AuthData, ChatConversation, ChatMetrics, ChatRequestDiagnostics, ChatResponse, MediaItem
 
 CHAT_REQUIREMENTS_URL = "https://chatgpt.com/backend-api/sentinel/chat-requirements"
 CHAT_BACKEND_URL = "https://chatgpt.com/backend-api/f/conversation"
@@ -798,6 +798,7 @@ class ChatGPTWebClient:
                 state["conversation_id"] = conversation_id
             message = value.get("message")
             if isinstance(message, dict):
+                ChatGPTWebClient._capture_message_diagnostics(message, state)
                 recipient = message.get("recipient")
                 if isinstance(recipient, str):
                     state["recipient"] = recipient
@@ -822,11 +823,36 @@ class ChatGPTWebClient:
                     if isinstance(token, str):
                         output.append(token)
                 elif item.get("p") == "/message/metadata" and state.get("recipient", "all") == "all":
-                    finish_reason = item.get("v", {}).get("finish_details", {}).get("type")
+                    metadata = item.get("v")
+                    ChatGPTWebClient._capture_metadata_diagnostics(metadata, state)
+                    finish_reason = metadata.get("finish_details", {}).get("type") if isinstance(metadata, dict) else None
                     if finish_reason:
                         state["finish_reason"] = finish_reason
             return output, None
+        if payload.get("type") == "server_ste_metadata":
+            ChatGPTWebClient._capture_metadata_diagnostics(payload.get("metadata"), state)
         return output, None
+
+    @staticmethod
+    def _capture_message_diagnostics(message: Any, state: dict[str, Any]) -> None:
+        if not isinstance(message, dict):
+            return
+        ChatGPTWebClient._capture_metadata_diagnostics(message.get("metadata"), state)
+
+    @staticmethod
+    def _capture_metadata_diagnostics(metadata: Any, state: dict[str, Any]) -> None:
+        if not isinstance(metadata, dict):
+            return
+        for key in ("model_slug", "model", "default_model_slug", "selected_model"):
+            model = metadata.get(key)
+            if isinstance(model, str) and model.strip():
+                state["observed_model"] = model.strip()
+                break
+        for key in ("thinking_effort", "reasoning_effort"):
+            effort = metadata.get(key)
+            if isinstance(effort, str) and effort.strip():
+                state["observed_reasoning_effort"] = effort.strip()
+                break
 
     @staticmethod
     def _conversation_to_dict(
@@ -1736,6 +1762,8 @@ class ChatGPTWebClient:
             "message_id": conversation_dict.get("message_id") if isinstance(conversation_dict, dict) else None,
             "parent_message_id": parent_message_id,
             "finish_reason": "stop",
+            "observed_model": None,
+            "observed_reasoning_effort": None,
         }
         first_token_latency: float | None = None
         last_token_latency: float | None = None
@@ -1857,5 +1885,24 @@ class ChatGPTWebClient:
                 first_token=first_token_latency,
                 last_token=last_token_latency,
                 total=total_latency,
+            ),
+            request=ChatRequestDiagnostics(
+                requested_model=model.strip() if isinstance(model, str) and model.strip() else None,
+                requested_reasoning_effort=reasoning_effort.strip()
+                if isinstance(reasoning_effort, str) and reasoning_effort.strip()
+                else None,
+                sent_model=payload.get("model"),
+                sent_reasoning_effort=payload.get("thinking_effort"),
+                conversation_id=state.get("conversation_id"),
+                parent_message_id=parent_message_id,
+                is_continuation=bool(conversation_id),
+                web_search=web_search,
+                temporary=temporary,
+                has_media=bool(normalized_media),
+                message_count=len(payload.get("messages", []))
+                if isinstance(payload.get("messages"), list)
+                else None,
+                observed_model=state.get("observed_model"),
+                observed_reasoning_effort=state.get("observed_reasoning_effort"),
             ),
         )

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -259,6 +259,52 @@ class ChatGPTWebClient:
             return None
         return data if isinstance(data, dict) else None
 
+    @staticmethod
+    def _capture_resume_token_diagnostics(token: str, state: dict[str, Any]) -> None:
+        decoded = ChatGPTWebClient._decode_jwt_payload(token)
+        if not isinstance(decoded, dict):
+            return
+        turn_topic_id = decoded.get("turn_topic_id")
+        if isinstance(turn_topic_id, str) and turn_topic_id.strip():
+            state["resume_turn_topic_id"] = turn_topic_id.strip()
+        conduit_uuid = decoded.get("conduit_uuid")
+        if isinstance(conduit_uuid, str) and conduit_uuid.strip():
+            state["resume_conduit_uuid"] = conduit_uuid.strip()
+        conduit_location = decoded.get("conduit_location")
+        if isinstance(conduit_location, str) and conduit_location.strip():
+            state["resume_conduit_location"] = conduit_location.strip()
+        cluster = decoded.get("cluster")
+        if isinstance(cluster, str) and cluster.strip():
+            state["resume_conduit_cluster"] = cluster.strip()
+
+    @staticmethod
+    def _capture_handoff_option_diagnostics(options: Any, state: dict[str, Any]) -> None:
+        if not isinstance(options, list):
+            return
+        state["stream_handoff_options"] = options
+        option_types: list[str] = []
+        for option in options:
+            if not isinstance(option, dict):
+                continue
+            option_type = option.get("type")
+            if isinstance(option_type, str) and option_type.strip():
+                normalized_type = option_type.strip()
+                option_types.append(normalized_type)
+            else:
+                normalized_type = ""
+            topic_id = option.get("topic_id")
+            if not isinstance(topic_id, str) or not topic_id.strip():
+                continue
+            normalized_topic_id = topic_id.strip()
+            if normalized_type == "resume_sse_endpoint":
+                state["resume_sse_topic_id"] = normalized_topic_id
+                state.setdefault("resume_turn_topic_id", normalized_topic_id)
+            elif normalized_type == "subscribe_ws_topic":
+                state["resume_ws_topic_id"] = normalized_topic_id
+                state.setdefault("resume_turn_topic_id", normalized_topic_id)
+        if option_types:
+            state["handoff_option_types"] = tuple(option_types)
+
     """Minimal sync adapter for chatgpt.com web sessions."""
 
     def __init__(
@@ -816,11 +862,7 @@ class ChatGPTWebClient:
                 state["resume_kind"] = kind.strip()
             if isinstance(token, str) and token.strip():
                 state["resume_token"] = token.strip()
-                decoded = ChatGPTWebClient._decode_jwt_payload(token.strip())
-                if isinstance(decoded, dict):
-                    turn_topic_id = decoded.get("turn_topic_id")
-                    if isinstance(turn_topic_id, str) and turn_topic_id.strip():
-                        state["resume_turn_topic_id"] = turn_topic_id.strip()
+                ChatGPTWebClient._capture_resume_token_diagnostics(token.strip(), state)
             conversation_id = payload.get("conversation_id")
             if isinstance(conversation_id, str) and conversation_id:
                 state["conversation_id"] = conversation_id
@@ -2148,17 +2190,7 @@ class ChatGPTWebClient:
                 )
                 if isinstance(event_payload, dict) and event_payload.get("type") == "stream_handoff":
                     options = event_payload.get("options")
-                    if isinstance(options, list):
-                        state["stream_handoff_options"] = options
-                        for option in options:
-                            if not isinstance(option, dict):
-                                continue
-                            if option.get("type") != "resume_sse_endpoint":
-                                continue
-                            topic_id = option.get("topic_id")
-                            if isinstance(topic_id, str) and topic_id.strip():
-                                state["resume_turn_topic_id"] = topic_id.strip()
-                                break
+                    self._capture_handoff_option_diagnostics(options, state)
                     self._emit_event(
                         on_event,
                         "stream_handoff",
@@ -2167,6 +2199,9 @@ class ChatGPTWebClient:
                         options=event_payload.get("options"),
                         resume_kind=state.get("resume_kind"),
                         resume_turn_topic_id=state.get("resume_turn_topic_id"),
+                        resume_sse_topic_id=state.get("resume_sse_topic_id"),
+                        resume_ws_topic_id=state.get("resume_ws_topic_id"),
+                        handoff_option_types=list(state.get("handoff_option_types", ()) or ()),
                         resume_token_present=bool(state.get("resume_token")),
                     )
                 tokens, maybe_title = self._parse_event(event_payload, state)
@@ -2361,7 +2396,13 @@ class ChatGPTWebClient:
                 resume_kind=state.get("resume_kind"),
                 resume_token_present=bool(state.get("resume_token")),
                 resume_turn_topic_id=state.get("resume_turn_topic_id"),
+                resume_sse_topic_id=state.get("resume_sse_topic_id"),
+                resume_ws_topic_id=state.get("resume_ws_topic_id"),
+                handoff_option_types=tuple(state.get("handoff_option_types", ()) or ()),
                 resume_with_websockets=bool(state.get("resume_with_websockets")),
                 turn_exchange_id=state.get("turn_exchange_id"),
+                resume_conduit_uuid=state.get("resume_conduit_uuid"),
+                resume_conduit_location=state.get("resume_conduit_location"),
+                resume_conduit_cluster=state.get("resume_conduit_cluster"),
             ),
         )

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -1196,22 +1196,90 @@ class ChatGPTWebClient:
         previous_message_id: str | None,
         timeout: float,
         interval: float,
+        on_event: Callable[[dict[str, Any]], None] | None = None,
+        reason: str = "approval_poll",
     ) -> tuple[dict[str, Any] | None, str, dict[str, Any] | None]:
+        self._emit_event(
+            on_event,
+            "conversation_poll_started",
+            conversation_id=conversation_id,
+            previous_message_id=previous_message_id,
+            timeout=timeout,
+            interval=interval,
+            reason=reason,
+        )
         deadline = time.monotonic() + max(0.0, timeout)
         last_message: dict[str, Any] | None = None
         last_text = ""
         last_payload: dict[str, Any] | None = None
+        attempt = 0
         while True:
-            payload = self._get_conversation_payload(conversation_id)
+            attempt += 1
+            try:
+                payload = self._get_conversation_payload(conversation_id)
+            except RequestError as error:
+                self._emit_event(
+                    on_event,
+                    "conversation_poll_error",
+                    conversation_id=conversation_id,
+                    previous_message_id=previous_message_id,
+                    attempt=attempt,
+                    reason=reason,
+                    status_code=getattr(error, "status_code", None),
+                    message=str(error),
+                )
+                if time.monotonic() >= deadline:
+                    self._emit_event(
+                        on_event,
+                        "conversation_poll_timeout",
+                        conversation_id=conversation_id,
+                        previous_message_id=previous_message_id,
+                        attempt=attempt,
+                        latest_message_id=last_message.get("id") if isinstance(last_message, dict) else None,
+                        text_length=len(last_text),
+                        reason=reason,
+                    )
+                    return last_message, last_text, last_payload
+                time.sleep(max(0.5, interval))
+                continue
             last_payload = payload
             message, text = self._latest_assistant_from_conversation(payload)
+            self._emit_event(
+                on_event,
+                "conversation_poll_attempt",
+                conversation_id=conversation_id,
+                previous_message_id=previous_message_id,
+                attempt=attempt,
+                latest_message_id=message.get("id") if isinstance(message, dict) else None,
+                text_length=len(text),
+                reason=reason,
+            )
             if message is not None:
                 last_message = message
                 last_text = text
                 message_id = message.get("id")
                 if isinstance(message_id, str) and message_id != previous_message_id:
+                    self._emit_event(
+                        on_event,
+                        "conversation_poll_completed",
+                        conversation_id=conversation_id,
+                        message_id=message_id,
+                        attempt=attempt,
+                        text_length=len(text),
+                        reason=reason,
+                    )
                     return message, text, payload
             if time.monotonic() >= deadline:
+                self._emit_event(
+                    on_event,
+                    "conversation_poll_timeout",
+                    conversation_id=conversation_id,
+                    previous_message_id=previous_message_id,
+                    attempt=attempt,
+                    latest_message_id=last_message.get("id") if isinstance(last_message, dict) else None,
+                    text_length=len(last_text),
+                    reason=reason,
+                )
                 return last_message, last_text, last_payload
             time.sleep(max(0.5, interval))
 
@@ -1469,6 +1537,8 @@ class ChatGPTWebClient:
                 previous_message_id=tool_id,
                 timeout=poll_timeout,
                 interval=poll_interval,
+                on_event=on_event,
+                reason="approval_poll",
             )
             if isinstance(message, dict):
                 next_message_id = message.get("id")
@@ -1738,6 +1808,7 @@ class ChatGPTWebClient:
         conversation: ChatConversation | dict[str, Any] | None = None,
         media: Sequence[MediaItem] | None = None,
         on_token: Callable[[str], None] | None = None,
+        on_event: Callable[[dict[str, Any]], None] | None = None,
     ) -> ChatResponse:
         normalized_effort = self._normalize_reasoning_effort(reasoning_effort)
         resolved_model = self._resolve_model(model, reasoning_effort)
@@ -1785,6 +1856,11 @@ class ChatGPTWebClient:
             payload["system_hints"] = ["search"]
         if normalized_effort is not None:
             payload["thinking_effort"] = normalized_effort
+        self._emit_event(
+            on_event,
+            "request_payload_prepared",
+            payload=json.loads(json.dumps(payload, ensure_ascii=False)),
+        )
 
         headers = self._build_headers(
             {
@@ -1847,12 +1923,34 @@ class ChatGPTWebClient:
                     continue
                 if raw_line.startswith(b"data: [DONE]"):
                     raw_events.append("[DONE]")
+                    self._emit_event(on_event, "raw_sse_done")
                     break
-                raw_events.append(raw_line[6:].decode("utf-8", errors="replace").strip())
+                raw_text = raw_line[6:].decode("utf-8", errors="replace").strip()
+                raw_events.append(raw_text)
                 try:
                     event_payload = json.loads(raw_line[6:])
                 except ValueError:
+                    self._emit_event(
+                        on_event,
+                        "raw_sse_event",
+                        raw=raw_text,
+                        parsed=None,
+                    )
                     continue
+                self._emit_event(
+                    on_event,
+                    "raw_sse_event",
+                    raw=raw_text,
+                    parsed=event_payload,
+                )
+                if isinstance(event_payload, dict) and event_payload.get("type") == "stream_handoff":
+                    self._emit_event(
+                        on_event,
+                        "stream_handoff",
+                        conversation_id=event_payload.get("conversation_id"),
+                        turn_exchange_id=event_payload.get("turn_exchange_id"),
+                        options=event_payload.get("options"),
+                    )
                 tokens, maybe_title = self._parse_event(event_payload, state)
                 if maybe_title and title_update is None:
                     title_update = maybe_title
@@ -1918,7 +2016,14 @@ class ChatGPTWebClient:
         ):
             try:
                 conversation_payload = self._get_conversation_payload(recovered_conversation_id)
-            except RequestError:
+            except RequestError as error:
+                self._emit_event(
+                    on_event,
+                    "conversation_recovery_fetch_error",
+                    conversation_id=recovered_conversation_id,
+                    status_code=getattr(error, "status_code", None),
+                    message=str(error),
+                )
                 conversation_payload = None
             if isinstance(conversation_payload, dict):
                 (
@@ -1945,8 +2050,13 @@ class ChatGPTWebClient:
                 recovered_message, polled_text, polled_payload = self._poll_conversation_after_prepare(
                     recovered_conversation_id,
                     previous_message_id=parent_message_id,
-                    timeout=DEFAULT_STREAM_RECOVERY_POLL_TIMEOUT_SECONDS,
+                    timeout=max(
+                        DEFAULT_STREAM_RECOVERY_POLL_TIMEOUT_SECONDS,
+                        float(self.timeout),
+                    ),
                     interval=DEFAULT_STREAM_RECOVERY_POLL_INTERVAL_SECONDS,
+                    on_event=on_event,
+                    reason="stream_handoff_recovery",
                 )
             except RequestError:
                 recovered_message, polled_text, polled_payload = None, "", None

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -246,6 +246,19 @@ def _get_image_size(data: bytes, mime_type: str) -> tuple[int | None, int | None
 
 
 class ChatGPTWebClient:
+    @staticmethod
+    def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
+        if not isinstance(token, str) or token.count(".") < 2:
+            return None
+        try:
+            _header, payload, _signature = token.split(".", 2)
+            padded = payload + "=" * (-len(payload) % 4)
+            decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+            data = json.loads(decoded.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        return data if isinstance(data, dict) else None
+
     """Minimal sync adapter for chatgpt.com web sessions."""
 
     def __init__(
@@ -796,6 +809,22 @@ class ChatGPTWebClient:
         if payload.get("type") == "title_generation":
             title = payload.get("title")
             return [], title.strip() if isinstance(title, str) and title.strip() else None
+        if payload.get("type") == "resume_conversation_token":
+            kind = payload.get("kind")
+            token = payload.get("token")
+            if isinstance(kind, str) and kind.strip():
+                state["resume_kind"] = kind.strip()
+            if isinstance(token, str) and token.strip():
+                state["resume_token"] = token.strip()
+                decoded = ChatGPTWebClient._decode_jwt_payload(token.strip())
+                if isinstance(decoded, dict):
+                    turn_topic_id = decoded.get("turn_topic_id")
+                    if isinstance(turn_topic_id, str) and turn_topic_id.strip():
+                        state["resume_turn_topic_id"] = turn_topic_id.strip()
+            conversation_id = payload.get("conversation_id")
+            if isinstance(conversation_id, str) and conversation_id:
+                state["conversation_id"] = conversation_id
+            return [], None
         ChatGPTWebClient._capture_event_ids(payload, state)
         output: list[str] = []
         value = payload.get("v")
@@ -872,6 +901,11 @@ class ChatGPTWebClient:
             if isinstance(effort, str) and effort.strip():
                 state["observed_reasoning_effort"] = effort.strip()
                 break
+        turn_exchange_id = metadata.get("turn_exchange_id")
+        if isinstance(turn_exchange_id, str) and turn_exchange_id.strip():
+            state["turn_exchange_id"] = turn_exchange_id.strip()
+        if "resume_with_websockets" in metadata:
+            state["resume_with_websockets"] = bool(metadata.get("resume_with_websockets"))
 
     @staticmethod
     def _conversation_to_dict(
@@ -2113,12 +2147,27 @@ class ChatGPTWebClient:
                     parsed=event_payload,
                 )
                 if isinstance(event_payload, dict) and event_payload.get("type") == "stream_handoff":
+                    options = event_payload.get("options")
+                    if isinstance(options, list):
+                        state["stream_handoff_options"] = options
+                        for option in options:
+                            if not isinstance(option, dict):
+                                continue
+                            if option.get("type") != "resume_sse_endpoint":
+                                continue
+                            topic_id = option.get("topic_id")
+                            if isinstance(topic_id, str) and topic_id.strip():
+                                state["resume_turn_topic_id"] = topic_id.strip()
+                                break
                     self._emit_event(
                         on_event,
                         "stream_handoff",
                         conversation_id=event_payload.get("conversation_id"),
                         turn_exchange_id=event_payload.get("turn_exchange_id"),
                         options=event_payload.get("options"),
+                        resume_kind=state.get("resume_kind"),
+                        resume_turn_topic_id=state.get("resume_turn_topic_id"),
+                        resume_token_present=bool(state.get("resume_token")),
                     )
                 tokens, maybe_title = self._parse_event(event_payload, state)
                 if maybe_title and title_update is None:
@@ -2195,6 +2244,10 @@ class ChatGPTWebClient:
                 )
                 conversation_payload = None
             if isinstance(conversation_payload, dict):
+                self._capture_message_diagnostics(
+                    self._current_message_from_conversation(conversation_payload),
+                    state,
+                )
                 (
                     recovered_conversation_id,
                     recovered_message_id,
@@ -2243,6 +2296,10 @@ class ChatGPTWebClient:
                 if recovered_observed_reasoning_effort is None:
                     recovered_observed_reasoning_effort = poll_state.get("observed_reasoning_effort")
             if isinstance(polled_payload, dict):
+                self._capture_message_diagnostics(
+                    self._current_message_from_conversation(polled_payload),
+                    state,
+                )
                 if not recovered_text or recovered_message_id == parent_message_id:
                     (
                         _polled_conversation_id,
@@ -2301,5 +2358,10 @@ class ChatGPTWebClient:
                 else None,
                 observed_model=recovered_observed_model,
                 observed_reasoning_effort=recovered_observed_reasoning_effort,
+                resume_kind=state.get("resume_kind"),
+                resume_token_present=bool(state.get("resume_token")),
+                resume_turn_topic_id=state.get("resume_turn_topic_id"),
+                resume_with_websockets=bool(state.get("resume_with_websockets")),
+                turn_exchange_id=state.get("turn_exchange_id"),
             ),
         )

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -19,6 +19,10 @@ from urllib.parse import urlparse
 
 from .auth import CHAT_URL, DEFAULT_AUTH_FILE, build_base_headers, load_auth_data
 from .exceptions import MediaError, RequestError
+from .model_detection import (
+    detect_model_from_conversation_payload,
+    detect_reasoning_effort_from_conversation_payload,
+)
 from .types import AuthData, ChatConversation, ChatMetrics, ChatRequestDiagnostics, ChatResponse, MediaItem
 
 CHAT_REQUIREMENTS_URL = "https://chatgpt.com/backend-api/sentinel/chat-requirements"
@@ -35,6 +39,8 @@ DEFAULT_APPROVAL_POLL_TIMEOUT_SECONDS = 90.0
 DEFAULT_APPROVAL_POLL_INTERVAL_SECONDS = 2.0
 DEFAULT_PENDING_POLL_INTERVAL_SECONDS = 3.0
 DEFAULT_APPROVAL_SETTLE_DELAY_SECONDS = 2.0
+DEFAULT_STREAM_RECOVERY_POLL_TIMEOUT_SECONDS = 15.0
+DEFAULT_STREAM_RECOVERY_POLL_INTERVAL_SECONDS = 1.0
 TRACE_REDACTED = "<redacted>"
 TRACE_HEADER_REDACT_KEYS = {
     "authorization",
@@ -1146,6 +1152,27 @@ class ChatGPTWebClient:
             metrics=ChatMetrics(),
         )
 
+    @classmethod
+    def _recover_stream_result_from_conversation(
+        cls,
+        payload: dict[str, Any],
+        *,
+        conversation_id: str,
+        fallback_user_id: str | None = None,
+    ) -> tuple[str | None, str | None, str, str | None, str | None]:
+        response = cls._build_response_from_conversation_payload(
+            payload,
+            fallback_conversation_id=conversation_id,
+            fallback_user_id=fallback_user_id,
+        )
+        return (
+            response.conversation.conversation_id,
+            response.conversation.message_id,
+            response.text,
+            detect_model_from_conversation_payload(payload),
+            detect_reasoning_effort_from_conversation_payload(payload),
+        )
+
     def _is_conversation_idle(
         self,
         conversation_id: str,
@@ -1169,21 +1196,23 @@ class ChatGPTWebClient:
         previous_message_id: str | None,
         timeout: float,
         interval: float,
-    ) -> tuple[dict[str, Any] | None, str]:
+    ) -> tuple[dict[str, Any] | None, str, dict[str, Any] | None]:
         deadline = time.monotonic() + max(0.0, timeout)
         last_message: dict[str, Any] | None = None
         last_text = ""
+        last_payload: dict[str, Any] | None = None
         while True:
             payload = self._get_conversation_payload(conversation_id)
+            last_payload = payload
             message, text = self._latest_assistant_from_conversation(payload)
             if message is not None:
                 last_message = message
                 last_text = text
                 message_id = message.get("id")
                 if isinstance(message_id, str) and message_id != previous_message_id:
-                    return message, text
+                    return message, text, payload
             if time.monotonic() >= deadline:
-                return last_message, last_text
+                return last_message, last_text, last_payload
             time.sleep(max(0.5, interval))
 
     def _stream_backend_payload(
@@ -1435,7 +1464,7 @@ class ChatGPTWebClient:
         message_id = tool_id
         finish_reason = None
         if poll:
-            message, text = self._poll_conversation_after_prepare(
+            message, text, _payload = self._poll_conversation_after_prepare(
                 conversation_id,
                 previous_message_id=tool_id,
                 timeout=poll_timeout,
@@ -1879,18 +1908,93 @@ class ChatGPTWebClient:
                     pass
 
         total_latency = time.perf_counter() - started_at
+        recovered_text = "".join(full_chunks)
+        recovered_conversation_id = state.get("conversation_id")
+        recovered_message_id = state.get("message_id") or state.get("parent_message_id")
+        recovered_observed_model = state.get("observed_model")
+        recovered_observed_reasoning_effort = state.get("observed_reasoning_effort")
+        if isinstance(recovered_conversation_id, str) and recovered_conversation_id and (
+            not recovered_text or not recovered_message_id
+        ):
+            try:
+                conversation_payload = self._get_conversation_payload(recovered_conversation_id)
+            except RequestError:
+                conversation_payload = None
+            if isinstance(conversation_payload, dict):
+                (
+                    recovered_conversation_id,
+                    recovered_message_id,
+                    recovered_text,
+                    recovered_payload_model,
+                    recovered_payload_reasoning_effort,
+                ) = self._recover_stream_result_from_conversation(
+                    conversation_payload,
+                    conversation_id=recovered_conversation_id,
+                    fallback_user_id=user_id,
+                )
+                if recovered_observed_model is None:
+                    recovered_observed_model = recovered_payload_model
+                if recovered_observed_reasoning_effort is None:
+                    recovered_observed_reasoning_effort = recovered_payload_reasoning_effort
+        if isinstance(recovered_conversation_id, str) and recovered_conversation_id and (
+            not recovered_text
+            or not recovered_message_id
+            or recovered_message_id == parent_message_id
+        ):
+            try:
+                recovered_message, polled_text, polled_payload = self._poll_conversation_after_prepare(
+                    recovered_conversation_id,
+                    previous_message_id=parent_message_id,
+                    timeout=DEFAULT_STREAM_RECOVERY_POLL_TIMEOUT_SECONDS,
+                    interval=DEFAULT_STREAM_RECOVERY_POLL_INTERVAL_SECONDS,
+                )
+            except RequestError:
+                recovered_message, polled_text, polled_payload = None, "", None
+            if isinstance(recovered_message, dict):
+                polled_message_id = recovered_message.get("id")
+                if isinstance(polled_message_id, str) and polled_message_id:
+                    recovered_message_id = polled_message_id
+                if polled_text:
+                    recovered_text = polled_text
+                poll_state: dict[str, Any] = {}
+                self._capture_message_diagnostics(recovered_message, poll_state)
+                if recovered_observed_model is None:
+                    recovered_observed_model = poll_state.get("observed_model")
+                if recovered_observed_reasoning_effort is None:
+                    recovered_observed_reasoning_effort = poll_state.get("observed_reasoning_effort")
+            if isinstance(polled_payload, dict):
+                if not recovered_text or recovered_message_id == parent_message_id:
+                    (
+                        _polled_conversation_id,
+                        polled_payload_message_id,
+                        polled_payload_text,
+                        polled_payload_model,
+                        polled_payload_reasoning_effort,
+                    ) = self._recover_stream_result_from_conversation(
+                        polled_payload,
+                        conversation_id=recovered_conversation_id,
+                        fallback_user_id=user_id,
+                    )
+                    if isinstance(polled_payload_message_id, str) and polled_payload_message_id:
+                        recovered_message_id = polled_payload_message_id
+                    if polled_payload_text:
+                        recovered_text = polled_payload_text
+                    if recovered_observed_model is None:
+                        recovered_observed_model = polled_payload_model
+                    if recovered_observed_reasoning_effort is None:
+                        recovered_observed_reasoning_effort = polled_payload_reasoning_effort
         self.prefetched_requirements = None
         self.prefetched_proof_header = None
         self.prefetched_ts = 0.0
         return ChatResponse(
-            text="".join(full_chunks),
+            text=recovered_text,
             title=title_update,
             conversation=ChatConversation(
-                conversation_id=state.get("conversation_id"),
-                message_id=state.get("message_id") or state.get("parent_message_id"),
+                conversation_id=recovered_conversation_id,
+                message_id=recovered_message_id,
                 user_id=user_id,
                 finish_reason=state.get("finish_reason"),
-                parent_message_id=state.get("parent_message_id"),
+                parent_message_id=recovered_message_id,
                 is_thinking=False,
             ),
             metrics=ChatMetrics(
@@ -1914,7 +2018,7 @@ class ChatGPTWebClient:
                 message_count=len(payload.get("messages", []))
                 if isinstance(payload.get("messages"), list)
                 else None,
-                observed_model=state.get("observed_model"),
-                observed_reasoning_effort=state.get("observed_reasoning_effort"),
+                observed_model=recovered_observed_model,
+                observed_reasoning_effort=recovered_observed_reasoning_effort,
             ),
         )

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -27,7 +27,8 @@ CHAT_CONVERSATION_PREPARE_URL = "https://chatgpt.com/backend-api/f/conversation/
 CHAT_CONVERSATION_URL = "https://chatgpt.com/backend-api/conversation/{conversation_id}"
 CHAT_CONVERSATIONS_URL = "https://chatgpt.com/backend-api/conversations"
 CHAT_FILES_URL = "https://chatgpt.com/backend-api/files"
-DEFAULT_MODEL = "gpt-4o-mini"
+DEFAULT_MODEL = "gpt-5-3-mini"
+DEFAULT_THINKING_MODEL = "gpt-5-5-thinking"
 DEFAULT_TIMEOUT_SECONDS = 90
 PREFETCH_TTL_SECONDS = 20.0
 DEFAULT_APPROVAL_POLL_TIMEOUT_SECONDS = 90.0
@@ -44,6 +45,8 @@ TRACE_HEADER_REDACT_KEYS = {
     "openai-sentinel-turnstile-token",
 }
 MODEL_ALIASES = {
+    "instant": DEFAULT_MODEL,
+    "thinking": DEFAULT_THINKING_MODEL,
     "gpt-5.1": "gpt-5-1",
     "gpt-4.1": "gpt-4.1",
     "gpt-4.1-mini": "gpt-4.1-mini",
@@ -1034,11 +1037,33 @@ class ChatGPTWebClient:
     @staticmethod
     def _normalize_reasoning_effort(reasoning_effort: str | None) -> str | None:
         normalized_effort = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
-        if normalized_effort in {"", "off", "none", "-"}:
+        if normalized_effort == "medium":
+            normalized_effort = "standard"
+        elif normalized_effort == "high":
+            normalized_effort = "extended"
+        elif normalized_effort in {"", "off", "none", "-", "instant"}:
             normalized_effort = None
         if normalized_effort not in {None, "standard", "extended"}:
-            raise ValueError("reasoning_effort must be one of: standard, extended, off/none/-")
+            raise ValueError(
+                "reasoning_effort must be one of: instant, medium, high, standard, extended, off/none/-"
+            )
         return normalized_effort
+
+    @staticmethod
+    def _resolve_model(model: str | None, reasoning_effort: str | None) -> str:
+        normalized_model = None
+        if isinstance(model, str):
+            model = model.strip()
+            if not model:
+                raise ValueError("model must not be empty")
+            normalized_model = MODEL_ALIASES.get(model.lower(), MODEL_ALIASES.get(model, model))
+
+        requested_mode = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
+        if normalized_model is not None:
+            return normalized_model
+        if requested_mode in {"medium", "high", "standard", "extended"}:
+            return DEFAULT_THINKING_MODEL
+        return DEFAULT_MODEL
 
     @staticmethod
     def _current_message_from_conversation(payload: dict[str, Any]) -> dict[str, Any] | None:
@@ -1638,7 +1663,7 @@ class ChatGPTWebClient:
         self,
         prompt: str,
         *,
-        model: str = DEFAULT_MODEL,
+        model: str | None = None,
         system: str | None = None,
         web_search: bool = False,
         temporary: bool = False,
@@ -1648,6 +1673,7 @@ class ChatGPTWebClient:
         on_token: Callable[[str], None] | None = None,
     ) -> ChatResponse:
         normalized_effort = self._normalize_reasoning_effort(reasoning_effort)
+        resolved_model = self._resolve_model(model, reasoning_effort)
 
         normalized_media = self._normalize_media_items(media)
         image_requests = self._upload_media_files(normalized_media) if normalized_media else None
@@ -1672,7 +1698,7 @@ class ChatGPTWebClient:
         payload: dict[str, Any] = {
             "action": "next",
             "parent_message_id": parent_message_id,
-            "model": MODEL_ALIASES.get(model, model),
+            "model": resolved_model,
             "conversation_mode": {"kind": "primary_assistant"},
             "enable_message_followups": False,
             "supports_buffering": True,

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -304,6 +304,10 @@ class ChatGPTWebClient:
                 state.setdefault("resume_turn_topic_id", normalized_topic_id)
         if option_types:
             state["handoff_option_types"] = tuple(option_types)
+        if state.get("resume_ws_topic_id"):
+            state["resume_transport_preference"] = "ws_topic"
+        elif state.get("resume_sse_topic_id"):
+            state["resume_transport_preference"] = "sse_topic"
 
     """Minimal sync adapter for chatgpt.com web sessions."""
 
@@ -2233,6 +2237,7 @@ class ChatGPTWebClient:
                         resume_sse_topic_id=state.get("resume_sse_topic_id"),
                         resume_ws_topic_id=state.get("resume_ws_topic_id"),
                         handoff_option_types=list(state.get("handoff_option_types", ()) or ()),
+                        resume_transport_preference=state.get("resume_transport_preference"),
                         resume_token_present=bool(state.get("resume_token")),
                     )
                 tokens, maybe_title = self._parse_event(event_payload, state)
@@ -2328,6 +2333,25 @@ class ChatGPTWebClient:
                     previous_message_id=parent_message_id,
                     allow_global_fallback=allow_global_recovery_fallback,
                 )
+                if recovered_text or (
+                    isinstance(recovered_message_id, str)
+                    and recovered_message_id
+                    and recovered_message_id != parent_message_id
+                ):
+                    preferred_transport = state.get("resume_transport_preference")
+                    if isinstance(preferred_transport, str) and preferred_transport:
+                        state["handoff_recovery_mode"] = "conversation_snapshot"
+                        self._emit_event(
+                            on_event,
+                            "stream_handoff_recovery_mode",
+                            conversation_id=recovered_conversation_id,
+                            preferred_transport=preferred_transport,
+                            recovery_mode="conversation_snapshot",
+                            reason="conversation_payload_recovered",
+                            resume_turn_topic_id=state.get("resume_turn_topic_id"),
+                            resume_sse_topic_id=state.get("resume_sse_topic_id"),
+                            resume_ws_topic_id=state.get("resume_ws_topic_id"),
+                        )
                 if recovered_observed_model is None:
                     recovered_observed_model = recovered_payload_model
                 if recovered_observed_reasoning_effort is None:
@@ -2337,6 +2361,20 @@ class ChatGPTWebClient:
             or not recovered_message_id
             or recovered_message_id == parent_message_id
         ):
+            preferred_transport = state.get("resume_transport_preference")
+            if isinstance(preferred_transport, str) and preferred_transport:
+                state["handoff_recovery_mode"] = "poll_recovery"
+                self._emit_event(
+                    on_event,
+                    "stream_handoff_recovery_mode",
+                    conversation_id=recovered_conversation_id,
+                    preferred_transport=preferred_transport,
+                    recovery_mode="poll_recovery",
+                    reason="topic_transport_not_implemented",
+                    resume_turn_topic_id=state.get("resume_turn_topic_id"),
+                    resume_sse_topic_id=state.get("resume_sse_topic_id"),
+                    resume_ws_topic_id=state.get("resume_ws_topic_id"),
+                )
             try:
                 recovered_message, polled_text, polled_payload = self._poll_conversation_after_prepare(
                     recovered_conversation_id,
@@ -2435,6 +2473,8 @@ class ChatGPTWebClient:
                 resume_sse_topic_id=state.get("resume_sse_topic_id"),
                 resume_ws_topic_id=state.get("resume_ws_topic_id"),
                 handoff_option_types=tuple(state.get("handoff_option_types", ()) or ()),
+                resume_transport_preference=state.get("resume_transport_preference"),
+                handoff_recovery_mode=state.get("handoff_recovery_mode"),
                 resume_with_websockets=bool(state.get("resume_with_websockets")),
                 turn_exchange_id=state.get("turn_exchange_id"),
                 resume_conduit_uuid=state.get("resume_conduit_uuid"),

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -789,6 +789,7 @@ class ChatGPTWebClient:
         if payload.get("type") == "title_generation":
             title = payload.get("title")
             return [], title.strip() if isinstance(title, str) and title.strip() else None
+        ChatGPTWebClient._capture_event_ids(payload, state)
         output: list[str] = []
         value = payload.get("v")
         path = payload.get("p")
@@ -832,6 +833,17 @@ class ChatGPTWebClient:
         if payload.get("type") == "server_ste_metadata":
             ChatGPTWebClient._capture_metadata_diagnostics(payload.get("metadata"), state)
         return output, None
+
+    @staticmethod
+    def _capture_event_ids(payload: Any, state: dict[str, Any]) -> None:
+        if not isinstance(payload, dict):
+            return
+        conversation_id = payload.get("conversation_id")
+        if isinstance(conversation_id, str) and conversation_id.strip():
+            state["conversation_id"] = conversation_id.strip()
+        message_id = payload.get("message_id")
+        if isinstance(message_id, str) and message_id.strip():
+            state["message_id"] = message_id.strip()
 
     @staticmethod
     def _capture_message_diagnostics(message: Any, state: dict[str, Any]) -> None:

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -1166,6 +1166,20 @@ class ChatGPTWebClient:
         messages.reverse()
         return messages
 
+    @staticmethod
+    def _branch_messages_after(
+        messages: list[dict[str, Any]],
+        *,
+        previous_message_id: str | None,
+    ) -> list[dict[str, Any]]:
+        if not previous_message_id:
+            return messages
+        for index, message in enumerate(messages):
+            message_id = message.get("id")
+            if isinstance(message_id, str) and message_id == previous_message_id:
+                return messages[index + 1 :]
+        return []
+
     @classmethod
     def _latest_branch_assistant_response(
         cls,
@@ -1173,15 +1187,20 @@ class ChatGPTWebClient:
         *,
         previous_message_id: str | None = None,
     ) -> tuple[dict[str, Any] | None, str]:
-        branch_messages = cls._current_branch_messages_from_conversation(payload)
+        branch_messages = cls._branch_messages_after(
+            cls._current_branch_messages_from_conversation(payload),
+            previous_message_id=previous_message_id,
+        )
         for message in reversed(branch_messages):
             message_id = message.get("id")
-            if not isinstance(message_id, str) or not message_id or message_id == previous_message_id:
+            if not isinstance(message_id, str) or not message_id:
                 continue
             if cls._message_role(message) != "assistant":
                 continue
             recipient = cls._message_recipient(message)
             if recipient not in {None, "all"}:
+                continue
+            if message.get("channel") == "commentary":
                 continue
             text = cls._conversation_message_text(message)
             if not text:

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -1262,6 +1262,7 @@ class ChatGPTWebClient:
         payload: dict[str, Any],
         *,
         previous_message_id: str | None = None,
+        allow_global_fallback: bool = True,
     ) -> tuple[dict[str, Any] | None, str]:
         branch_messages = cls._branch_messages_after(
             cls._current_branch_messages_from_conversation(payload),
@@ -1282,7 +1283,7 @@ class ChatGPTWebClient:
             if not text:
                 continue
             return message, text
-        if branch_messages:
+        if branch_messages or not allow_global_fallback:
             return None, ""
         message, text = cls._latest_assistant_from_conversation(payload)
         message_id = message.get("id") if isinstance(message, dict) else None
@@ -1298,11 +1299,13 @@ class ChatGPTWebClient:
         fallback_conversation_id: str,
         fallback_user_id: str | None = None,
         previous_message_id: str | None = None,
+        allow_global_fallback: bool = True,
     ) -> ChatResponse | None:
         status = _status_from_payload(payload)
         selected_message, text = cls._latest_branch_assistant_response(
             payload,
             previous_message_id=previous_message_id,
+            allow_global_fallback=allow_global_fallback,
         )
         if selected_message is None:
             return None
@@ -1375,12 +1378,14 @@ class ChatGPTWebClient:
         conversation_id: str,
         fallback_user_id: str | None = None,
         previous_message_id: str | None = None,
+        allow_global_fallback: bool = True,
     ) -> tuple[str | None, str | None, str, str | None, str | None]:
         response = cls._build_recovery_response_from_conversation_payload(
             payload,
             fallback_conversation_id=conversation_id,
             fallback_user_id=fallback_user_id,
             previous_message_id=previous_message_id,
+            allow_global_fallback=allow_global_fallback,
         )
         if response is None:
             return (
@@ -1421,8 +1426,10 @@ class ChatGPTWebClient:
         previous_message_id: str | None,
         timeout: float,
         interval: float,
+        on_token: Callable[[str], None] | None = None,
         on_event: Callable[[dict[str, Any]], None] | None = None,
         reason: str = "approval_poll",
+        allow_global_fallback: bool = True,
     ) -> tuple[dict[str, Any] | None, str, dict[str, Any] | None]:
         self._emit_event(
             on_event,
@@ -1437,6 +1444,8 @@ class ChatGPTWebClient:
         last_message: dict[str, Any] | None = None
         last_text = ""
         last_payload: dict[str, Any] | None = None
+        streamed_message_id: str | None = None
+        streamed_text = ""
         attempt = 0
         while True:
             attempt += 1
@@ -1472,6 +1481,7 @@ class ChatGPTWebClient:
             message, text = self._latest_branch_assistant_response(
                 payload,
                 previous_message_id=previous_message_id,
+                allow_global_fallback=allow_global_fallback,
             )
             metadata = message.get("metadata") if isinstance(message, dict) else None
             finish_details = metadata.get("finish_details") if isinstance(metadata, dict) else None
@@ -1483,6 +1493,28 @@ class ChatGPTWebClient:
                 and isinstance(finish_type, str)
                 and bool(finish_type)
             )
+            message_id = message.get("id") if isinstance(message, dict) else None
+            if isinstance(message_id, str) and message_id and text:
+                if message_id != streamed_message_id:
+                    streamed_message_id = message_id
+                    streamed_text = ""
+                delta = text
+                if streamed_text and text.startswith(streamed_text):
+                    delta = text[len(streamed_text) :]
+                if delta:
+                    streamed_text = text
+                    self._emit_event(
+                        on_event,
+                        "conversation_poll_stream_delta",
+                        conversation_id=conversation_id,
+                        message_id=message_id,
+                        attempt=attempt,
+                        delta=delta,
+                        text_length=len(text),
+                        reason=reason,
+                    )
+                    if on_token is not None:
+                        on_token(delta)
             self._emit_event(
                 on_event,
                 "conversation_poll_attempt",
@@ -1493,14 +1525,13 @@ class ChatGPTWebClient:
                 lifecycle_status=status.status,
                 async_status=status.async_status,
                 finish_reason=status.finish_reason,
-                latest_message_id=message.get("id") if isinstance(message, dict) else None,
+                latest_message_id=message_id,
                 text_length=len(text),
                 reason=reason,
             )
             if (completed_via_status or completed_via_fallback) and message is not None:
                 last_message = message
                 last_text = text
-                message_id = message.get("id")
                 if isinstance(message_id, str) and message_id:
                     self._emit_event(
                         on_event,
@@ -2264,6 +2295,7 @@ class ChatGPTWebClient:
         recovered_message_id = state.get("message_id") or state.get("parent_message_id")
         recovered_observed_model = state.get("observed_model")
         recovered_observed_reasoning_effort = state.get("observed_reasoning_effort")
+        allow_global_recovery_fallback = not bool(conversation_id)
         if isinstance(recovered_conversation_id, str) and recovered_conversation_id and (
             not recovered_text or not recovered_message_id
         ):
@@ -2294,6 +2326,7 @@ class ChatGPTWebClient:
                     conversation_id=recovered_conversation_id,
                     fallback_user_id=user_id,
                     previous_message_id=parent_message_id,
+                    allow_global_fallback=allow_global_recovery_fallback,
                 )
                 if recovered_observed_model is None:
                     recovered_observed_model = recovered_payload_model
@@ -2313,8 +2346,10 @@ class ChatGPTWebClient:
                         float(self.timeout),
                     ),
                     interval=DEFAULT_STREAM_RECOVERY_POLL_INTERVAL_SECONDS,
+                    on_token=on_token,
                     on_event=on_event,
                     reason="stream_handoff_recovery",
+                    allow_global_fallback=allow_global_recovery_fallback,
                 )
             except RequestError:
                 recovered_message, polled_text, polled_payload = None, "", None
@@ -2347,6 +2382,7 @@ class ChatGPTWebClient:
                         conversation_id=recovered_conversation_id,
                         fallback_user_id=user_id,
                         previous_message_id=parent_message_id,
+                        allow_global_fallback=allow_global_recovery_fallback,
                     )
                     if isinstance(polled_payload_message_id, str) and polled_payload_message_id:
                         recovered_message_id = polled_payload_message_id

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import json
@@ -682,7 +683,188 @@ class ChatGPTWebClient:
         websocket_url = data.get("websocket_url")
         if not isinstance(websocket_url, str) or not websocket_url.strip():
             raise RequestError("celsius ws user response missing websocket_url")
+        data["websocket_url"] = websocket_url.strip()
         return data
+
+    @staticmethod
+    def _parse_encoded_stream_item(encoded_item: str) -> dict[str, str] | None:
+        if not isinstance(encoded_item, str) or not encoded_item:
+            return None
+        last_event: str | None = None
+        last_data: str | None = None
+        current_event: str | None = None
+        current_data: list[str] = []
+        lines = encoded_item.replace("\r\n", "\n").split("\n")
+        for line in lines:
+            if not line:
+                if current_event is not None or current_data:
+                    last_event = current_event
+                    last_data = "\n".join(current_data)
+                current_event = None
+                current_data = []
+                continue
+            if line.startswith("event:"):
+                current_event = line.split(":", 1)[1].lstrip()
+                continue
+            if line.startswith("data:"):
+                current_data.append(line.split(":", 1)[1].lstrip())
+        if current_event is not None or current_data:
+            last_event = current_event
+            last_data = "\n".join(current_data)
+        if last_data is None:
+            return None
+        return {"event": last_event or "message", "data": last_data}
+
+    async def _stream_handoff_via_ws_topic_async(
+        self,
+        topic_id: str,
+        *,
+        state: dict[str, Any],
+        on_event: Callable[[dict[str, Any]], None] | None,
+        on_token: Callable[[str], None] | None,
+    ) -> None:
+        import websockets
+
+        ws_info = self._probe_celsius_ws_user()
+        websocket_url = ws_info.get("websocket_url")
+        if not isinstance(websocket_url, str) or not websocket_url:
+            raise RequestError("celsius ws user response missing websocket_url")
+        state["resume_ws_url"] = websocket_url
+        self._capture_ws_url_diagnostics(websocket_url, state)
+        headers = self._build_headers({"origin": CHAT_URL.rstrip("/")})
+        connect_command = {"id": 1, "command": {"type": "connect", "presence": {"type": "presence", "state": "foreground"}}}
+        subscribe_command = {"id": 2, "command": {"type": "subscribe", "topic_id": topic_id, "offset": "0"}}
+        completed = False
+
+        def process_ws_message(message: dict[str, Any]) -> None:
+            nonlocal completed
+            payload = message.get("payload")
+            if not isinstance(payload, dict) or payload.get("type") != "conversation-turn-stream":
+                return
+            inner = payload.get("payload")
+            if not isinstance(inner, dict):
+                return
+            inner_type = inner.get("type")
+            if inner_type == "done":
+                completed = True
+                self._emit_event(on_event, "raw_ws_done", topic_id=topic_id)
+                return
+            if inner_type != "stream-item":
+                return
+            encoded_item = inner.get("encoded_item")
+            parsed_item = self._parse_encoded_stream_item(encoded_item)
+            if not parsed_item:
+                return
+            raw_data = parsed_item["data"]
+            if raw_data == "[DONE]":
+                completed = True
+                self._emit_event(on_event, "raw_ws_done", topic_id=topic_id)
+                return
+            try:
+                parsed_payload = json.loads(raw_data)
+            except ValueError:
+                self._emit_event(
+                    on_event,
+                    "raw_ws_event",
+                    topic_id=topic_id,
+                    raw=raw_data,
+                    parsed=None,
+                    event=parsed_item["event"],
+                )
+                return
+            self._emit_event(
+                on_event,
+                "raw_ws_event",
+                topic_id=topic_id,
+                raw=raw_data,
+                parsed=parsed_payload,
+                event=parsed_item["event"],
+            )
+            tokens, maybe_title = self._parse_event(parsed_payload, state)
+            if maybe_title:
+                state.setdefault("title_update", maybe_title)
+            for token in tokens:
+                if token and on_token is not None:
+                    on_token(token)
+
+        async with websockets.connect(
+            websocket_url,
+            additional_headers=headers,
+            open_timeout=10,
+            ping_interval=None,
+            ping_timeout=None,
+            max_size=None,
+        ) as websocket:
+            self._emit_event(
+                on_event,
+                "stream_handoff_ws_connected",
+                topic_id=topic_id,
+                websocket_url_host=state.get("resume_ws_url_host"),
+                websocket_url_scheme=state.get("resume_ws_url_scheme"),
+            )
+            await websocket.send(json.dumps([connect_command, subscribe_command], ensure_ascii=False))
+            while not completed:
+                try:
+                    raw_frame = await asyncio.wait_for(websocket.recv(), timeout=max(float(self.timeout), 30.0))
+                except TimeoutError as error:
+                    raise RequestError("ws topic stream timed out while waiting for a frame") from error
+                if not isinstance(raw_frame, str):
+                    continue
+                self._emit_event(on_event, "raw_ws_frame", topic_id=topic_id, raw=raw_frame)
+                try:
+                    items = json.loads(raw_frame)
+                except ValueError:
+                    continue
+                if not isinstance(items, list):
+                    items = [items]
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    if item.get("type") == "message" and item.get("topic_id") == topic_id:
+                        process_ws_message(item)
+                        continue
+                    reply = item.get("reply")
+                    if item.get("id") != 2 or not isinstance(reply, dict):
+                        continue
+                    self._emit_event(
+                        on_event,
+                        "stream_handoff_ws_subscribed",
+                        topic_id=topic_id,
+                        recovered=bool(reply.get("recovered")),
+                        catchup_count=len(reply.get("catchups") or ()),
+                        last_offset_present=reply.get("last_offset") is not None,
+                    )
+                    catchups = reply.get("catchups")
+                    if isinstance(catchups, list):
+                        for catchup in catchups:
+                            if isinstance(catchup, dict):
+                                process_ws_message(catchup)
+                if completed:
+                    break
+        if not completed:
+            raise RequestError("ws topic stream ended before a done event was received")
+
+    def _stream_handoff_via_ws_topic(
+        self,
+        topic_id: str,
+        *,
+        state: dict[str, Any],
+        on_event: Callable[[dict[str, Any]], None] | None,
+        on_token: Callable[[str], None] | None,
+    ) -> None:
+        try:
+            asyncio.run(
+                self._stream_handoff_via_ws_topic_async(
+                    topic_id,
+                    state=state,
+                    on_event=on_event,
+                    on_token=on_token,
+                )
+            )
+        except RequestError:
+            raise
+        except Exception as error:
+            raise RequestError(f"ws topic stream failed: {error}") from error
 
     def _build_proof_header(self, requirements: dict[str, Any]) -> str | None:
         proof_block = requirements.get("proofofwork")
@@ -2190,6 +2372,7 @@ class ChatGPTWebClient:
         last_token_latency: float | None = None
         full_chunks: list[str] = []
         title_update: str | None = None
+        ws_handoff_consumed = False
         started_at = time.perf_counter()
         payload_path: str | None = None
         process: subprocess.Popen | None = None
@@ -2202,6 +2385,18 @@ class ChatGPTWebClient:
         with tempfile.NamedTemporaryFile(delete=False) as header_file:
             header_path = header_file.name
         try:
+            def record_token(token: str) -> None:
+                nonlocal first_token_latency, last_token_latency
+                if not token:
+                    return
+                now = time.perf_counter()
+                if first_token_latency is None:
+                    first_token_latency = now - started_at
+                last_token_latency = now - started_at
+                full_chunks.append(token)
+                if on_token is not None:
+                    on_token(token)
+
             with tempfile.NamedTemporaryFile(delete=False) as payload_file:
                 payload_file.write(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
                 payload_path = payload_file.name
@@ -2294,19 +2489,50 @@ class ChatGPTWebClient:
                         resume_ws_url_scheme=state.get("resume_ws_url_scheme"),
                         resume_ws_url_host=state.get("resume_ws_url_host"),
                     )
+                    if (
+                        not ws_handoff_consumed
+                        and state.get("resume_transport_preference") == "ws_topic"
+                        and isinstance(state.get("resume_ws_topic_id"), str)
+                        and state.get("resume_ws_topic_id")
+                    ):
+                        topic_id = str(state["resume_ws_topic_id"])
+                        try:
+                            self._stream_handoff_via_ws_topic(
+                                topic_id,
+                                state=state,
+                                on_event=on_event,
+                                on_token=record_token,
+                            )
+                        except RequestError as error:
+                            self._emit_event(
+                                on_event,
+                                "stream_handoff_ws_failed",
+                                topic_id=topic_id,
+                                message=str(error),
+                            )
+                        else:
+                            ws_handoff_consumed = True
+                            if title_update is None:
+                                ws_title = state.get("title_update")
+                                if isinstance(ws_title, str) and ws_title.strip():
+                                    title_update = ws_title.strip()
+                            state["handoff_recovery_mode"] = "ws_topic_stream"
+                            self._emit_event(
+                                on_event,
+                                "stream_handoff_recovery_mode",
+                                conversation_id=state.get("conversation_id"),
+                                preferred_transport="ws_topic",
+                                recovery_mode="ws_topic_stream",
+                                reason="subscribed_ws_topic",
+                                resume_turn_topic_id=state.get("resume_turn_topic_id"),
+                                resume_sse_topic_id=state.get("resume_sse_topic_id"),
+                                resume_ws_topic_id=state.get("resume_ws_topic_id"),
+                            )
                 tokens, maybe_title = self._parse_event(event_payload, state)
                 if maybe_title and title_update is None:
                     title_update = maybe_title
                 for token in tokens:
-                    if not token:
-                        continue
-                    now = time.perf_counter()
-                    if first_token_latency is None:
-                        first_token_latency = now - started_at
-                    last_token_latency = now - started_at
-                    full_chunks.append(token)
-                    if on_token is not None:
-                        on_token(token)
+                    record_token(token)
             if process.stderr is not None:
                 stderr_text = process.stderr.read().decode("utf-8", errors="replace")
             return_code = process.wait()
@@ -2355,7 +2581,7 @@ class ChatGPTWebClient:
         recovered_observed_model = state.get("observed_model")
         recovered_observed_reasoning_effort = state.get("observed_reasoning_effort")
         allow_global_recovery_fallback = not bool(conversation_id)
-        if isinstance(recovered_conversation_id, str) and recovered_conversation_id and (
+        if not ws_handoff_consumed and isinstance(recovered_conversation_id, str) and recovered_conversation_id and (
             not recovered_text or not recovered_message_id
         ):
             try:
@@ -2410,7 +2636,7 @@ class ChatGPTWebClient:
                     recovered_observed_model = recovered_payload_model
                 if recovered_observed_reasoning_effort is None:
                     recovered_observed_reasoning_effort = recovered_payload_reasoning_effort
-        if isinstance(recovered_conversation_id, str) and recovered_conversation_id and (
+        if not ws_handoff_consumed and isinstance(recovered_conversation_id, str) and recovered_conversation_id and (
             not recovered_text
             or not recovered_message_id
             or recovered_message_id == parent_message_id

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -23,6 +23,7 @@ from .model_detection import (
     detect_model_from_conversation_payload,
     detect_reasoning_effort_from_conversation_payload,
 )
+from .status import _status_from_payload
 from .types import AuthData, ChatConversation, ChatMetrics, ChatRequestDiagnostics, ChatResponse, MediaItem
 
 CHAT_REQUIREMENTS_URL = "https://chatgpt.com/backend-api/sentinel/chat-requirements"
@@ -1121,6 +1122,125 @@ class ChatGPTWebClient:
         message = node.get("message")
         return message if isinstance(message, dict) else None
 
+    @staticmethod
+    def _message_role(message: dict[str, Any] | None) -> str | None:
+        if not isinstance(message, dict):
+            return None
+        author = message.get("author")
+        if not isinstance(author, dict):
+            return None
+        role = author.get("role")
+        return role if isinstance(role, str) and role else None
+
+    @staticmethod
+    def _message_recipient(message: dict[str, Any] | None) -> str | None:
+        if not isinstance(message, dict):
+            return None
+        recipient = message.get("recipient")
+        return recipient if isinstance(recipient, str) and recipient else None
+
+    @classmethod
+    def _current_branch_messages_from_conversation(
+        cls,
+        payload: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        mapping = payload.get("mapping")
+        current_node = payload.get("current_node")
+        if not isinstance(mapping, dict) or not isinstance(current_node, str) or not current_node.strip():
+            return []
+        messages: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        node_id = current_node
+        while isinstance(node_id, str) and node_id.strip():
+            if node_id in seen:
+                break
+            seen.add(node_id)
+            node = mapping.get(node_id)
+            if not isinstance(node, dict):
+                break
+            message = node.get("message")
+            if isinstance(message, dict):
+                messages.append(message)
+            parent = node.get("parent")
+            node_id = parent if isinstance(parent, str) else ""
+        messages.reverse()
+        return messages
+
+    @classmethod
+    def _latest_branch_assistant_response(
+        cls,
+        payload: dict[str, Any],
+        *,
+        previous_message_id: str | None = None,
+    ) -> tuple[dict[str, Any] | None, str]:
+        branch_messages = cls._current_branch_messages_from_conversation(payload)
+        for message in reversed(branch_messages):
+            message_id = message.get("id")
+            if not isinstance(message_id, str) or not message_id or message_id == previous_message_id:
+                continue
+            if cls._message_role(message) != "assistant":
+                continue
+            recipient = cls._message_recipient(message)
+            if recipient not in {None, "all"}:
+                continue
+            text = cls._conversation_message_text(message)
+            if not text:
+                continue
+            return message, text
+        if branch_messages:
+            return None, ""
+        message, text = cls._latest_assistant_from_conversation(payload)
+        message_id = message.get("id") if isinstance(message, dict) else None
+        if isinstance(message_id, str) and message_id and message_id != previous_message_id and text:
+            return message, text
+        return None, ""
+
+    @classmethod
+    def _build_recovery_response_from_conversation_payload(
+        cls,
+        payload: dict[str, Any],
+        *,
+        fallback_conversation_id: str,
+        fallback_user_id: str | None = None,
+        previous_message_id: str | None = None,
+    ) -> ChatResponse | None:
+        status = _status_from_payload(payload)
+        selected_message, text = cls._latest_branch_assistant_response(
+            payload,
+            previous_message_id=previous_message_id,
+        )
+        if selected_message is None:
+            return None
+        message_id = selected_message.get("id") if isinstance(selected_message.get("id"), str) else None
+        metadata = selected_message.get("metadata") if isinstance(selected_message, dict) else None
+        finish_reason = status.finish_reason or "stop"
+        if isinstance(metadata, dict):
+            finish_details = metadata.get("finish_details")
+            if isinstance(finish_details, dict) and isinstance(finish_details.get("type"), str):
+                finish_reason = finish_details["type"]
+        is_completed = status.status == "completed" and status.message_id != previous_message_id
+        has_completed_message_fallback = (
+            status.status == "unknown"
+            and isinstance(message_id, str)
+            and message_id != previous_message_id
+            and isinstance(finish_reason, str)
+            and bool(finish_reason)
+        )
+        if not is_completed and not has_completed_message_fallback:
+            return None
+        return ChatResponse(
+            text=text,
+            conversation=ChatConversation(
+                conversation_id=str(payload.get("conversation_id") or fallback_conversation_id),
+                message_id=message_id,
+                user_id=fallback_user_id,
+                finish_reason=finish_reason,
+                parent_message_id=message_id,
+                is_thinking=False,
+            ),
+            metrics=ChatMetrics(),
+        )
+
     @classmethod
     def _build_response_from_conversation_payload(
         cls,
@@ -1159,12 +1279,22 @@ class ChatGPTWebClient:
         *,
         conversation_id: str,
         fallback_user_id: str | None = None,
+        previous_message_id: str | None = None,
     ) -> tuple[str | None, str | None, str, str | None, str | None]:
-        response = cls._build_response_from_conversation_payload(
+        response = cls._build_recovery_response_from_conversation_payload(
             payload,
             fallback_conversation_id=conversation_id,
             fallback_user_id=fallback_user_id,
+            previous_message_id=previous_message_id,
         )
+        if response is None:
+            return (
+                str(payload.get("conversation_id") or conversation_id),
+                None,
+                "",
+                detect_model_from_conversation_payload(payload),
+                detect_reasoning_effort_from_conversation_payload(payload),
+            )
         return (
             response.conversation.conversation_id,
             response.conversation.message_id,
@@ -1243,22 +1373,40 @@ class ChatGPTWebClient:
                 time.sleep(max(0.5, interval))
                 continue
             last_payload = payload
-            message, text = self._latest_assistant_from_conversation(payload)
+            status = _status_from_payload(payload)
+            message, text = self._latest_branch_assistant_response(
+                payload,
+                previous_message_id=previous_message_id,
+            )
+            metadata = message.get("metadata") if isinstance(message, dict) else None
+            finish_details = metadata.get("finish_details") if isinstance(metadata, dict) else None
+            finish_type = finish_details.get("type") if isinstance(finish_details, dict) else None
+            completed_via_status = status.status == "completed"
+            completed_via_fallback = (
+                status.status == "unknown"
+                and isinstance(message, dict)
+                and isinstance(finish_type, str)
+                and bool(finish_type)
+            )
             self._emit_event(
                 on_event,
                 "conversation_poll_attempt",
                 conversation_id=conversation_id,
                 previous_message_id=previous_message_id,
                 attempt=attempt,
+                current_message_id=status.message_id,
+                lifecycle_status=status.status,
+                async_status=status.async_status,
+                finish_reason=status.finish_reason,
                 latest_message_id=message.get("id") if isinstance(message, dict) else None,
                 text_length=len(text),
                 reason=reason,
             )
-            if message is not None:
+            if (completed_via_status or completed_via_fallback) and message is not None:
                 last_message = message
                 last_text = text
                 message_id = message.get("id")
-                if isinstance(message_id, str) and message_id != previous_message_id:
+                if isinstance(message_id, str) and message_id:
                     self._emit_event(
                         on_event,
                         "conversation_poll_completed",
@@ -1266,6 +1414,8 @@ class ChatGPTWebClient:
                         message_id=message_id,
                         attempt=attempt,
                         text_length=len(text),
+                        lifecycle_status=status.status,
+                        async_status=status.async_status,
                         reason=reason,
                     )
                     return message, text, payload
@@ -2036,6 +2186,7 @@ class ChatGPTWebClient:
                     conversation_payload,
                     conversation_id=recovered_conversation_id,
                     fallback_user_id=user_id,
+                    previous_message_id=parent_message_id,
                 )
                 if recovered_observed_model is None:
                     recovered_observed_model = recovered_payload_model
@@ -2084,6 +2235,7 @@ class ChatGPTWebClient:
                         polled_payload,
                         conversation_id=recovered_conversation_id,
                         fallback_user_id=user_id,
+                        previous_message_id=parent_message_id,
                     )
                     if isinstance(polled_payload_message_id, str) and polled_payload_message_id:
                         recovered_message_id = polled_payload_message_id

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -32,6 +32,7 @@ CHAT_CONVERSATION_PREPARE_URL = "https://chatgpt.com/backend-api/f/conversation/
 CHAT_CONVERSATION_URL = "https://chatgpt.com/backend-api/conversation/{conversation_id}"
 CHAT_CONVERSATIONS_URL = "https://chatgpt.com/backend-api/conversations"
 CHAT_FILES_URL = "https://chatgpt.com/backend-api/files"
+CELSIUS_WS_USER_URL = "https://chatgpt.com/celsius/ws/user"
 DEFAULT_MODEL = "gpt-5-3-mini"
 DEFAULT_THINKING_MODEL = "gpt-5-5-thinking"
 DEFAULT_TIMEOUT_SECONDS = 90
@@ -308,6 +309,17 @@ class ChatGPTWebClient:
             state["resume_transport_preference"] = "ws_topic"
         elif state.get("resume_sse_topic_id"):
             state["resume_transport_preference"] = "sse_topic"
+
+    @staticmethod
+    def _capture_ws_url_diagnostics(ws_url: str, state: dict[str, Any]) -> None:
+        parsed = urlparse(ws_url)
+        scheme = parsed.scheme.strip() if isinstance(parsed.scheme, str) else ""
+        hostname = parsed.hostname.strip() if isinstance(parsed.hostname, str) else ""
+        state["resume_ws_url_present"] = True
+        if scheme:
+            state["resume_ws_url_scheme"] = scheme
+        if hostname:
+            state["resume_ws_url_host"] = hostname
 
     """Minimal sync adapter for chatgpt.com web sessions."""
 
@@ -658,6 +670,18 @@ class ChatGPTWebClient:
             raise RequestError(f"chat-requirements request failed: status={status}: {data}")
         if not isinstance(data, dict):
             raise RequestError("chat-requirements response expected JSON object")
+        return data
+
+    def _probe_celsius_ws_user(self) -> dict[str, Any] | None:
+        headers = self._build_headers({"accept": "application/json, text/plain, */*"})
+        status, data = self._json_request("GET", CELSIUS_WS_USER_URL, None, headers)
+        if status >= 400:
+            raise RequestError(f"celsius ws user request failed: status={status}: {data}")
+        if not isinstance(data, dict):
+            raise RequestError("celsius ws user response expected JSON object")
+        websocket_url = data.get("websocket_url")
+        if not isinstance(websocket_url, str) or not websocket_url.strip():
+            raise RequestError("celsius ws user response missing websocket_url")
         return data
 
     def _build_proof_header(self, requirements: dict[str, Any]) -> str | None:
@@ -2226,6 +2250,33 @@ class ChatGPTWebClient:
                 if isinstance(event_payload, dict) and event_payload.get("type") == "stream_handoff":
                     options = event_payload.get("options")
                     self._capture_handoff_option_diagnostics(options, state)
+                    if (
+                        state.get("resume_transport_preference") == "ws_topic"
+                        and not bool(state.get("resume_ws_url_present"))
+                    ):
+                        try:
+                            ws_payload = self._probe_celsius_ws_user()
+                        except RequestError as error:
+                            self._emit_event(
+                                on_event,
+                                "stream_handoff_transport_probe",
+                                transport="ws_topic",
+                                success=False,
+                                error=str(error),
+                            )
+                        else:
+                            websocket_url = ws_payload.get("websocket_url")
+                            if isinstance(websocket_url, str) and websocket_url.strip():
+                                self._capture_ws_url_diagnostics(websocket_url.strip(), state)
+                            self._emit_event(
+                                on_event,
+                                "stream_handoff_transport_probe",
+                                transport="ws_topic",
+                                success=True,
+                                websocket_url_present=bool(state.get("resume_ws_url_present")),
+                                websocket_url_scheme=state.get("resume_ws_url_scheme"),
+                                websocket_url_host=state.get("resume_ws_url_host"),
+                            )
                     self._emit_event(
                         on_event,
                         "stream_handoff",
@@ -2239,6 +2290,9 @@ class ChatGPTWebClient:
                         handoff_option_types=list(state.get("handoff_option_types", ()) or ()),
                         resume_transport_preference=state.get("resume_transport_preference"),
                         resume_token_present=bool(state.get("resume_token")),
+                        resume_ws_url_present=bool(state.get("resume_ws_url_present")),
+                        resume_ws_url_scheme=state.get("resume_ws_url_scheme"),
+                        resume_ws_url_host=state.get("resume_ws_url_host"),
                     )
                 tokens, maybe_title = self._parse_event(event_payload, state)
                 if maybe_title and title_update is None:
@@ -2480,5 +2534,8 @@ class ChatGPTWebClient:
                 resume_conduit_uuid=state.get("resume_conduit_uuid"),
                 resume_conduit_location=state.get("resume_conduit_location"),
                 resume_conduit_cluster=state.get("resume_conduit_cluster"),
+                resume_ws_url_present=bool(state.get("resume_ws_url_present")),
+                resume_ws_url_scheme=state.get("resume_ws_url_scheme"),
+                resume_ws_url_host=state.get("resume_ws_url_host"),
             ),
         )

--- a/src/chatgpt_web_adapter/conversation_send.py
+++ b/src/chatgpt_web_adapter/conversation_send.py
@@ -48,6 +48,7 @@ def send_to_conversation(
     reasoning_effort: str | None = None,
     media: Sequence[MediaItem] | None = None,
     on_token: Callable[[str], None] | None = None,
+    on_event: Callable[[dict[str, Any]], None] | None = None,
 ) -> ChatResponse:
     """Send a prompt to an existing chatgpt.com conversation by URL or id."""
 
@@ -73,4 +74,5 @@ def send_to_conversation(
         conversation=attached.conversation,
         media=media,
         on_token=on_token,
+        on_event=on_event,
     )

--- a/src/chatgpt_web_adapter/diagnostic_metrics.py
+++ b/src/chatgpt_web_adapter/diagnostic_metrics.py
@@ -131,7 +131,8 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
         _emit_event(
             on_event,
             "request_started",
-            model=kwargs.get("model"),
+            requested_model=kwargs.get("model"),
+            requested_reasoning_effort=kwargs.get("reasoning_effort"),
             has_conversation=kwargs.get("conversation") is not None,
             has_media=bool(kwargs.get("media")),
         )
@@ -194,6 +195,10 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
             conversation_id=getattr(response.conversation, "conversation_id", None),
             message_id=getattr(response.conversation, "message_id", None),
             text_length=len(text),
+            sent_model=getattr(response.request, "sent_model", None),
+            sent_reasoning_effort=getattr(response.request, "sent_reasoning_effort", None),
+            observed_model=getattr(response.request, "observed_model", None),
+            observed_reasoning_effort=getattr(response.request, "observed_reasoning_effort", None),
         )
         _emit_event(
             on_event,
@@ -201,6 +206,10 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
             conversation_id=getattr(response.conversation, "conversation_id", None),
             message_id=getattr(response.conversation, "message_id", None),
             text_length=len(text),
+            sent_model=getattr(response.request, "sent_model", None),
+            sent_reasoning_effort=getattr(response.request, "sent_reasoning_effort", None),
+            observed_model=getattr(response.request, "observed_model", None),
+            observed_reasoning_effort=getattr(response.request, "observed_reasoning_effort", None),
         )
         _emit_event(
             on_event,
@@ -209,6 +218,10 @@ def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..
             message_id=getattr(response.conversation, "message_id", None),
             finish_reason=getattr(response.conversation, "finish_reason", None),
             total=response.metrics.total,
+            sent_model=getattr(response.request, "sent_model", None),
+            sent_reasoning_effort=getattr(response.request, "sent_reasoning_effort", None),
+            observed_model=getattr(response.request, "observed_model", None),
+            observed_reasoning_effort=getattr(response.request, "observed_reasoning_effort", None),
         )
         return response
 

--- a/src/chatgpt_web_adapter/diagnostic_metrics.py
+++ b/src/chatgpt_web_adapter/diagnostic_metrics.py
@@ -49,7 +49,7 @@ def _fill_request_error(
 
 def send_with_expanded_metrics(original_send: Callable[..., Any]) -> Callable[..., Any]:
     def send(self: Any, *args: Any, **kwargs: Any) -> Any:
-        on_event = kwargs.pop("on_event", None)
+        on_event = kwargs.get("on_event")
         on_token = kwargs.get("on_token")
         requirements_latency: float | None = None
         backend_status: int | None = None

--- a/src/chatgpt_web_adapter/payload_builder.py
+++ b/src/chatgpt_web_adapter/payload_builder.py
@@ -5,7 +5,7 @@ import time
 import uuid
 from typing import Any
 
-from .client import DEFAULT_MODEL, MODEL_ALIASES
+from .client import DEFAULT_MODEL, DEFAULT_THINKING_MODEL, MODEL_ALIASES
 from .types import ChatConversation
 
 
@@ -25,17 +25,28 @@ def _required_str(value: Any, field_name: str) -> str:
     return value
 
 
-def _normalize_model(model: str) -> str:
-    model_name = _required_str(model, "model")
-    return MODEL_ALIASES.get(model_name, model_name)
+def _normalize_model(model: str | None, reasoning_effort: str | None) -> str:
+    if isinstance(model, str):
+        model_name = _required_str(model, "model")
+        return MODEL_ALIASES.get(model_name.lower(), MODEL_ALIASES.get(model_name, model_name))
+    normalized_effort = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
+    if normalized_effort in {"medium", "high", "standard", "extended"}:
+        return DEFAULT_THINKING_MODEL
+    return DEFAULT_MODEL
 
 
 def _normalize_reasoning_effort(reasoning_effort: str | None) -> str | None:
     normalized = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
-    if normalized in {"", "off", "none", "-"}:
+    if normalized == "medium":
+        normalized = "standard"
+    elif normalized == "high":
+        normalized = "extended"
+    elif normalized in {"", "off", "none", "-", "instant"}:
         normalized = None
     if normalized not in {None, "standard", "extended"}:
-        raise ValueError("reasoning_effort must be one of: standard, extended, off/none/-")
+        raise ValueError(
+            "reasoning_effort must be one of: instant, medium, high, standard, extended, off/none/-"
+        )
     return normalized
 
 
@@ -72,7 +83,7 @@ def _conversation_to_dict(
 def _base_payload(
     *,
     prompt: str,
-    model: str,
+    model: str | None,
     parent_message_id: str,
     system: str | None = None,
     web_search: bool = False,
@@ -96,7 +107,7 @@ def _base_payload(
     payload: dict[str, Any] = {
         "action": "next",
         "parent_message_id": parent_message_id,
-        "model": _normalize_model(model),
+        "model": _normalize_model(model, reasoning_effort),
         "conversation_mode": {"kind": "primary_assistant"},
         "enable_message_followups": False,
         "supports_buffering": True,
@@ -144,7 +155,7 @@ class PayloadBuilder:
     def new_chat(
         prompt: Any,
         *,
-        model: str = DEFAULT_MODEL,
+        model: str | None = None,
         system: str | None = None,
         web_search: bool = False,
         temporary: bool = False,
@@ -169,7 +180,7 @@ class PayloadBuilder:
         conversation: ChatConversation | dict[str, Any] | None = None,
         conversation_id: str | None = None,
         parent_message_id: str | None = None,
-        model: str = DEFAULT_MODEL,
+        model: str | None = None,
         web_search: bool = False,
         reasoning_effort: str | None = None,
     ) -> dict[str, Any]:

--- a/src/chatgpt_web_adapter/types.py
+++ b/src/chatgpt_web_adapter/types.py
@@ -649,6 +649,11 @@ class ChatRequestDiagnostics:
     message_count: int | None = None
     observed_model: str | None = None
     observed_reasoning_effort: str | None = None
+    resume_kind: str | None = None
+    resume_token_present: bool = False
+    resume_turn_topic_id: str | None = None
+    resume_with_websockets: bool = False
+    turn_exchange_id: str | None = None
 
     def __post_init__(self) -> None:
         self.requested_model = _optional_str(self.requested_model)
@@ -664,6 +669,11 @@ class ChatRequestDiagnostics:
         self.message_count = _optional_positive_int(self.message_count)
         self.observed_model = _optional_str(self.observed_model)
         self.observed_reasoning_effort = _optional_str(self.observed_reasoning_effort)
+        self.resume_kind = _optional_str(self.resume_kind)
+        self.resume_token_present = bool(self.resume_token_present)
+        self.resume_turn_topic_id = _optional_str(self.resume_turn_topic_id)
+        self.resume_with_websockets = bool(self.resume_with_websockets)
+        self.turn_exchange_id = _optional_str(self.turn_exchange_id)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any] | None) -> "ChatRequestDiagnostics":
@@ -683,6 +693,11 @@ class ChatRequestDiagnostics:
             message_count=payload.get("message_count"),
             observed_model=payload.get("observed_model"),
             observed_reasoning_effort=payload.get("observed_reasoning_effort"),
+            resume_kind=payload.get("resume_kind"),
+            resume_token_present=payload.get("resume_token_present", False),
+            resume_turn_topic_id=payload.get("resume_turn_topic_id"),
+            resume_with_websockets=payload.get("resume_with_websockets", False),
+            turn_exchange_id=payload.get("turn_exchange_id"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -700,6 +715,11 @@ class ChatRequestDiagnostics:
             "message_count": self.message_count,
             "observed_model": self.observed_model,
             "observed_reasoning_effort": self.observed_reasoning_effort,
+            "resume_kind": self.resume_kind,
+            "resume_token_present": self.resume_token_present,
+            "resume_turn_topic_id": self.resume_turn_topic_id,
+            "resume_with_websockets": self.resume_with_websockets,
+            "turn_exchange_id": self.turn_exchange_id,
         }
 
 

--- a/src/chatgpt_web_adapter/types.py
+++ b/src/chatgpt_web_adapter/types.py
@@ -635,8 +635,78 @@ class ChatMetrics:
 
 
 @dataclass
+class ChatRequestDiagnostics:
+    requested_model: str | None = None
+    requested_reasoning_effort: str | None = None
+    sent_model: str | None = None
+    sent_reasoning_effort: str | None = None
+    conversation_id: str | None = None
+    parent_message_id: str | None = None
+    is_continuation: bool = False
+    web_search: bool = False
+    temporary: bool = False
+    has_media: bool = False
+    message_count: int | None = None
+    observed_model: str | None = None
+    observed_reasoning_effort: str | None = None
+
+    def __post_init__(self) -> None:
+        self.requested_model = _optional_str(self.requested_model)
+        self.requested_reasoning_effort = _optional_str(self.requested_reasoning_effort)
+        self.sent_model = _optional_str(self.sent_model)
+        self.sent_reasoning_effort = _optional_str(self.sent_reasoning_effort)
+        self.conversation_id = _optional_str(self.conversation_id)
+        self.parent_message_id = _optional_str(self.parent_message_id)
+        self.is_continuation = bool(self.is_continuation)
+        self.web_search = bool(self.web_search)
+        self.temporary = bool(self.temporary)
+        self.has_media = bool(self.has_media)
+        self.message_count = _optional_positive_int(self.message_count)
+        self.observed_model = _optional_str(self.observed_model)
+        self.observed_reasoning_effort = _optional_str(self.observed_reasoning_effort)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> "ChatRequestDiagnostics":
+        if not isinstance(payload, dict):
+            return cls()
+        return cls(
+            requested_model=payload.get("requested_model"),
+            requested_reasoning_effort=payload.get("requested_reasoning_effort"),
+            sent_model=payload.get("sent_model"),
+            sent_reasoning_effort=payload.get("sent_reasoning_effort"),
+            conversation_id=payload.get("conversation_id"),
+            parent_message_id=payload.get("parent_message_id"),
+            is_continuation=payload.get("is_continuation", False),
+            web_search=payload.get("web_search", False),
+            temporary=payload.get("temporary", False),
+            has_media=payload.get("has_media", False),
+            message_count=payload.get("message_count"),
+            observed_model=payload.get("observed_model"),
+            observed_reasoning_effort=payload.get("observed_reasoning_effort"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "requested_model": self.requested_model,
+            "requested_reasoning_effort": self.requested_reasoning_effort,
+            "sent_model": self.sent_model,
+            "sent_reasoning_effort": self.sent_reasoning_effort,
+            "conversation_id": self.conversation_id,
+            "parent_message_id": self.parent_message_id,
+            "is_continuation": self.is_continuation,
+            "web_search": self.web_search,
+            "temporary": self.temporary,
+            "has_media": self.has_media,
+            "message_count": self.message_count,
+            "observed_model": self.observed_model,
+            "observed_reasoning_effort": self.observed_reasoning_effort,
+        }
+
+
+@dataclass
 class ChatResponse:
     text: str
     title: str | None = None
     conversation: ChatConversation = field(default_factory=ChatConversation)
     metrics: ChatMetrics = field(default_factory=ChatMetrics)
+    request: ChatRequestDiagnostics = field(default_factory=ChatRequestDiagnostics)

--- a/src/chatgpt_web_adapter/types.py
+++ b/src/chatgpt_web_adapter/types.py
@@ -655,6 +655,8 @@ class ChatRequestDiagnostics:
     resume_sse_topic_id: str | None = None
     resume_ws_topic_id: str | None = None
     handoff_option_types: tuple[str, ...] = ()
+    resume_transport_preference: str | None = None
+    handoff_recovery_mode: str | None = None
     resume_with_websockets: bool = False
     turn_exchange_id: str | None = None
     resume_conduit_uuid: str | None = None
@@ -685,6 +687,8 @@ class ChatRequestDiagnostics:
             for value in self.handoff_option_types
             if isinstance(value, str) and value.strip()
         )
+        self.resume_transport_preference = _optional_str(self.resume_transport_preference)
+        self.handoff_recovery_mode = _optional_str(self.handoff_recovery_mode)
         self.resume_with_websockets = bool(self.resume_with_websockets)
         self.turn_exchange_id = _optional_str(self.turn_exchange_id)
         self.resume_conduit_uuid = _optional_str(self.resume_conduit_uuid)
@@ -715,6 +719,8 @@ class ChatRequestDiagnostics:
             resume_sse_topic_id=payload.get("resume_sse_topic_id"),
             resume_ws_topic_id=payload.get("resume_ws_topic_id"),
             handoff_option_types=tuple(payload.get("handoff_option_types", ()) or ()),
+            resume_transport_preference=payload.get("resume_transport_preference"),
+            handoff_recovery_mode=payload.get("handoff_recovery_mode"),
             resume_with_websockets=payload.get("resume_with_websockets", False),
             turn_exchange_id=payload.get("turn_exchange_id"),
             resume_conduit_uuid=payload.get("resume_conduit_uuid"),
@@ -743,6 +749,8 @@ class ChatRequestDiagnostics:
             "resume_sse_topic_id": self.resume_sse_topic_id,
             "resume_ws_topic_id": self.resume_ws_topic_id,
             "handoff_option_types": list(self.handoff_option_types),
+            "resume_transport_preference": self.resume_transport_preference,
+            "handoff_recovery_mode": self.handoff_recovery_mode,
             "resume_with_websockets": self.resume_with_websockets,
             "turn_exchange_id": self.turn_exchange_id,
             "resume_conduit_uuid": self.resume_conduit_uuid,

--- a/src/chatgpt_web_adapter/types.py
+++ b/src/chatgpt_web_adapter/types.py
@@ -652,8 +652,14 @@ class ChatRequestDiagnostics:
     resume_kind: str | None = None
     resume_token_present: bool = False
     resume_turn_topic_id: str | None = None
+    resume_sse_topic_id: str | None = None
+    resume_ws_topic_id: str | None = None
+    handoff_option_types: tuple[str, ...] = ()
     resume_with_websockets: bool = False
     turn_exchange_id: str | None = None
+    resume_conduit_uuid: str | None = None
+    resume_conduit_location: str | None = None
+    resume_conduit_cluster: str | None = None
 
     def __post_init__(self) -> None:
         self.requested_model = _optional_str(self.requested_model)
@@ -672,8 +678,18 @@ class ChatRequestDiagnostics:
         self.resume_kind = _optional_str(self.resume_kind)
         self.resume_token_present = bool(self.resume_token_present)
         self.resume_turn_topic_id = _optional_str(self.resume_turn_topic_id)
+        self.resume_sse_topic_id = _optional_str(self.resume_sse_topic_id)
+        self.resume_ws_topic_id = _optional_str(self.resume_ws_topic_id)
+        self.handoff_option_types = tuple(
+            value.strip()
+            for value in self.handoff_option_types
+            if isinstance(value, str) and value.strip()
+        )
         self.resume_with_websockets = bool(self.resume_with_websockets)
         self.turn_exchange_id = _optional_str(self.turn_exchange_id)
+        self.resume_conduit_uuid = _optional_str(self.resume_conduit_uuid)
+        self.resume_conduit_location = _optional_str(self.resume_conduit_location)
+        self.resume_conduit_cluster = _optional_str(self.resume_conduit_cluster)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any] | None) -> "ChatRequestDiagnostics":
@@ -696,8 +712,14 @@ class ChatRequestDiagnostics:
             resume_kind=payload.get("resume_kind"),
             resume_token_present=payload.get("resume_token_present", False),
             resume_turn_topic_id=payload.get("resume_turn_topic_id"),
+            resume_sse_topic_id=payload.get("resume_sse_topic_id"),
+            resume_ws_topic_id=payload.get("resume_ws_topic_id"),
+            handoff_option_types=tuple(payload.get("handoff_option_types", ()) or ()),
             resume_with_websockets=payload.get("resume_with_websockets", False),
             turn_exchange_id=payload.get("turn_exchange_id"),
+            resume_conduit_uuid=payload.get("resume_conduit_uuid"),
+            resume_conduit_location=payload.get("resume_conduit_location"),
+            resume_conduit_cluster=payload.get("resume_conduit_cluster"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -718,8 +740,14 @@ class ChatRequestDiagnostics:
             "resume_kind": self.resume_kind,
             "resume_token_present": self.resume_token_present,
             "resume_turn_topic_id": self.resume_turn_topic_id,
+            "resume_sse_topic_id": self.resume_sse_topic_id,
+            "resume_ws_topic_id": self.resume_ws_topic_id,
+            "handoff_option_types": list(self.handoff_option_types),
             "resume_with_websockets": self.resume_with_websockets,
             "turn_exchange_id": self.turn_exchange_id,
+            "resume_conduit_uuid": self.resume_conduit_uuid,
+            "resume_conduit_location": self.resume_conduit_location,
+            "resume_conduit_cluster": self.resume_conduit_cluster,
         }
 
 

--- a/src/chatgpt_web_adapter/types.py
+++ b/src/chatgpt_web_adapter/types.py
@@ -662,6 +662,9 @@ class ChatRequestDiagnostics:
     resume_conduit_uuid: str | None = None
     resume_conduit_location: str | None = None
     resume_conduit_cluster: str | None = None
+    resume_ws_url_present: bool = False
+    resume_ws_url_scheme: str | None = None
+    resume_ws_url_host: str | None = None
 
     def __post_init__(self) -> None:
         self.requested_model = _optional_str(self.requested_model)
@@ -694,6 +697,9 @@ class ChatRequestDiagnostics:
         self.resume_conduit_uuid = _optional_str(self.resume_conduit_uuid)
         self.resume_conduit_location = _optional_str(self.resume_conduit_location)
         self.resume_conduit_cluster = _optional_str(self.resume_conduit_cluster)
+        self.resume_ws_url_present = bool(self.resume_ws_url_present)
+        self.resume_ws_url_scheme = _optional_str(self.resume_ws_url_scheme)
+        self.resume_ws_url_host = _optional_str(self.resume_ws_url_host)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any] | None) -> "ChatRequestDiagnostics":
@@ -726,6 +732,9 @@ class ChatRequestDiagnostics:
             resume_conduit_uuid=payload.get("resume_conduit_uuid"),
             resume_conduit_location=payload.get("resume_conduit_location"),
             resume_conduit_cluster=payload.get("resume_conduit_cluster"),
+            resume_ws_url_present=payload.get("resume_ws_url_present", False),
+            resume_ws_url_scheme=payload.get("resume_ws_url_scheme"),
+            resume_ws_url_host=payload.get("resume_ws_url_host"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -756,6 +765,9 @@ class ChatRequestDiagnostics:
             "resume_conduit_uuid": self.resume_conduit_uuid,
             "resume_conduit_location": self.resume_conduit_location,
             "resume_conduit_cluster": self.resume_conduit_cluster,
+            "resume_ws_url_present": self.resume_ws_url_present,
+            "resume_ws_url_scheme": self.resume_ws_url_scheme,
+            "resume_ws_url_host": self.resume_ws_url_host,
         }
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -86,6 +86,42 @@ def _live_like_stream_events(
     ]
 
 
+def _top_level_id_only_stream_events(
+    *,
+    conversation_id: str = "conv-top-level",
+    assistant_message_id: str = "assistant-top-level",
+    text_parts: tuple[str, ...] = ("top-", "level"),
+) -> list[dict[str, Any]]:
+    return [
+        {"type": "resume_conversation_token", "kind": "topic", "token": "resume-token"},
+        {
+            "v": {
+                "message": {
+                    "author": {"role": "assistant"},
+                    "id": "assistant-ephemeral",
+                    "recipient": "all",
+                    "content": {"content_type": "text", "parts": [""]},
+                }
+            }
+        },
+        {
+            "type": "message_marker",
+            "conversation_id": conversation_id,
+            "message_id": assistant_message_id,
+        },
+        {
+            "v": [
+                *(
+                    {"p": "/message/content/parts/0", "v": part}
+                    for part in text_parts
+                ),
+                {"p": "/message/metadata", "v": {"finish_details": {"type": "stop"}}},
+            ]
+        },
+        {"type": "message_stream_complete", "conversation_id": conversation_id},
+    ]
+
+
 def _build_client() -> adapter.ChatGPTWebClient:
     client = object.__new__(adapter.ChatGPTWebClient)
     client.auth = adapter.AuthData(cookies={})
@@ -682,6 +718,32 @@ def test_send_event_callback_tolerates_live_like_sse_metadata(monkeypatch: pytes
     assert events[-1]["observed_model"] == "gpt-5-3-mini"
     assert events[-1]["conversation_id"] == "conv-live"
     assert events[-1]["message_id"] == "assistant-final"
+
+
+def test_send_recovers_conversation_id_from_top_level_sse_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "stream_events": _top_level_id_only_stream_events(),
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send("Reply with exactly: top-level", reasoning_effort="high")
+
+    assert response.text == "top-level"
+    assert response.conversation.conversation_id == "conv-top-level"
+    assert response.conversation.message_id == "assistant-top-level"
+    assert response.request.conversation_id == "conv-top-level"
+    assert response.request.sent_model == "gpt-5-5-thinking"
+    assert response.request.sent_reasoning_effort == "extended"
 
 
 def test_approve_pending_action_posts_prepare_and_polls_conversation(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -525,6 +525,64 @@ def test_send_with_warmup_media_and_flags_uses_prefetched_requirements(
     assert response.metrics.total is not None
 
 
+def test_send_instant_mode_uses_minimal_payload_without_thinking_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send("Reply with exactly: instant", reasoning_effort="instant")
+
+    payload = state["conversation_payloads"][0]
+    assert response.text == "Hello world"
+    assert payload["model"] == "gpt-5-3-mini"
+    assert "thinking_effort" not in payload
+    assert "system_hints" not in payload
+    assert [message["author"]["role"] for message in payload["messages"]] == ["user"]
+
+
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_model", "expected_effort"),
+    [
+        ("medium", "gpt-5-5-thinking", "standard"),
+        ("high", "gpt-5-5-thinking", "extended"),
+    ],
+)
+def test_send_ui_reasoning_modes_map_to_current_backend_values(
+    monkeypatch: pytest.MonkeyPatch,
+    reasoning_effort: str,
+    expected_model: str,
+    expected_effort: str,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send("Reply with exactly: mapped", reasoning_effort=reasoning_effort)
+
+    payload = state["conversation_payloads"][0]
+    assert response.text == "Hello world"
+    assert payload["model"] == expected_model
+    assert payload["thinking_effort"] == expected_effort
+
+
 def test_send_backend_error_raises_request_error(monkeypatch: pytest.MonkeyPatch) -> None:
     client = _build_client()
     client.auth.accessToken = "test-token"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,7 +19,16 @@ PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"0" * 40
 
 def _resume_topic_token(topic_id: str = "conversation-turn-123") -> str:
     header = base64.urlsafe_b64encode(json.dumps({"alg": "ES256", "typ": "JWT"}).encode("utf-8")).decode("ascii").rstrip("=")
-    payload = base64.urlsafe_b64encode(json.dumps({"turn_topic_id": topic_id}).encode("utf-8")).decode("ascii").rstrip("=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps(
+            {
+                "turn_topic_id": topic_id,
+                "conduit_uuid": "conduit-123",
+                "conduit_location": "10.0.0.1:8305",
+                "cluster": "unified-123",
+            }
+        ).encode("utf-8")
+    ).decode("ascii").rstrip("=")
     return f"{header}.{payload}.signature"
 
 
@@ -149,7 +158,11 @@ def _handoff_only_stream_events(
                 {
                     "type": "resume_sse_endpoint",
                     "topic_id": "conversation-turn-123",
-                }
+                },
+                {
+                    "type": "subscribe_ws_topic",
+                    "topic_id": "conversation-turn-123",
+                },
             ],
         },
     ]
@@ -899,6 +912,12 @@ def test_send_emits_handoff_and_poll_events(
     assert handoff_event["turn_exchange_id"] == "turn-123"
     assert handoff_event["resume_kind"] == "topic"
     assert handoff_event["resume_turn_topic_id"] == "conversation-turn-123"
+    assert handoff_event["resume_sse_topic_id"] == "conversation-turn-123"
+    assert handoff_event["resume_ws_topic_id"] == "conversation-turn-123"
+    assert handoff_event["handoff_option_types"] == [
+        "resume_sse_endpoint",
+        "subscribe_ws_topic",
+    ]
     assert handoff_event["resume_token_present"] is True
 
 
@@ -947,6 +966,15 @@ def test_send_exposes_resume_diagnostics_after_stream_handoff(
     assert response.request.resume_kind == "topic"
     assert response.request.resume_token_present is True
     assert response.request.resume_turn_topic_id == "conversation-turn-123"
+    assert response.request.resume_sse_topic_id == "conversation-turn-123"
+    assert response.request.resume_ws_topic_id == "conversation-turn-123"
+    assert response.request.handoff_option_types == (
+        "resume_sse_endpoint",
+        "subscribe_ws_topic",
+    )
+    assert response.request.resume_conduit_uuid == "conduit-123"
+    assert response.request.resume_conduit_location == "10.0.0.1:8305"
+    assert response.request.resume_conduit_cluster == "unified-123"
     assert response.request.resume_with_websockets is True
     assert response.request.turn_exchange_id == "turn-123"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -122,6 +122,32 @@ def _top_level_id_only_stream_events(
     ]
 
 
+def _handoff_only_stream_events(
+    *,
+    conversation_id: str = "conv-123",
+) -> list[dict[str, Any]]:
+    return [
+        "v1",
+        {
+            "type": "resume_conversation_token",
+            "kind": "topic",
+            "token": "resume-token",
+            "conversation_id": conversation_id,
+        },
+        {
+            "type": "stream_handoff",
+            "conversation_id": conversation_id,
+            "turn_exchange_id": "turn-123",
+            "options": [
+                {
+                    "type": "resume_sse_endpoint",
+                    "topic_id": "conversation-turn-123",
+                }
+            ],
+        },
+    ]
+
+
 def _build_client() -> adapter.ChatGPTWebClient:
     client = object.__new__(adapter.ChatGPTWebClient)
     client.auth = adapter.AuthData(cookies={})
@@ -312,6 +338,12 @@ def _make_chat_handler(
                 return
             if self.path == "/backend-api/conversation/conv-123":
                 state["conversation_get_calls"] = state.get("conversation_get_calls", 0) + 1
+                conversation_payloads = state.get("conversation_get_payloads")
+                if isinstance(conversation_payloads, list) and conversation_payloads:
+                    conversation_payload = conversation_payloads.pop(0)
+                    if isinstance(conversation_payload, dict):
+                        self._write_json(200, conversation_payload)
+                        return
                 conversation_payload = state.get("conversation_get_payload")
                 if isinstance(conversation_payload, dict):
                     self._write_json(200, conversation_payload)
@@ -744,6 +776,121 @@ def test_send_recovers_conversation_id_from_top_level_sse_fields(
     assert response.request.conversation_id == "conv-top-level"
     assert response.request.sent_model == "gpt-5-5-thinking"
     assert response.request.sent_reasoning_effort == "extended"
+
+
+def test_send_recovers_message_id_text_and_metadata_after_stream_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+        "conversation_get_payload": {
+            "conversation_id": "conv-123",
+            "current_node": "assistant-final",
+            "mapping": {
+                "assistant-final": {
+                    "message": {
+                        "id": "assistant-final",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "create_time": 2,
+                        "content": {"content_type": "text", "parts": ["handoff-ok"]},
+                        "metadata": {
+                            "model_slug": "gpt-5-5-thinking",
+                            "thinking_effort": "extended",
+                            "finish_details": {"type": "stop"},
+                        },
+                    }
+                }
+            },
+        },
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send("Reply with exactly: handoff-ok", reasoning_effort="high")
+
+    assert state["conversation_get_calls"] == 1
+    assert response.text == "handoff-ok"
+    assert response.conversation.conversation_id == "conv-123"
+    assert response.conversation.message_id == "assistant-final"
+    assert response.conversation.parent_message_id == "assistant-final"
+    assert response.request.conversation_id == "conv-123"
+    assert response.request.sent_model == "gpt-5-5-thinking"
+    assert response.request.sent_reasoning_effort == "extended"
+    assert response.request.observed_model == "gpt-5-5-thinking"
+    assert response.request.observed_reasoning_effort == "extended"
+
+
+def test_send_polls_conversation_until_handoff_reply_appears(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+        "conversation_get_payloads": [
+            {
+                "conversation_id": "conv-123",
+                "current_node": "user-new",
+                "mapping": {
+                    "user-new": {
+                        "message": {
+                            "id": "user-new",
+                            "author": {"role": "user"},
+                            "recipient": "all",
+                            "create_time": 1,
+                            "content": {"content_type": "text", "parts": ["Reply with exactly: polled-ok"]},
+                        }
+                    }
+                },
+            },
+            {
+                "conversation_id": "conv-123",
+                "current_node": "assistant-final",
+                "mapping": {
+                    "assistant-final": {
+                        "message": {
+                            "id": "assistant-final",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 2,
+                            "content": {"content_type": "text", "parts": ["polled-ok"]},
+                            "metadata": {
+                                "model_slug": "gpt-5-5-thinking",
+                                "thinking_effort": "extended",
+                                "finish_details": {"type": "stop"},
+                            },
+                        }
+                    }
+                },
+            },
+        ],
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send("Reply with exactly: polled-ok", reasoning_effort="high")
+
+    assert state["conversation_get_calls"] >= 2
+    assert response.text == "polled-ok"
+    assert response.conversation.conversation_id == "conv-123"
+    assert response.conversation.message_id == "assistant-final"
+    assert response.request.observed_model == "gpt-5-5-thinking"
+    assert response.request.observed_reasoning_effort == "extended"
 
 
 def test_approve_pending_action_posts_prepare_and_polls_conversation(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1091,6 +1091,142 @@ def test_send_to_existing_conversation_does_not_return_stale_assistant_reply_aft
     assert attempt_events[0]["lifecycle_status"] == "user_last_message"
 
 
+def test_send_to_existing_conversation_ignores_older_branch_assistant_before_parent_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    events: list[dict[str, Any]] = []
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+        "conversation_get_payloads": [
+            {
+                "conversation_id": "conv-123",
+                "current_node": "assistant-old-current",
+                "mapping": {
+                    "assistant-older": {
+                        "message": {
+                            "id": "assistant-older",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 1,
+                            "content": {"content_type": "text", "parts": ["very-old-reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                    "user-old": {
+                        "parent": "assistant-older",
+                        "message": {
+                            "id": "user-old",
+                            "author": {"role": "user"},
+                            "recipient": "all",
+                            "create_time": 2,
+                            "content": {"content_type": "text", "parts": ["old prompt"]},
+                        }
+                    },
+                    "assistant-old-current": {
+                        "parent": "user-old",
+                        "message": {
+                            "id": "assistant-old-current",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 3,
+                            "content": {"content_type": "text", "parts": ["previous-visible-reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                },
+            },
+            {
+                "conversation_id": "conv-123",
+                "current_node": "assistant-final",
+                "mapping": {
+                    "assistant-older": {
+                        "message": {
+                            "id": "assistant-older",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 1,
+                            "content": {"content_type": "text", "parts": ["very-old-reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                    "user-old": {
+                        "parent": "assistant-older",
+                        "message": {
+                            "id": "user-old",
+                            "author": {"role": "user"},
+                            "recipient": "all",
+                            "create_time": 2,
+                            "content": {"content_type": "text", "parts": ["old prompt"]},
+                        }
+                    },
+                    "assistant-old-current": {
+                        "parent": "user-old",
+                        "message": {
+                            "id": "assistant-old-current",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 3,
+                            "content": {"content_type": "text", "parts": ["previous-visible-reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                    "user-new": {
+                        "parent": "assistant-old-current",
+                        "message": {
+                            "id": "user-new",
+                            "author": {"role": "user"},
+                            "recipient": "all",
+                            "create_time": 4,
+                            "content": {"content_type": "text", "parts": ["fresh prompt"]},
+                        }
+                    },
+                    "assistant-final": {
+                        "parent": "user-new",
+                        "message": {
+                            "id": "assistant-final",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 5,
+                            "content": {"content_type": "text", "parts": ["fresh-final-reply-2"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                },
+            },
+        ],
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send(
+            "fresh prompt",
+            conversation=adapter.ChatConversation(
+                conversation_id="conv-123",
+                message_id="assistant-old-current",
+                parent_message_id="assistant-old-current",
+            ),
+            model="gpt-5-5-thinking",
+            reasoning_effort="high",
+            on_event=events.append,
+        )
+
+    assert response.text == "fresh-final-reply-2"
+    assert response.conversation.message_id == "assistant-final"
+    attempt_events = [event for event in events if event["type"] == "conversation_poll_attempt"]
+    assert attempt_events
+    latest_ids = {event.get("latest_message_id") for event in attempt_events}
+    assert "assistant-older" not in latest_ids
+    assert "assistant-old-current" not in latest_ids
+
+
 def test_send_retries_after_conversation_inaccessible_during_handoff_recovery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -918,6 +918,7 @@ def test_send_emits_handoff_and_poll_events(
         "resume_sse_endpoint",
         "subscribe_ws_topic",
     ]
+    assert handoff_event["resume_transport_preference"] == "ws_topic"
     assert handoff_event["resume_token_present"] is True
 
 
@@ -972,6 +973,8 @@ def test_send_exposes_resume_diagnostics_after_stream_handoff(
         "resume_sse_endpoint",
         "subscribe_ws_topic",
     )
+    assert response.request.resume_transport_preference == "ws_topic"
+    assert response.request.handoff_recovery_mode == "conversation_snapshot"
     assert response.request.resume_conduit_uuid == "conduit-123"
     assert response.request.resume_conduit_location == "10.0.0.1:8305"
     assert response.request.resume_conduit_cluster == "unified-123"
@@ -1047,9 +1050,14 @@ def test_send_polls_conversation_until_handoff_reply_appears(
     assert response.request.observed_model == "gpt-5-5-thinking"
     assert response.request.observed_reasoning_effort == "extended"
     event_types = [event["type"] for event in events]
+    assert "stream_handoff_recovery_mode" in event_types
     assert "conversation_poll_started" in event_types
     assert "conversation_poll_attempt" in event_types
     assert "conversation_poll_completed" in event_types
+    recovery_mode_event = next(event for event in events if event["type"] == "stream_handoff_recovery_mode")
+    assert recovery_mode_event["preferred_transport"] == "ws_topic"
+    assert recovery_mode_event["recovery_mode"] == "poll_recovery"
+    assert recovery_mode_event["reason"] == "topic_transport_not_implemented"
 
 
 def test_send_streams_poll_recovery_text_deltas_after_handoff(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1052,6 +1052,82 @@ def test_send_emits_ws_transport_probe_event_after_stream_handoff(
     assert probe_event["websocket_url_host"] == "pubsub.chatgpt.com"
 
 
+def test_parse_encoded_stream_item_extracts_last_sse_event() -> None:
+    parsed = adapter.ChatGPTWebClient._parse_encoded_stream_item(
+        "event: delta\n"
+        'data: {"p":"/message/content/parts/0","v":"hello"}\n'
+        "\n"
+        "event: done\n"
+        "data: [DONE]\n"
+        "\n"
+    )
+
+    assert parsed == {"event": "done", "data": "[DONE]"}
+
+
+def test_send_uses_ws_topic_stream_after_stream_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    events: list[dict[str, Any]] = []
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+    }
+
+    def fake_ws_stream(
+        self: adapter.ChatGPTWebClient,
+        topic_id: str,
+        *,
+        state: dict[str, Any],
+        on_event: Any,
+        on_token: Any,
+    ) -> None:
+        state["conversation_id"] = "conv-123"
+        state["message_id"] = "assistant-ws"
+        state["parent_message_id"] = "assistant-ws"
+        state["observed_model"] = "gpt-5-5-thinking"
+        state["observed_reasoning_effort"] = "extended"
+        state["finish_reason"] = "stop"
+        if on_event is not None:
+            on_event({"type": "stream_handoff_ws_connected", "topic_id": topic_id})
+            on_event({"type": "raw_ws_event", "topic_id": topic_id, "raw": '{"mock":true}', "parsed": {"mock": True}})
+            on_event({"type": "raw_ws_done", "topic_id": topic_id})
+        if on_token is not None:
+            on_token("ws-")
+            on_token("stream-ok")
+
+    monkeypatch.setattr(adapter.ChatGPTWebClient, "_stream_handoff_via_ws_topic", fake_ws_stream)
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send(
+            "Reply with exactly: ws-stream-ok",
+            reasoning_effort="high",
+            on_event=events.append,
+        )
+
+    assert response.text == "ws-stream-ok"
+    assert response.conversation.conversation_id == "conv-123"
+    assert response.conversation.message_id == "assistant-ws"
+    assert response.request.handoff_recovery_mode == "ws_topic_stream"
+    assert response.request.resume_transport_preference == "ws_topic"
+    assert state["conversation_get_calls"] == 0
+    event_types = [event["type"] for event in events]
+    assert "stream_handoff_ws_connected" in event_types
+    assert "raw_ws_event" in event_types
+    assert "raw_ws_done" in event_types
+    recovery_mode_event = next(event for event in events if event["type"] == "stream_handoff_recovery_mode")
+    assert recovery_mode_event["preferred_transport"] == "ws_topic"
+    assert recovery_mode_event["recovery_mode"] == "ws_topic_stream"
+
+
 def test_send_polls_conversation_until_handoff_reply_appears(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1052,6 +1052,169 @@ def test_send_polls_conversation_until_handoff_reply_appears(
     assert "conversation_poll_completed" in event_types
 
 
+def test_send_streams_poll_recovery_text_deltas_after_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    events: list[dict[str, Any]] = []
+    streamed_tokens: list[str] = []
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+        "conversation_get_payloads": [
+            {
+                "conversation_id": "conv-123",
+                "current_node": "assistant-final",
+                "mapping": {
+                    "assistant-old": {
+                        "message": {
+                            "id": "assistant-old",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 0,
+                            "content": {"content_type": "text", "parts": ["old reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                    "user-new": {
+                        "parent": "assistant-old",
+                        "message": {
+                            "id": "user-new",
+                            "author": {"role": "user"},
+                            "recipient": "all",
+                            "create_time": 1,
+                            "content": {"content_type": "text", "parts": ["stream me"]},
+                        }
+                    },
+                    "assistant-final": {
+                        "parent": "user-new",
+                        "message": {
+                            "id": "assistant-final",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 2,
+                            "content": {"content_type": "text", "parts": ["partial"]},
+                            "metadata": {
+                                "model_slug": "gpt-5-5-thinking",
+                                "thinking_effort": "extended",
+                                "async_status": "running",
+                            },
+                        }
+                    },
+                },
+            },
+            {
+                "conversation_id": "conv-123",
+                "current_node": "assistant-final",
+                "mapping": {
+                    "assistant-old": {
+                        "message": {
+                            "id": "assistant-old",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 0,
+                            "content": {"content_type": "text", "parts": ["old reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                    "user-new": {
+                        "parent": "assistant-old",
+                        "message": {
+                            "id": "user-new",
+                            "author": {"role": "user"},
+                            "recipient": "all",
+                            "create_time": 1,
+                            "content": {"content_type": "text", "parts": ["stream me"]},
+                        }
+                    },
+                    "assistant-final": {
+                        "parent": "user-new",
+                        "message": {
+                            "id": "assistant-final",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 2,
+                            "content": {"content_type": "text", "parts": ["partial"]},
+                            "metadata": {
+                                "model_slug": "gpt-5-5-thinking",
+                                "thinking_effort": "extended",
+                                "async_status": "running",
+                            },
+                        }
+                    },
+                },
+            },
+            {
+                "conversation_id": "conv-123",
+                "current_node": "assistant-final",
+                "mapping": {
+                    "assistant-old": {
+                        "message": {
+                            "id": "assistant-old",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 0,
+                            "content": {"content_type": "text", "parts": ["old reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                    "user-new": {
+                        "parent": "assistant-old",
+                        "message": {
+                            "id": "user-new",
+                            "author": {"role": "user"},
+                            "recipient": "all",
+                            "create_time": 1,
+                            "content": {"content_type": "text", "parts": ["stream me"]},
+                        }
+                    },
+                    "assistant-final": {
+                        "parent": "user-new",
+                        "message": {
+                            "id": "assistant-final",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 2,
+                            "content": {"content_type": "text", "parts": ["partial done"]},
+                            "metadata": {
+                                "model_slug": "gpt-5-5-thinking",
+                                "thinking_effort": "extended",
+                                "finish_details": {"type": "stop"},
+                            },
+                        }
+                    },
+                },
+            },
+        ],
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send(
+            "stream me",
+            conversation=adapter.ChatConversation(
+                conversation_id="conv-123",
+                message_id="assistant-old",
+                parent_message_id="assistant-old",
+            ),
+            model="gpt-5-5-thinking",
+            reasoning_effort="high",
+            on_token=streamed_tokens.append,
+            on_event=events.append,
+        )
+
+    assert response.text == "partial done"
+    assert streamed_tokens == ["partial", " done"]
+    delta_events = [event for event in events if event["type"] == "conversation_poll_stream_delta"]
+    assert [event["delta"] for event in delta_events] == ["partial", " done"]
+
+
 def test_send_to_existing_conversation_does_not_return_stale_assistant_reply_after_handoff(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -239,6 +239,7 @@ def _patch_chat_endpoints(monkeypatch: pytest.MonkeyPatch, base_url: str) -> Non
     monkeypatch.setattr(client_mod, "CHAT_CONVERSATION_URL", f"{base_url}/backend-api/conversation/{{conversation_id}}")
     monkeypatch.setattr(client_mod, "CHAT_CONVERSATIONS_URL", f"{base_url}/backend-api/conversations")
     monkeypatch.setattr(client_mod, "CHAT_FILES_URL", f"{base_url}/backend-api/files")
+    monkeypatch.setattr(client_mod, "CELSIUS_WS_USER_URL", f"{base_url}/celsius/ws/user")
 
 
 def _make_chat_handler(
@@ -344,6 +345,14 @@ def _make_chat_handler(
             self.end_headers()
 
         def do_GET(self) -> None:
+            if self.path == "/celsius/ws/user":
+                self._write_json(
+                    200,
+                    {
+                        "websocket_url": "wss://pubsub.chatgpt.com/v1/socket?token=test-token",
+                    },
+                )
+                return
             if self.path.startswith("/backend-api/conversations"):
                 state["conversations_get_calls"] = state.get("conversations_get_calls", 0) + 1
                 self._write_json(
@@ -978,8 +987,69 @@ def test_send_exposes_resume_diagnostics_after_stream_handoff(
     assert response.request.resume_conduit_uuid == "conduit-123"
     assert response.request.resume_conduit_location == "10.0.0.1:8305"
     assert response.request.resume_conduit_cluster == "unified-123"
+    assert response.request.resume_ws_url_present is True
+    assert response.request.resume_ws_url_scheme == "wss"
+    assert response.request.resume_ws_url_host == "pubsub.chatgpt.com"
     assert response.request.resume_with_websockets is True
     assert response.request.turn_exchange_id == "turn-123"
+
+
+def test_send_emits_ws_transport_probe_event_after_stream_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    events: list[dict[str, Any]] = []
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+        "conversation_get_payload": {
+            "conversation_id": "conv-123",
+            "current_node": "assistant-final",
+            "mapping": {
+                "assistant-final": {
+                    "message": {
+                        "id": "assistant-final",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "create_time": 2,
+                        "content": {"content_type": "text", "parts": ["transport-probe-ok"]},
+                        "metadata": {
+                            "model_slug": "gpt-5-5-thinking",
+                            "thinking_effort": "extended",
+                            "turn_exchange_id": "turn-123",
+                            "resume_with_websockets": True,
+                            "finish_details": {"type": "stop"},
+                        },
+                    }
+                }
+            },
+        },
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        monkeypatch.setattr(client_mod, "CELSIUS_WS_USER_URL", f"{base_url}/celsius/ws/user")
+        response = client.send(
+            "Reply with exactly: transport-probe-ok",
+            reasoning_effort="high",
+            on_event=events.append,
+        )
+
+    assert response.text == "transport-probe-ok"
+    event_types = [event["type"] for event in events]
+    assert "stream_handoff_transport_probe" in event_types
+    probe_event = next(event for event in events if event["type"] == "stream_handoff_transport_probe")
+    assert probe_event["transport"] == "ws_topic"
+    assert probe_event["success"] is True
+    assert probe_event["websocket_url_present"] is True
+    assert probe_event["websocket_url_scheme"] == "wss"
+    assert probe_event["websocket_url_host"] == "pubsub.chatgpt.com"
 
 
 def test_send_polls_conversation_until_handoff_reply_appears(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -965,6 +965,132 @@ def test_send_polls_conversation_until_handoff_reply_appears(
     assert "conversation_poll_completed" in event_types
 
 
+def test_send_to_existing_conversation_does_not_return_stale_assistant_reply_after_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    events: list[dict[str, Any]] = []
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+        "conversation_get_payloads": [
+            {
+                "conversation_id": "conv-123",
+                "current_node": "assistant-old",
+                "mapping": {
+                    "assistant-old": {
+                        "message": {
+                            "id": "assistant-old",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 1,
+                            "content": {"content_type": "text", "parts": ["stale-old-reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    }
+                },
+            },
+            {
+                "conversation_id": "conv-123",
+                "current_node": "user-new",
+                "mapping": {
+                    "assistant-old": {
+                        "message": {
+                            "id": "assistant-old",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 1,
+                            "content": {"content_type": "text", "parts": ["stale-old-reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                    "user-new": {
+                        "parent": "assistant-old",
+                        "message": {
+                            "id": "user-new",
+                            "author": {"role": "user"},
+                            "recipient": "all",
+                            "create_time": 2,
+                            "content": {"content_type": "text", "parts": ["fresh prompt"]},
+                        }
+                    },
+                },
+            },
+            {
+                "conversation_id": "conv-123",
+                "current_node": "assistant-final",
+                "mapping": {
+                    "assistant-old": {
+                        "message": {
+                            "id": "assistant-old",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 1,
+                            "content": {"content_type": "text", "parts": ["stale-old-reply"]},
+                            "metadata": {"finish_details": {"type": "stop"}},
+                        }
+                    },
+                    "user-new": {
+                        "parent": "assistant-old",
+                        "message": {
+                            "id": "user-new",
+                            "author": {"role": "user"},
+                            "recipient": "all",
+                            "create_time": 2,
+                            "content": {"content_type": "text", "parts": ["fresh prompt"]},
+                        }
+                    },
+                    "assistant-final": {
+                        "parent": "user-new",
+                        "message": {
+                            "id": "assistant-final",
+                            "author": {"role": "assistant"},
+                            "recipient": "all",
+                            "create_time": 3,
+                            "content": {"content_type": "text", "parts": ["fresh-final-reply"]},
+                            "metadata": {
+                                "model_slug": "gpt-5-5-thinking",
+                                "thinking_effort": "extended",
+                                "finish_details": {"type": "stop"},
+                            },
+                        }
+                    },
+                },
+            },
+        ],
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send(
+            "fresh prompt",
+            conversation=adapter.ChatConversation(
+                conversation_id="conv-123",
+                message_id="assistant-old",
+                parent_message_id="assistant-old",
+            ),
+            model="gpt-5-5-thinking",
+            reasoning_effort="high",
+            on_event=events.append,
+        )
+
+    assert state["conversation_get_calls"] >= 3
+    assert response.text == "fresh-final-reply"
+    assert response.conversation.message_id == "assistant-final"
+    event_types = [event["type"] for event in events]
+    assert "conversation_poll_started" in event_types
+    assert "conversation_poll_completed" in event_types
+    attempt_events = [event for event in events if event["type"] == "conversation_poll_attempt"]
+    assert attempt_events
+    assert attempt_events[0]["lifecycle_status"] == "user_last_message"
+
+
 def test_send_retries_after_conversation_inaccessible_during_handoff_recovery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -544,6 +544,8 @@ def test_send_instant_mode_uses_minimal_payload_without_thinking_effort(
 
     payload = state["conversation_payloads"][0]
     assert response.text == "Hello world"
+    assert response.request.sent_model == "gpt-5-3-mini"
+    assert response.request.sent_reasoning_effort is None
     assert payload["model"] == "gpt-5-3-mini"
     assert "thinking_effort" not in payload
     assert "system_hints" not in payload
@@ -579,6 +581,9 @@ def test_send_ui_reasoning_modes_map_to_current_backend_values(
 
     payload = state["conversation_payloads"][0]
     assert response.text == "Hello world"
+    assert response.request.requested_reasoning_effort == reasoning_effort
+    assert response.request.sent_model == expected_model
+    assert response.request.sent_reasoning_effort == expected_effort
     assert payload["model"] == expected_model
     assert payload["thinking_effort"] == expected_effort
 
@@ -624,6 +629,9 @@ def test_send_handles_richer_live_like_sse_stream(monkeypatch: pytest.MonkeyPatc
     assert response.conversation.conversation_id == "conv-live"
     assert response.conversation.message_id == "assistant-final"
     assert response.conversation.finish_reason == "stop"
+    assert response.request.sent_model == "gpt-5-3-mini"
+    assert response.request.sent_reasoning_effort is None
+    assert response.request.observed_model == "gpt-5-3-mini"
 
 
 def test_send_event_callback_tolerates_live_like_sse_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -667,7 +675,11 @@ def test_send_event_callback_tolerates_live_like_sse_metadata(monkeypatch: pytes
         "stream_done",
         "request_completed",
     ]
+    assert events[0]["requested_model"] is None
+    assert events[0]["requested_reasoning_effort"] is None
     assert events[-3]["text_length"] == len("alpha-beta-done")
+    assert events[-1]["sent_model"] == "gpt-5-3-mini"
+    assert events[-1]["observed_model"] == "gpt-5-3-mini"
     assert events[-1]["conversation_id"] == "conv-live"
     assert events[-1]["message_id"] == "assistant-final"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -338,6 +338,12 @@ def _make_chat_handler(
                 return
             if self.path == "/backend-api/conversation/conv-123":
                 state["conversation_get_calls"] = state.get("conversation_get_calls", 0) + 1
+                conversation_statuses = state.get("conversation_get_statuses")
+                if isinstance(conversation_statuses, list) and conversation_statuses:
+                    status_entry = conversation_statuses.pop(0)
+                    if isinstance(status_entry, dict):
+                        self._write_json(int(status_entry.get("status", 200)), status_entry.get("payload") or {})
+                        return
                 conversation_payloads = state.get("conversation_get_payloads")
                 if isinstance(conversation_payloads, list) and conversation_payloads:
                     conversation_payload = conversation_payloads.pop(0)
@@ -731,20 +737,22 @@ def test_send_event_callback_tolerates_live_like_sse_metadata(monkeypatch: pytes
     assert response.title == "Live callback title"
     assert streamed_tokens == ["alpha-", "beta", "-done"]
     event_types = [event["type"] for event in events]
-    assert event_types == [
+    assert event_types[0:4] == [
         "request_started",
         "requirements_ready",
+        "request_payload_prepared",
         "stream_started",
-        "first_token",
-        "assistant_token",
-        "assistant_token",
-        "assistant_token",
+    ]
+    assert event_types.count("raw_sse_event") >= 1
+    assert event_types.count("assistant_token") == 3
+    assert event_types[-3:] == [
         "stream_completed",
         "stream_done",
         "request_completed",
     ]
     assert events[0]["requested_model"] is None
     assert events[0]["requested_reasoning_effort"] is None
+    assert events[2]["payload"]["model"] == "gpt-5-3-mini"
     assert events[-3]["text_length"] == len("alpha-beta-done")
     assert events[-1]["sent_model"] == "gpt-5-3-mini"
     assert events[-1]["observed_model"] == "gpt-5-3-mini"
@@ -829,11 +837,67 @@ def test_send_recovers_message_id_text_and_metadata_after_stream_handoff(
     assert response.request.observed_reasoning_effort == "extended"
 
 
+def test_send_emits_handoff_and_poll_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+        "conversation_get_payload": {
+            "conversation_id": "conv-123",
+            "current_node": "assistant-final",
+            "mapping": {
+                "assistant-final": {
+                    "message": {
+                        "id": "assistant-final",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "create_time": 2,
+                        "content": {"content_type": "text", "parts": ["handoff-events-ok"]},
+                        "metadata": {
+                            "model_slug": "gpt-5-5-thinking",
+                            "thinking_effort": "extended",
+                            "finish_details": {"type": "stop"},
+                        },
+                    }
+                }
+            },
+        },
+    }
+    events: list[dict[str, Any]] = []
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send(
+            "Reply with exactly: handoff-events-ok",
+            reasoning_effort="high",
+            on_event=events.append,
+        )
+
+    assert response.text == "handoff-events-ok"
+    event_types = [event["type"] for event in events]
+    assert "request_payload_prepared" in event_types
+    assert "raw_sse_event" in event_types
+    assert "raw_sse_done" in event_types
+    assert "stream_handoff" in event_types
+    handoff_event = next(event for event in events if event["type"] == "stream_handoff")
+    assert handoff_event["conversation_id"] == "conv-123"
+    assert handoff_event["turn_exchange_id"] == "turn-123"
+
+
 def test_send_polls_conversation_until_handoff_reply_appears(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _build_client()
     client.auth.accessToken = "test-token"
+    events: list[dict[str, Any]] = []
     state = {
         "requirements_calls": 0,
         "file_create_payloads": [],
@@ -883,7 +947,11 @@ def test_send_polls_conversation_until_handoff_reply_appears(
 
     with _serve(_make_chat_handler(state)) as base_url:
         _patch_chat_endpoints(monkeypatch, base_url)
-        response = client.send("Reply with exactly: polled-ok", reasoning_effort="high")
+        response = client.send(
+            "Reply with exactly: polled-ok",
+            reasoning_effort="high",
+            on_event=events.append,
+        )
 
     assert state["conversation_get_calls"] >= 2
     assert response.text == "polled-ok"
@@ -891,6 +959,74 @@ def test_send_polls_conversation_until_handoff_reply_appears(
     assert response.conversation.message_id == "assistant-final"
     assert response.request.observed_model == "gpt-5-5-thinking"
     assert response.request.observed_reasoning_effort == "extended"
+    event_types = [event["type"] for event in events]
+    assert "conversation_poll_started" in event_types
+    assert "conversation_poll_attempt" in event_types
+    assert "conversation_poll_completed" in event_types
+
+
+def test_send_retries_after_conversation_inaccessible_during_handoff_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    events: list[dict[str, Any]] = []
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+        "conversation_get_statuses": [
+            {
+                "status": 404,
+                "payload": {
+                    "detail": {
+                        "message": "conversation not ready yet",
+                        "code": "conversation_inaccessible",
+                        "can_retry": False,
+                        "conversation_id": "conv-123",
+                    }
+                },
+            }
+        ],
+        "conversation_get_payload": {
+            "conversation_id": "conv-123",
+            "current_node": "assistant-final",
+            "mapping": {
+                "assistant-final": {
+                    "message": {
+                        "id": "assistant-final",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "create_time": 2,
+                        "content": {"content_type": "text", "parts": ["retry-ok"]},
+                        "metadata": {
+                            "model_slug": "gpt-5-5-thinking",
+                            "thinking_effort": "extended",
+                            "finish_details": {"type": "stop"},
+                        },
+                    }
+                }
+            },
+        },
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send(
+            "Reply with exactly: retry-ok",
+            reasoning_effort="high",
+            on_event=events.append,
+        )
+
+    assert state["conversation_get_calls"] >= 2
+    assert response.text == "retry-ok"
+    event_types = [event["type"] for event in events]
+    assert "conversation_recovery_fetch_error" in event_types
+    assert "conversation_poll_completed" in event_types
 
 
 def test_approve_pending_action_posts_prepare_and_polls_conversation(
@@ -1010,14 +1146,18 @@ def test_approve_pending_action_posts_prepare_and_polls_conversation(
     }
     assert state["conversation_get_calls"] == 2
     assert streamed_tokens == ["Hello ", "world"]
-    assert [event["type"] for event in events] == [
+    event_types = [event["type"] for event in events]
+    assert event_types[:5] == [
         "pending_approval_detected",
         "approval_prepare_succeeded",
         "assistant_token",
         "assistant_token",
         "approval_sent",
-        "approval_completed",
     ]
+    assert "conversation_poll_started" in event_types
+    assert "conversation_poll_attempt" in event_types
+    assert "conversation_poll_completed" in event_types
+    assert event_types[-1] == "approval_completed"
     assert response.text == "approved result"
     assert response.conversation.conversation_id == "conv-123"
     assert response.conversation.message_id == "assistant-new"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import base64
 import json
 import shutil
 import threading
@@ -14,6 +15,12 @@ import chatgpt_web_adapter.client as client_mod
 import pytest
 
 PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"0" * 40
+
+
+def _resume_topic_token(topic_id: str = "conversation-turn-123") -> str:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "ES256", "typ": "JWT"}).encode("utf-8")).decode("ascii").rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps({"turn_topic_id": topic_id}).encode("utf-8")).decode("ascii").rstrip("=")
+    return f"{header}.{payload}.signature"
 
 
 def _live_like_stream_events(
@@ -131,7 +138,7 @@ def _handoff_only_stream_events(
         {
             "type": "resume_conversation_token",
             "kind": "topic",
-            "token": "resume-token",
+            "token": _resume_topic_token(),
             "conversation_id": conversation_id,
         },
         {
@@ -890,6 +897,58 @@ def test_send_emits_handoff_and_poll_events(
     handoff_event = next(event for event in events if event["type"] == "stream_handoff")
     assert handoff_event["conversation_id"] == "conv-123"
     assert handoff_event["turn_exchange_id"] == "turn-123"
+    assert handoff_event["resume_kind"] == "topic"
+    assert handoff_event["resume_turn_topic_id"] == "conversation-turn-123"
+    assert handoff_event["resume_token_present"] is True
+
+
+def test_send_exposes_resume_diagnostics_after_stream_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+        "conversation_get_calls": 0,
+        "stream_events": _handoff_only_stream_events(),
+        "conversation_get_payload": {
+            "conversation_id": "conv-123",
+            "current_node": "assistant-final",
+            "mapping": {
+                "assistant-final": {
+                    "message": {
+                        "id": "assistant-final",
+                        "author": {"role": "assistant"},
+                        "recipient": "all",
+                        "create_time": 2,
+                        "content": {"content_type": "text", "parts": ["resume-diagnostics-ok"]},
+                        "metadata": {
+                            "model_slug": "gpt-5-5-thinking",
+                            "thinking_effort": "extended",
+                            "turn_exchange_id": "turn-123",
+                            "resume_with_websockets": True,
+                            "finish_details": {"type": "stop"},
+                        },
+                    }
+                }
+            },
+        },
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send("Reply with exactly: resume-diagnostics-ok", reasoning_effort="high")
+
+    assert response.text == "resume-diagnostics-ok"
+    assert response.request.resume_kind == "topic"
+    assert response.request.resume_token_present is True
+    assert response.request.resume_turn_topic_id == "conversation-turn-123"
+    assert response.request.resume_with_websockets is True
+    assert response.request.turn_exchange_id == "turn-123"
 
 
 def test_send_polls_conversation_until_handoff_reply_appears(

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -109,13 +109,13 @@ def test_text_message_rejects_invalid_metadata() -> None:
 def test_new_chat_builds_minimal_payload() -> None:
     payload = PayloadBuilder.new_chat(
         "hello",
-        model="gpt-4o-mini",
+        model="gpt-5-3-mini",
         parent_message_id="parent-1",
     )
 
     assert payload["action"] == "next"
     assert payload["parent_message_id"] == "parent-1"
-    assert payload["model"] == "gpt-4o-mini"
+    assert payload["model"] == "gpt-5-3-mini"
     assert payload["conversation_mode"] == {"kind": "primary_assistant"}
     assert payload["enable_message_followups"] is False
     assert payload["supports_buffering"] is True
@@ -178,6 +178,41 @@ def test_new_chat_reasoning_effort(reasoning_effort: str) -> None:
     )
 
     assert payload["thinking_effort"] == reasoning_effort
+
+
+def test_new_chat_instant_mode_omits_thinking_effort_and_uses_instant_model() -> None:
+    payload = PayloadBuilder.new_chat(
+        "think",
+        reasoning_effort="instant",
+        parent_message_id="parent-1",
+    )
+
+    assert payload["model"] == "gpt-5-3-mini"
+    assert "thinking_effort" not in payload
+    assert len(payload["messages"]) == 1
+    assert payload["messages"][0]["author"] == {"role": "user"}
+
+
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_model", "expected_effort"),
+    [
+        ("medium", "gpt-5-5-thinking", "standard"),
+        ("high", "gpt-5-5-thinking", "extended"),
+    ],
+)
+def test_new_chat_ui_reasoning_modes_map_to_current_backend_values(
+    reasoning_effort: str,
+    expected_model: str,
+    expected_effort: str,
+) -> None:
+    payload = PayloadBuilder.new_chat(
+        "think",
+        reasoning_effort=reasoning_effort,
+        parent_message_id="parent-1",
+    )
+
+    assert payload["model"] == expected_model
+    assert payload["thinking_effort"] == expected_effort
 
 
 @pytest.mark.parametrize("reasoning_effort", [None, "", "off", "none", "-"])

--- a/tests/test_public_api_surface.py
+++ b/tests/test_public_api_surface.py
@@ -13,6 +13,7 @@ CORE_PUBLIC_API = [
     "PendingApproval",
     "ChatResponse",
     "ChatMetrics",
+    "ChatRequestDiagnostics",
     "AuthData",
     "errors",
 ]

--- a/tests/test_send_metrics.py
+++ b/tests/test_send_metrics.py
@@ -178,6 +178,9 @@ def test_send_populates_expanded_metrics(monkeypatch: pytest.MonkeyPatch) -> Non
     assert response.metrics.total >= response.metrics.stream_duration
     assert response.metrics.chars_per_second == len(response.text) / response.metrics.stream_duration
     assert response.metrics.backend_status == 200
+    assert response.request.requested_model == "gpt-4o-mini"
+    assert response.request.sent_model == "gpt-4o-mini"
+    assert response.request.observed_model is None
 
 
 def test_send_metrics_to_dict_contains_expanded_values(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -233,12 +236,15 @@ def test_send_emits_event_callback_sequence(monkeypatch: pytest.MonkeyPatch) -> 
         "stream_done",
         "request_completed",
     ]
-    assert events[0]["model"] == "gpt-4o-mini"
+    assert events[0]["requested_model"] == "gpt-4o-mini"
+    assert events[0]["requested_reasoning_effort"] is None
     assert events[1]["token_present"] is True
     assert events[3]["token"] == "Hi"
     assert events[4]["token"] == "Hi"
     assert events[5]["token"] == " there"
     assert events[-2]["text_length"] == len("Hi there")
+    assert events[-1]["sent_model"] == "gpt-4o-mini"
+    assert events[-1]["observed_model"] is None
     assert events[-1]["conversation_id"] == "conv-123"
     assert events[-1]["message_id"] == "assistant-1"
     assert events[-1]["finish_reason"] == "stop"

--- a/tests/test_send_metrics.py
+++ b/tests/test_send_metrics.py
@@ -225,13 +225,15 @@ def test_send_emits_event_callback_sequence(monkeypatch: pytest.MonkeyPatch) -> 
     assert response.text == "Hi there"
     assert tokens == ["Hi", " there"]
     event_types = [event["type"] for event in events]
-    assert event_types == [
+    assert event_types[0:4] == [
         "request_started",
         "requirements_ready",
+        "request_payload_prepared",
         "stream_started",
-        "first_token",
-        "assistant_token",
-        "assistant_token",
+    ]
+    assert event_types.count("raw_sse_event") >= 1
+    assert event_types.count("assistant_token") == 2
+    assert event_types[-3:] == [
         "stream_completed",
         "stream_done",
         "request_completed",
@@ -239,9 +241,12 @@ def test_send_emits_event_callback_sequence(monkeypatch: pytest.MonkeyPatch) -> 
     assert events[0]["requested_model"] == "gpt-4o-mini"
     assert events[0]["requested_reasoning_effort"] is None
     assert events[1]["token_present"] is True
-    assert events[3]["token"] == "Hi"
-    assert events[4]["token"] == "Hi"
-    assert events[5]["token"] == " there"
+    assert events[2]["payload"]["model"] == "gpt-4o-mini"
+    first_token_event = next(event for event in events if event["type"] == "first_token")
+    assistant_token_events = [event for event in events if event["type"] == "assistant_token"]
+    assert first_token_event["token"] == "Hi"
+    assert assistant_token_events[0]["token"] == "Hi"
+    assert assistant_token_events[1]["token"] == " there"
     assert events[-2]["text_length"] == len("Hi there")
     assert events[-1]["sent_model"] == "gpt-4o-mini"
     assert events[-1]["observed_model"] is None
@@ -273,12 +278,13 @@ def test_send_emits_error_event_on_failure(monkeypatch: pytest.MonkeyPatch) -> N
     assert error.request_stage == "conversation_stream"
 
     event_types = [event["type"] for event in events]
-    assert event_types == [
+    assert event_types[0:4] == [
         "request_started",
         "requirements_ready",
+        "request_payload_prepared",
         "stream_started",
-        "error",
     ]
+    assert event_types[-1] == "error"
     assert events[-1]["error_type"] == "RequestError"
     assert "backend status=500" in events[-1]["message"]
     assert events[-1]["status_code"] == 500

--- a/tests/test_send_to_conversation.py
+++ b/tests/test_send_to_conversation.py
@@ -77,6 +77,7 @@ def test_send_to_conversation_attaches_and_sends_with_detected_model() -> None:
             "conversation": attached.conversation,
             "media": None,
             "on_token": None,
+            "on_event": None,
         }
     ]
 
@@ -198,6 +199,9 @@ def test_send_to_conversation_passes_send_options_through() -> None:
     def on_token(token: str) -> None:
         assert token
 
+    def on_event(event: dict[str, Any]) -> None:
+        assert event is not None
+
     client.send_to_conversation(
         CONVERSATION_ID,
         "РџСЂРѕРґРѕР»Р¶Рё",
@@ -206,6 +210,7 @@ def test_send_to_conversation_passes_send_options_through() -> None:
         temporary=True,
         media=media,
         on_token=on_token,
+        on_event=on_event,
     )
 
     call = send_calls[0]
@@ -214,6 +219,7 @@ def test_send_to_conversation_passes_send_options_through() -> None:
     assert call["temporary"] is True
     assert call["media"] == media
     assert call["on_token"] is on_token
+    assert call["on_event"] is on_event
 
 
 def test_send_to_conversation_propagates_attach_errors_without_sending() -> None:

--- a/tests/test_watch_conversation_example.py
+++ b/tests/test_watch_conversation_example.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "examples" / "watch_conversation.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("watch_conversation_example", MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_live_fragments_reads_reasoning_from_raw_ws_event() -> None:
+    module = _load_module()
+
+    fragments = module._extract_live_fragments(
+        {
+            "type": "raw_ws_event",
+            "parsed": {
+                "v": [
+                    {
+                        "p": "/message/reasoning/summary",
+                        "v": "Need to compare the two transport paths before replying.",
+                    }
+                ]
+            },
+        }
+    )
+
+    assert fragments == [
+        {
+            "kind": "reasoning",
+            "key": "path:/message/reasoning/summary",
+            "label": "reasoning",
+            "text": "Need to compare the two transport paths before replying.",
+        }
+    ]
+
+
+def test_extract_live_fragments_reads_tool_result_message() -> None:
+    module = _load_module()
+
+    fragments = module._extract_live_fragments(
+        {
+            "type": "raw_sse_event",
+            "parsed": {
+                "v": {
+                    "message": {
+                        "id": "tool-1",
+                        "author": {"role": "tool", "name": "browser"},
+                        "recipient": "browser",
+                        "content": {"parts": ["Found 3 matching files."]},
+                        "metadata": {},
+                    }
+                }
+            },
+        }
+    )
+
+    assert fragments == [
+        {
+            "kind": "tool_result",
+            "key": "tool_result:tool-1",
+            "label": "tool_result:browser",
+            "text": "Found 3 matching files.",
+        }
+    ]


### PR DESCRIPTION
## Summary

Adds explicit reasoning-effort mapping for ChatGPT web payloads and diagnostics.

## Changes

- Normalize user-facing reasoning aliases:
  - `medium` -> `standard`
  - `high` -> `extended`
  - `off`, `none`, `-`, `instant`, and empty values -> no `thinking_effort`
- Select the default thinking model when reasoning effort is requested and no explicit model is provided.
- Preserve explicit model selection and existing model aliases.
- Add best-effort detection of `thinking_effort` / `reasoning_effort` from conversation payload metadata.
- Store detected reasoning effort on attached conversations and request diagnostics.
- Apply the same reasoning normalization in `PayloadBuilder`.
- Add tests for model resolution, payload building, attach detection, and send diagnostics.

## Notes

This PR does not guarantee that every ChatGPT web model supports every reasoning mode. It only maps the SDK's public options to the backend fields currently observed by the web payloads.