### PR TITLE
PR7.9: Add GPT-5.6 live web contract probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+- diagnostics: added a privacy-safe live model/transport contract probe for validating ChatGPT web model rollouts before changing SDK defaults or aliases
+- docs: added the PR7.9 live model contract probe protocol and evidence/exit criteria
+
 ## 0.1.5 - 2026-06-24
 
 - feat: added experimental required-action detection for connector OAuth/linking cards such as Gmail connect prompts

--- a/docs/live_model_contract_probe.md
+++ b/docs/live_model_contract_probe.md
@@ -1,0 +1,94 @@
+# Live Model Contract Probe
+
+`examples/probe_live_contract.py` records the minimum evidence needed to update
+`chatgpt-web-adapter` after a ChatGPT web model rollout without guessing private
+backend model slugs or reasoning values.
+
+The probe is deliberately **evidence-only**. It does not change SDK defaults,
+model aliases, or reasoning mappings.
+
+## Why an existing conversation is required
+
+The web UI is the source of truth for the user-facing model/mode selection. Create
+(or reuse) a conversation in ChatGPT with the target model and reasoning mode,
+then let the SDK attach to that conversation and continue it with
+`preserve_model=True`.
+
+This separates three contracts that must not be conflated:
+
+1. ChatGPT UI label (for example Medium or High).
+2. Private web backend model slug actually present in the conversation/request.
+3. Private backend reasoning value actually present in the conversation/request.
+
+API model ids are not assumed to equal private ChatGPT web slugs.
+
+## Safety properties
+
+The JSON report does **not** serialize:
+
+- prompt or assistant response text;
+- access tokens, cookies, proof tokens, or resume tokens;
+- conversation, message, turn, conduit, or topic ids;
+- raw SSE/WebSocket frames;
+- full websocket URLs;
+- connector/tool payload values.
+
+Identifiers are represented only as `*_present: true/false`. The probe stores
+model/reasoning scalar values only when they come from model/reasoning-named
+fields and match a conservative token-like character set.
+
+Still review the report before attaching it to an issue or pull request.
+Never share `auth_data.json` or a raw `watch_conversation.py` transcript.
+
+## Run on Windows PowerShell
+
+Install the checkout in editable mode. Installing `websockets` is recommended so
+we can distinguish a real websocket path from polling fallback while PR7.11 is
+still pending.
+
+```powershell
+python -m pip install -e ".[test]"
+python -m pip install websockets
+```
+
+Create separate ChatGPT conversations for the modes you want to measure. Then run:
+
+```powershell
+python .\examples\probe_live_contract.py `
+  "https://chatgpt.com/c/<conversation-id>" `
+  --output .\artifacts\gpt56-medium.json
+```
+
+Repeat for High and, when available to the account/workspace, Extra High and Pro.
+The prompt defaults to `Reply exactly: probe-ok`; it is intentionally not written
+to the report.
+
+## What to compare
+
+For each report inspect:
+
+- `attach.detected_model`
+- `attach.detected_reasoning_effort`
+- `request.sent_model`
+- `request.sent_reasoning_effort`
+- `request.observed_model`
+- `request.observed_reasoning_effort`
+- `transport.*`
+- `field_evidence`
+- `verdict`
+
+Expected first-pass verdict is `CONTRACT_OBSERVED`.
+
+A mismatch verdict is evidence, not an instruction to patch aliases immediately.
+Preserve the report and first determine whether the mismatch is caused by model
+routing, automatic switching, stale detector locations, or an actual backend
+contract change.
+
+## PR7.9 exit criteria
+
+PR7.9 can close when we have sanitized live evidence showing the current web
+contract for at least Medium and High, plus regression fixtures for any new
+metadata locations discovered by the probe.
+
+Only after that evidence should PR7.10 update the model capability registry and
+public convenience modes.

--- a/examples/probe_live_contract.py
+++ b/examples/probe_live_contract.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+"""Capture a privacy-safe ChatGPT web model/transport contract probe.
+
+This example is intentionally evidence-only. It does not change model defaults or
+reasoning aliases. Run it against an existing ChatGPT conversation whose model
+and reasoning mode were selected in the web UI.
+"""
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from chatgpt_web_adapter import ChatGPTWebClient
+
+
+PROBE_SCHEMA = "chatgpt-web-adapter.live-contract-probe.v1"
+DEFAULT_PROMPT = "Reply exactly: probe-ok"
+SAFE_SCALAR = re.compile(r"^[A-Za-z0-9._:/+-]{1,96}$")
+MODEL_KEYS = {"model", "model_slug", "default_model_slug", "selected_model"}
+REASONING_KEYS = {"thinking_effort", "reasoning_effort"}
+IDENTIFIER_KEYS = {
+    "conversation_id",
+    "message_id",
+    "parent_message_id",
+    "turn_exchange_id",
+    "resume_turn_topic_id",
+    "resume_sse_topic_id",
+    "resume_ws_topic_id",
+    "resume_conduit_uuid",
+}
+SECRET_OR_CONTENT_KEYS = {
+    "access_token",
+    "authorization",
+    "cookie",
+    "cookies",
+    "prompt",
+    "raw",
+    "response_text",
+    "resume_token",
+    "text",
+    "token",
+    "websocket_url",
+}
+
+
+def _safe_contract_value(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value or not SAFE_SCALAR.fullmatch(value):
+        return None
+    return value
+
+
+def _walk_contract_fields(value: Any, *, path: str = "$") -> list[dict[str, str]]:
+    """Collect only model/reasoning scalar evidence and structural paths.
+
+    No generic scalar values are retained. This keeps prompts, assistant output,
+    ids, tokens, URLs, connector payloads, and other account data out of the
+    generated report by construction.
+    """
+
+    evidence: list[dict[str, str]] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_text = str(key)
+            key_lower = key_text.lower()
+            child_path = f"{path}.{key_text}"
+            if key_lower in SECRET_OR_CONTENT_KEYS or key_lower in IDENTIFIER_KEYS:
+                continue
+            if key_lower in MODEL_KEYS | REASONING_KEYS:
+                candidate = _safe_contract_value(nested)
+                if candidate is not None:
+                    evidence.append(
+                        {
+                            "path": child_path,
+                            "kind": "model" if key_lower in MODEL_KEYS else "reasoning",
+                            "value": candidate,
+                        }
+                    )
+                continue
+            if isinstance(nested, (dict, list)):
+                evidence.extend(_walk_contract_fields(nested, path=child_path))
+    elif isinstance(value, list):
+        for nested in value:
+            if isinstance(nested, (dict, list)):
+                evidence.extend(_walk_contract_fields(nested, path=f"{path}[]"))
+    return evidence
+
+
+def _presence(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _request_contract(request: Any) -> dict[str, Any]:
+    payload = request.to_dict() if hasattr(request, "to_dict") else dict(request or {})
+    return {
+        "requested_model": payload.get("requested_model"),
+        "requested_reasoning_effort": payload.get("requested_reasoning_effort"),
+        "sent_model": payload.get("sent_model"),
+        "sent_reasoning_effort": payload.get("sent_reasoning_effort"),
+        "observed_model": payload.get("observed_model"),
+        "observed_reasoning_effort": payload.get("observed_reasoning_effort"),
+        "is_continuation": bool(payload.get("is_continuation")),
+        "resume_kind": payload.get("resume_kind"),
+        "resume_token_present": bool(payload.get("resume_token_present")),
+        "handoff_option_types": list(payload.get("handoff_option_types") or ()),
+        "resume_transport_preference": payload.get("resume_transport_preference"),
+        "handoff_recovery_mode": payload.get("handoff_recovery_mode"),
+        "resume_with_websockets": bool(payload.get("resume_with_websockets")),
+        "resume_ws_url_present": bool(payload.get("resume_ws_url_present")),
+        "resume_ws_url_scheme": payload.get("resume_ws_url_scheme"),
+        "resume_ws_url_host": payload.get("resume_ws_url_host"),
+        "conversation_id_present": _presence(payload.get("conversation_id")),
+        "parent_message_id_present": _presence(payload.get("parent_message_id")),
+        "turn_exchange_id_present": _presence(payload.get("turn_exchange_id")),
+        "resume_turn_topic_id_present": _presence(payload.get("resume_turn_topic_id")),
+        "resume_sse_topic_id_present": _presence(payload.get("resume_sse_topic_id")),
+        "resume_ws_topic_id_present": _presence(payload.get("resume_ws_topic_id")),
+        "resume_conduit_uuid_present": _presence(payload.get("resume_conduit_uuid")),
+    }
+
+
+def _transport_summary(event_types: list[str], request_contract: dict[str, Any]) -> dict[str, Any]:
+    counts = Counter(event_types)
+    return {
+        "event_counts": dict(sorted(counts.items())),
+        "saw_raw_sse_event": counts["raw_sse_event"] > 0,
+        "saw_raw_ws_event": counts["raw_ws_event"] > 0,
+        "saw_ws_connected": counts["stream_handoff_ws_connected"] > 0,
+        "saw_ws_subscribed": counts["stream_handoff_ws_subscribed"] > 0,
+        "saw_ws_failure": counts["stream_handoff_ws_failed"] > 0,
+        "saw_polling": any(name.startswith("conversation_poll_") for name in counts),
+        "handoff_recovery_mode": request_contract.get("handoff_recovery_mode"),
+        "resume_transport_preference": request_contract.get("resume_transport_preference"),
+    }
+
+
+def _verdict(
+    *,
+    attached_model: str | None,
+    attached_reasoning: str | None,
+    request_contract: dict[str, Any],
+    field_evidence: list[dict[str, str]],
+) -> str:
+    observed_model = request_contract.get("observed_model")
+    sent_model = request_contract.get("sent_model")
+    observed_reasoning = request_contract.get("observed_reasoning_effort")
+    sent_reasoning = request_contract.get("sent_reasoning_effort")
+
+    if not attached_model and not observed_model and not any(item["kind"] == "model" for item in field_evidence):
+        return "MODEL_CONTRACT_UNOBSERVED"
+    if attached_model and sent_model and attached_model != sent_model:
+        return "PRESERVE_MODEL_MISMATCH"
+    if observed_model and sent_model and observed_model != sent_model:
+        return "OBSERVED_MODEL_DIFFERS_FROM_SENT"
+    if attached_reasoning and sent_reasoning and attached_reasoning != sent_reasoning:
+        return "PRESERVE_REASONING_MISMATCH"
+    if observed_reasoning and sent_reasoning and observed_reasoning != sent_reasoning:
+        return "OBSERVED_REASONING_DIFFERS_FROM_SENT"
+    return "CONTRACT_OBSERVED"
+
+
+def build_report(
+    *,
+    attached: Any,
+    response: Any,
+    events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    attached_model = getattr(attached, "detected_model", None)
+    attached_reasoning = getattr(attached, "detected_reasoning_effort", None)
+    request_contract = _request_contract(response.request)
+    field_evidence: list[dict[str, str]] = []
+    event_types: list[str] = []
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if isinstance(event_type, str) and event_type:
+            event_types.append(event_type)
+        field_evidence.extend(_walk_contract_fields(event))
+
+    unique_evidence = {
+        (item["kind"], item["path"], item["value"]): item
+        for item in field_evidence
+    }
+    field_evidence = [unique_evidence[key] for key in sorted(unique_evidence)]
+
+    report = {
+        "schema": PROBE_SCHEMA,
+        "probe": {
+            "preserve_model": True,
+            "existing_conversation": True,
+            "response_text_recorded": False,
+            "prompt_text_recorded": False,
+            "raw_event_payloads_recorded": False,
+        },
+        "attach": {
+            "detected_model": attached_model,
+            "detected_reasoning_effort": attached_reasoning,
+            "conversation_id_present": bool(getattr(attached, "conversation_id", None)),
+            "current_node_present": bool(getattr(attached, "current_node", None)),
+        },
+        "request": request_contract,
+        "transport": _transport_summary(event_types, request_contract),
+        "field_evidence": field_evidence,
+    }
+    report["verdict"] = _verdict(
+        attached_model=attached_model,
+        attached_reasoning=attached_reasoning,
+        request_contract=request_contract,
+        field_evidence=field_evidence,
+    )
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Capture a privacy-safe live ChatGPT web model/transport contract report.",
+    )
+    parser.add_argument("conversation", help="Existing ChatGPT conversation URL or raw id.")
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument("--output", default="live_contract_probe.json")
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    attached = client.attach_conversation(args.conversation)
+    events: list[dict[str, Any]] = []
+
+    def on_event(event: dict[str, Any]) -> None:
+        if isinstance(event, dict):
+            events.append(event)
+
+    response = client.send_to_conversation(
+        args.conversation,
+        args.prompt,
+        model=None,
+        reasoning_effort=None,
+        preserve_model=True,
+        on_event=on_event,
+    )
+    report = build_report(attached=attached, response=response, events=events)
+
+    output_path = Path(args.output)
+    output_path.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    print(f"report: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_probe_live_contract_example.py
+++ b/tests/test_probe_live_contract_example.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "examples" / "probe_live_contract.py"
+
+
+def _load_module():
+    if "chatgpt_web_adapter" not in sys.modules:
+        stub = types.ModuleType("chatgpt_web_adapter")
+        stub.ChatGPTWebClient = object
+        sys.modules["chatgpt_web_adapter"] = stub
+    spec = importlib.util.spec_from_file_location("probe_live_contract_example", MODULE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Request:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def to_dict(self):
+        return dict(self.payload)
+
+
+def _attached():
+    return SimpleNamespace(
+        detected_model="gpt-5-6-sol-web",
+        detected_reasoning_effort="extended",
+        conversation_id="conv-secret",
+        current_node="node-secret",
+    )
+
+
+def _response(**overrides):
+    payload = {
+        "requested_model": None,
+        "requested_reasoning_effort": None,
+        "sent_model": "gpt-5-6-sol-web",
+        "sent_reasoning_effort": "extended",
+        "observed_model": "gpt-5-6-sol-web",
+        "observed_reasoning_effort": "extended",
+        "conversation_id": "conv-secret",
+        "parent_message_id": "message-secret",
+        "turn_exchange_id": "turn-secret",
+        "resume_token_present": True,
+        "resume_ws_topic_id": "topic-secret",
+        "resume_ws_url_present": True,
+        "resume_ws_url_scheme": "wss",
+        "resume_ws_url_host": "chatgpt.com",
+        "handoff_recovery_mode": "websocket_topic",
+    }
+    payload.update(overrides)
+    return SimpleNamespace(request=_Request(payload))
+
+
+def test_report_does_not_serialize_prompt_response_or_ids() -> None:
+    module = _load_module()
+    events = [
+        {
+            "type": "request_payload_prepared",
+            "prompt": "TOP SECRET PROMPT",
+            "conversation_id": "conv-secret",
+            "token": "resume-secret",
+            "payload": {
+                "model": "gpt-5-6-sol-web",
+                "thinking_effort": "extended",
+                "messages": [{"content": {"parts": ["TOP SECRET PROMPT"]}}],
+            },
+        },
+        {
+            "type": "raw_ws_event",
+            "raw": "TOP SECRET RAW FRAME",
+            "parsed": {
+                "message_id": "message-secret",
+                "model_slug": "gpt-5-6-sol-web",
+                "content": {"parts": ["TOP SECRET RESPONSE"]},
+            },
+        },
+    ]
+
+    report = module.build_report(attached=_attached(), response=_response(), events=events)
+    serialized = json.dumps(report, sort_keys=True)
+
+    for secret in (
+        "TOP SECRET PROMPT",
+        "TOP SECRET RESPONSE",
+        "TOP SECRET RAW FRAME",
+        "conv-secret",
+        "message-secret",
+        "turn-secret",
+        "topic-secret",
+        "resume-secret",
+    ):
+        assert secret not in serialized
+    assert report["request"]["conversation_id_present"] is True
+    assert report["request"]["parent_message_id_present"] is True
+
+
+def test_field_evidence_collects_only_model_and_reasoning_scalars() -> None:
+    module = _load_module()
+    evidence = module._walk_contract_fields(
+        {
+            "metadata": {
+                "model_slug": "gpt-5-6-sol-web",
+                "thinking_effort": "extra-high",
+                "other": "must-not-be-recorded",
+                "selected_model": {"slug": "nested-object-is-not-a-scalar"},
+            }
+        }
+    )
+
+    assert evidence == [
+        {"path": "$.metadata.model_slug", "kind": "model", "value": "gpt-5-6-sol-web"},
+        {"path": "$.metadata.thinking_effort", "kind": "reasoning", "value": "extra-high"},
+    ]
+
+
+def test_matching_preserved_contract_is_observed() -> None:
+    module = _load_module()
+    report = module.build_report(
+        attached=_attached(),
+        response=_response(),
+        events=[{"type": "raw_sse_event", "parsed": {"model_slug": "gpt-5-6-sol-web"}}],
+    )
+
+    assert report["verdict"] == "CONTRACT_OBSERVED"
+    assert report["transport"]["saw_raw_sse_event"] is True
+
+
+def test_detector_drift_gets_explicit_verdict() -> None:
+    module = _load_module()
+    report = module.build_report(
+        attached=_attached(),
+        response=_response(sent_model="another-web-slug", observed_model="another-web-slug"),
+        events=[],
+    )
+
+    assert report["verdict"] == "PRESERVE_MODEL_MISMATCH"


### PR DESCRIPTION
## Summary

Adds an evidence-only live contract probe for validating ChatGPT web model/reasoning/transport behavior after the GPT-5.6 rollout without guessing private backend slugs.

## Changes

- add `examples/probe_live_contract.py`
- add `docs/live_model_contract_probe.md`
- add unit coverage for privacy/sanitization, field extraction, preserved-contract success, and detector drift
- document the probe in `CHANGELOG.md`

## Safety / scope

- does not change `DEFAULT_MODEL`, model aliases, reasoning mappings, or runtime transport behavior
- requires an existing ChatGPT conversation and continues it with `preserve_model=True`
- report omits prompt/response text, auth/cookie/resume tokens, raw SSE/WebSocket frames, conversation/message/turn/topic IDs, and full websocket URLs
- identifiers are represented only as presence booleans

## Validation

Local validation of the prepared patch:

- `py_compile`: PASS
- probe unit tests: 4 passed

## Exit criteria

Capture sanitized live evidence for current GPT-5.6 Sol Medium and High conversations (plus Extra High/Pro where available), then add regression fixtures for any newly observed metadata locations before changing model policy in PR7.10.