### PR TITLE
PR7.9a: Repair current web session and Turnstile gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+- auth: raw ChatGPT `/api/auth/session` dumps now best-effort map `sessionToken` to the web session cookie while preserving explicit/chunked browser cookies
+- compatibility: web writes now synchronize `oai-did` to `oai-device-id` and fail early with `TURNSTILE_REQUIRED` when ChatGPT requires browser challenge evidence that was not supplied
+- diagnostics: live contract probes now preserve read-only model/reasoning evidence when a write is blocked by Turnstile and support explicit `--attach-only` capture
 - diagnostics: added a privacy-safe live model/transport contract probe for validating ChatGPT web model rollouts before changing SDK defaults or aliases
 - docs: added the PR7.9 live model contract probe protocol and evidence/exit criteria
 

--- a/docs/live_model_contract_probe.md
+++ b/docs/live_model_contract_probe.md
@@ -22,12 +22,34 @@ This separates three contracts that must not be conflated:
 
 API model ids are not assumed to equal private ChatGPT web slugs.
 
+## Fast auth from `/api/auth/session`
+
+While signed in to ChatGPT in the browser, the JSON returned by
+`https://chatgpt.com/api/auth/session` can be saved locally as `auth_data.json`.
+The adapter consumes the top-level `accessToken` and now best-effort maps the
+endpoint's `sessionToken` to the ChatGPT NextAuth session cookie when explicit
+browser cookies are not already present.
+
+Explicit cookies win. This matters because current browser sessions may expose a
+chunked session cookie such as `__Secure-next-auth.session-token.0` and `.1`.
+If those cookies are copied into `auth_data.json`, the adapter leaves them intact.
+
+Before a write, the adapter also reuses or obtains the server-issued `oai-did`
+cookie and mirrors it into the `oai-device-id` request header.
+
+`/api/auth/session` is **not** a complete substitute for browser challenge state.
+If `chat-requirements` says Turnstile is required and no legitimate browser-derived
+Turnstile token was supplied, the adapter stops before the conversation POST with
+`TURNSTILE_REQUIRED`. It does not synthesize, solve, or bypass that challenge.
+
+Never share `auth_data.json` or values copied from browser authentication headers.
+
 ## Safety properties
 
 The JSON report does **not** serialize:
 
 - prompt or assistant response text;
-- access tokens, cookies, proof tokens, or resume tokens;
+- access tokens, cookies, proof tokens, Turnstile tokens, or resume tokens;
 - conversation, message, turn, conduit, or topic ids;
 - raw SSE/WebSocket frames;
 - full websocket URLs;
@@ -59,6 +81,28 @@ python .\examples\probe_live_contract.py `
   --output .\artifacts\gpt56-medium.json
 ```
 
+If the current web session requires Turnstile, the command no longer loses the
+useful read evidence. It writes a sanitized report with:
+
+```text
+verdict = WRITE_BLOCKED_TURNSTILE
+```
+
+and keeps the model/reasoning values detected while attaching to the existing
+conversation.
+
+You can explicitly request a read-only probe with no write attempt:
+
+```powershell
+python .\examples\probe_live_contract.py `
+  "https://chatgpt.com/c/<conversation-id>" `
+  --attach-only `
+  --output .\artifacts\gpt56-medium.json
+```
+
+A successful read-only capture reports `ATTACH_ONLY_CONTRACT_OBSERVED` when the
+existing conversation exposes a detectable model contract.
+
 Repeat for High and, when available to the account/workspace, Extra High and Pro.
 The prompt defaults to `Reply exactly: probe-ok`; it is intentionally not written
 to the report.
@@ -73,11 +117,14 @@ For each report inspect:
 - `request.sent_reasoning_effort`
 - `request.observed_model`
 - `request.observed_reasoning_effort`
+- `write_gate.*`
 - `transport.*`
 - `field_evidence`
 - `verdict`
 
-Expected first-pass verdict is `CONTRACT_OBSERVED`.
+Expected full-write first-pass verdict is `CONTRACT_OBSERVED`. A read-only result
+or a Turnstile-blocked result is still useful evidence for the attach-side model
+contract, but it does not prove the write/stream transport contract.
 
 A mismatch verdict is evidence, not an instruction to patch aliases immediately.
 Preserve the report and first determine whether the mismatch is caused by model

--- a/examples/probe_live_contract.py
+++ b/examples/probe_live_contract.py
@@ -14,7 +14,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-from chatgpt_web_adapter import ChatGPTWebClient
+from chatgpt_web_adapter import ChatGPTWebClient, RequestError
 
 
 PROBE_SCHEMA = "chatgpt-web-adapter.live-contract-probe.v1"
@@ -168,12 +168,12 @@ def _verdict(
 def build_report(
     *,
     attached: Any,
-    response: Any,
+    response: Any | None,
     events: list[dict[str, Any]],
 ) -> dict[str, Any]:
     attached_model = getattr(attached, "detected_model", None)
     attached_reasoning = getattr(attached, "detected_reasoning_effort", None)
-    request_contract = _request_contract(response.request)
+    request_contract = _request_contract(getattr(response, "request", None))
     field_evidence: list[dict[str, str]] = []
     event_types: list[str] = []
 
@@ -196,6 +196,7 @@ def build_report(
         "probe": {
             "preserve_model": True,
             "existing_conversation": True,
+            "write_attempted": response is not None,
             "response_text_recorded": False,
             "prompt_text_recorded": False,
             "raw_event_payloads_recorded": False,
@@ -209,6 +210,11 @@ def build_report(
         "request": request_contract,
         "transport": _transport_summary(event_types, request_contract),
         "field_evidence": field_evidence,
+        "write_gate": {
+            "blocked": False,
+            "reason": None,
+            "browser_challenge_token_recorded": False,
+        },
     }
     report["verdict"] = _verdict(
         attached_model=attached_model,
@@ -228,6 +234,11 @@ def main() -> None:
     parser.add_argument("--prompt", default=DEFAULT_PROMPT)
     parser.add_argument("--timeout", type=int, default=180)
     parser.add_argument("--output", default="live_contract_probe.json")
+    parser.add_argument(
+        "--attach-only",
+        action="store_true",
+        help="Record only the existing conversation contract; do not attempt a write.",
+    )
     args = parser.parse_args()
 
     client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
@@ -238,15 +249,33 @@ def main() -> None:
         if isinstance(event, dict):
             events.append(event)
 
-    response = client.send_to_conversation(
-        args.conversation,
-        args.prompt,
-        model=None,
-        reasoning_effort=None,
-        preserve_model=True,
-        on_event=on_event,
-    )
-    report = build_report(attached=attached, response=response, events=events)
+    if args.attach_only:
+        report = build_report(attached=attached, response=None, events=[])
+        if report["verdict"] != "MODEL_CONTRACT_UNOBSERVED":
+            report["verdict"] = "ATTACH_ONLY_CONTRACT_OBSERVED"
+    else:
+        try:
+            response = client.send_to_conversation(
+                args.conversation,
+                args.prompt,
+                model=None,
+                reasoning_effort=None,
+                preserve_model=True,
+                on_event=on_event,
+            )
+        except RequestError as error:
+            if getattr(error, "request_stage", None) != "turnstile_gate":
+                raise
+            report = build_report(attached=attached, response=None, events=events)
+            report["probe"]["write_attempted"] = True
+            report["write_gate"] = {
+                "blocked": True,
+                "reason": "turnstile_required",
+                "browser_challenge_token_recorded": False,
+            }
+            report["verdict"] = "WRITE_BLOCKED_TURNSTILE"
+        else:
+            report = build_report(attached=attached, response=response, events=events)
 
     output_path = Path(args.output)
     output_path.write_text(

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -45,11 +45,16 @@ from .types import (
     WaitResult,
 )
 from .wait import wait_until_completed as _wait_until_completed
+from .web_session import gate_get_ready_requirements as _gate_get_ready_requirements
 
 _original_send = ChatGPTWebClient.send
 _original_approve_pending_action = ChatGPTWebClient.approve_pending_action
 _original_send_and_auto_approve = ChatGPTWebClient.send_and_auto_approve
+_original_get_ready_requirements = ChatGPTWebClient._get_ready_requirements
 
+ChatGPTWebClient._get_ready_requirements = _gate_get_ready_requirements(
+    _original_get_ready_requirements
+)
 ChatGPTWebClient.approve_pending_action = _policy_approve_pending_action(
     _original_approve_pending_action
 )

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -45,15 +45,22 @@ from .types import (
     WaitResult,
 )
 from .wait import wait_until_completed as _wait_until_completed
-from .web_session import gate_get_ready_requirements as _gate_get_ready_requirements
+from .web_session import (
+    gate_get_ready_requirements as _gate_get_ready_requirements,
+    redact_web_session_headers as _redact_web_session_headers,
+)
 
 _original_send = ChatGPTWebClient.send
 _original_approve_pending_action = ChatGPTWebClient.approve_pending_action
 _original_send_and_auto_approve = ChatGPTWebClient.send_and_auto_approve
 _original_get_ready_requirements = ChatGPTWebClient._get_ready_requirements
+_original_sanitize_header_value = ChatGPTWebClient._sanitize_header_value
 
 ChatGPTWebClient._get_ready_requirements = _gate_get_ready_requirements(
     _original_get_ready_requirements
+)
+ChatGPTWebClient._sanitize_header_value = _redact_web_session_headers(
+    _original_sanitize_header_value
 )
 ChatGPTWebClient.approve_pending_action = _policy_approve_pending_action(
     _original_approve_pending_action

--- a/src/chatgpt_web_adapter/auth.py
+++ b/src/chatgpt_web_adapter/auth.py
@@ -15,6 +15,7 @@ DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 )
+CHATGPT_SESSION_COOKIE = "__Secure-next-auth.session-token"
 
 
 def _iter_env_candidates(auth_path: Path) -> list[Path]:
@@ -78,6 +79,34 @@ def _get_access_token_expiry(access_token: str | None) -> datetime | None:
         return None
 
 
+def _has_session_cookie(auth: AuthData) -> bool:
+    return any(
+        name == CHATGPT_SESSION_COOKIE or name.startswith(f"{CHATGPT_SESSION_COOKIE}.")
+        for name in auth.cookies
+    )
+
+
+def _seed_session_cookie_from_auth_file(auth: AuthData, auth_path: Path) -> None:
+    """Best-effort mapping for a raw ``/api/auth/session`` JSON dump.
+
+    ChatGPT's session endpoint exposes ``sessionToken`` while browser requests use
+    the NextAuth session cookie. Explicit cookies always win, including chunked
+    ``.0``/``.1`` variants copied from a browser.
+    """
+
+    if _has_session_cookie(auth) or not auth_path.is_file():
+        return
+    try:
+        payload = json.loads(auth_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    if not isinstance(payload, dict):
+        return
+    session_token = payload.get("sessionToken")
+    if isinstance(session_token, str) and session_token.strip():
+        auth.cookies[CHATGPT_SESSION_COOKIE] = session_token.strip()
+
+
 def load_auth_data(auth_file: str | Path = DEFAULT_AUTH_FILE) -> AuthData:
     auth_path = Path(auth_file)
     try:
@@ -88,6 +117,8 @@ def load_auth_data(auth_file: str | Path = DEFAULT_AUTH_FILE) -> AuthData:
         raise AuthError(f"Failed to read auth data from {auth_path}: {error}") from error
     except ValueError as error:
         raise AuthError(f"Failed to parse auth data from {auth_path}: {error}") from error
+
+    _seed_session_cookie_from_auth_file(auth, auth_path)
 
     candidates: list[tuple[str, str]] = []
     if auth.accessToken:
@@ -133,6 +164,9 @@ def build_base_headers(auth: AuthData) -> dict[str, str]:
         if key_str in {"authorization", "cookie"}:
             continue
         headers[key_str] = str(value)
+    device_id = auth.cookies.get("oai-did")
+    if isinstance(device_id, str) and device_id.strip():
+        headers.setdefault("oai-device-id", device_id.strip())
     headers.setdefault("accept", "*/*")
     headers.setdefault("accept-language", "en-US,en;q=0.8")
     headers.setdefault("content-type", "application/json")

--- a/src/chatgpt_web_adapter/web_session.py
+++ b/src/chatgpt_web_adapter/web_session.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .auth import CHAT_URL
+from .exceptions import RequestError
+
+
+def _sync_device_header(client: Any) -> bool:
+    device_id = getattr(client.auth, "cookies", {}).get("oai-did")
+    if not isinstance(device_id, str) or not device_id.strip():
+        return False
+    client.base_headers["oai-device-id"] = device_id.strip()
+    return True
+
+
+def bootstrap_web_session(client: Any) -> bool:
+    """Refresh the minimum server-issued web-session context used by writes.
+
+    This does not solve or synthesize browser challenges. It only reuses supplied
+    session material, lets ChatGPT set ordinary cookies such as ``oai-did``, and
+    mirrors that device id into the request header expected by the web backend.
+    """
+
+    if _sync_device_header(client):
+        return True
+    if bool(getattr(client, "_web_session_bootstrapped", False)):
+        return False
+
+    headers = client._build_headers({"accept": "text/html,application/xhtml+xml"})
+    headers.pop("content-type", None)
+    status, _body, _header_text = client._run_curl(
+        "GET",
+        CHAT_URL,
+        headers,
+        follow_redirects=True,
+    )
+    client._web_session_bootstrapped = True
+    if status >= 400:
+        raise RequestError(
+            f"web session bootstrap status={status}",
+            status_code=status,
+            endpoint="/",
+            request_stage="web_session_bootstrap",
+        )
+    return _sync_device_header(client)
+
+
+def gate_get_ready_requirements(
+    original_get_ready_requirements: Callable[..., tuple[dict[str, Any], str | None]],
+) -> Callable[..., tuple[dict[str, Any], str | None]]:
+    """Require legitimate browser challenge evidence before a write proceeds."""
+
+    def get_ready_requirements(self: Any) -> tuple[dict[str, Any], str | None]:
+        bootstrap_web_session(self)
+        requirements, proof_header = original_get_ready_requirements(self)
+        turnstile = requirements.get("turnstile") if isinstance(requirements, dict) else None
+        turnstile_required = bool(turnstile.get("required")) if isinstance(turnstile, dict) else False
+        if turnstile_required and not getattr(self.auth, "turnstile_token", None):
+            self._emit_event(
+                None,
+                "web_session_gate_blocked",
+                reason="turnstile_required",
+            )
+            raise RequestError(
+                "TURNSTILE_REQUIRED: ChatGPT requires browser-derived Turnstile evidence for this write. "
+                "The adapter will not synthesize or bypass that challenge; provide a legitimate token "
+                "captured from the active browser session or use a read-only probe.",
+                endpoint="chat-requirements",
+                request_stage="turnstile_gate",
+            )
+        return requirements, proof_header
+
+    return get_ready_requirements

--- a/src/chatgpt_web_adapter/web_session.py
+++ b/src/chatgpt_web_adapter/web_session.py
@@ -54,10 +54,16 @@ def bootstrap_web_session(client: Any) -> bool:
 def gate_get_ready_requirements(
     original_get_ready_requirements: Callable[..., tuple[dict[str, Any], str | None]],
 ) -> Callable[..., tuple[dict[str, Any], str | None]]:
-    """Require legitimate browser challenge evidence before a write proceeds."""
+    """Require legitimate browser challenge evidence before a write proceeds.
+
+    The write gate is deliberately network-neutral apart from the underlying
+    chat-requirements request. It may synchronize an already supplied ``oai-did``
+    into ``oai-device-id``, but acquiring browser/session cookies remains an
+    explicit ``bootstrap_web_session()`` operation.
+    """
 
     def get_ready_requirements(self: Any) -> tuple[dict[str, Any], str | None]:
-        bootstrap_web_session(self)
+        _sync_device_header(self)
         requirements, proof_header = original_get_ready_requirements(self)
         turnstile = requirements.get("turnstile") if isinstance(requirements, dict) else None
         turnstile_required = bool(turnstile.get("required")) if isinstance(turnstile, dict) else False

--- a/src/chatgpt_web_adapter/web_session.py
+++ b/src/chatgpt_web_adapter/web_session.py
@@ -5,6 +5,11 @@ from typing import Any, Callable
 from .auth import CHAT_URL
 from .exceptions import RequestError
 
+SENSITIVE_WEB_SESSION_HEADERS = {
+    "oai-device-id",
+    "x-conduit-token",
+}
+
 
 def _sync_device_header(client: Any) -> bool:
     device_id = getattr(client.auth, "cookies", {}).get("oai-did")
@@ -57,11 +62,6 @@ def gate_get_ready_requirements(
         turnstile = requirements.get("turnstile") if isinstance(requirements, dict) else None
         turnstile_required = bool(turnstile.get("required")) if isinstance(turnstile, dict) else False
         if turnstile_required and not getattr(self.auth, "turnstile_token", None):
-            self._emit_event(
-                None,
-                "web_session_gate_blocked",
-                reason="turnstile_required",
-            )
             raise RequestError(
                 "TURNSTILE_REQUIRED: ChatGPT requires browser-derived Turnstile evidence for this write. "
                 "The adapter will not synthesize or bypass that challenge; provide a legitimate token "
@@ -72,3 +72,19 @@ def gate_get_ready_requirements(
         return requirements, proof_header
 
     return get_ready_requirements
+
+
+def redact_web_session_headers(
+    original_sanitize_header_value: Callable[..., str],
+) -> Callable[..., str]:
+    """Extend sanitized debug traces to cover current web-session credentials."""
+
+    def sanitize_header_value(self: Any, key: str, value: str) -> str:
+        if (
+            bool(getattr(self, "debug_trace_sanitize", True))
+            and key.strip().lower() in SENSITIVE_WEB_SESSION_HEADERS
+        ):
+            return "<redacted>"
+        return original_sanitize_header_value(self, key, value)
+
+    return sanitize_header_value

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import json
+
 import chatgpt_web_adapter as adapter
 import pytest
+
+from chatgpt_web_adapter.auth import build_base_headers
 
 
 def test_load_auth_data_uses_env_token_when_auth_file_is_missing(
@@ -71,3 +75,57 @@ def test_auth_data_accepts_legacy_constructor_names() -> None:
     assert auth.accessTokenSource == "legacy-source"
     assert auth.api_key == "legacy-token"
     assert auth.api_key_source == "legacy-source"
+
+
+def test_load_auth_data_maps_raw_chatgpt_session_token_to_cookie(tmp_path) -> None:
+    auth_file = tmp_path / "auth_data.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "accessToken": "not.a.jwt",
+                "sessionToken": "browser-session-token",
+                "user": {"id": "redacted"},
+                "account": {"id": "redacted"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    auth = adapter.load_auth_data(auth_file)
+
+    assert auth.accessToken == "not.a.jwt"
+    assert auth.cookies["__Secure-next-auth.session-token"] == "browser-session-token"
+
+
+def test_explicit_chunked_browser_session_cookies_win_over_session_token(tmp_path) -> None:
+    auth_file = tmp_path / "auth_data.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "accessToken": "not.a.jwt",
+                "sessionToken": "must-not-replace-explicit-cookie",
+                "cookies": {
+                    "__Secure-next-auth.session-token.0": "chunk-zero",
+                    "__Secure-next-auth.session-token.1": "chunk-one",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    auth = adapter.load_auth_data(auth_file)
+
+    assert "__Secure-next-auth.session-token" not in auth.cookies
+    assert auth.cookies["__Secure-next-auth.session-token.0"] == "chunk-zero"
+    assert auth.cookies["__Secure-next-auth.session-token.1"] == "chunk-one"
+
+
+def test_oai_did_cookie_seeds_device_header() -> None:
+    auth = adapter.AuthData(
+        accessToken="token",
+        cookies={"oai-did": "device-id"},
+    )
+
+    headers = build_base_headers(auth)
+
+    assert headers["oai-device-id"] == "device-id"

--- a/tests/test_probe_live_contract_example.py
+++ b/tests/test_probe_live_contract_example.py
@@ -16,6 +16,7 @@ def _load_module():
     if "chatgpt_web_adapter" not in sys.modules:
         stub = types.ModuleType("chatgpt_web_adapter")
         stub.ChatGPTWebClient = object
+        stub.RequestError = RuntimeError
         sys.modules["chatgpt_web_adapter"] = stub
     spec = importlib.util.spec_from_file_location("probe_live_contract_example", MODULE_PATH)
     assert spec is not None
@@ -147,3 +148,15 @@ def test_detector_drift_gets_explicit_verdict() -> None:
     )
 
     assert report["verdict"] == "PRESERVE_MODEL_MISMATCH"
+
+
+def test_attach_only_report_keeps_detected_contract_without_request() -> None:
+    module = _load_module()
+
+    report = module.build_report(attached=_attached(), response=None, events=[])
+
+    assert report["attach"]["detected_model"] == "gpt-5-6-sol-web"
+    assert report["attach"]["detected_reasoning_effort"] == "extended"
+    assert report["probe"]["write_attempted"] is False
+    assert report["request"]["sent_model"] is None
+    assert report["verdict"] == "CONTRACT_OBSERVED"

--- a/tests/test_web_session_gate.py
+++ b/tests/test_web_session_gate.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 
 from chatgpt_web_adapter import AuthData, RequestError
-from chatgpt_web_adapter.web_session import bootstrap_web_session, gate_get_ready_requirements
+from chatgpt_web_adapter.web_session import (
+    bootstrap_web_session,
+    gate_get_ready_requirements,
+    redact_web_session_headers,
+)
 
 
 class _FakeClient:
@@ -18,6 +20,7 @@ class _FakeClient:
         self.base_headers = {"content-type": "application/json"}
         self.bootstrap_calls = 0
         self._web_session_bootstrapped = False
+        self.debug_trace_sanitize = True
 
     def _build_headers(self, extra=None):
         headers = dict(self.base_headers)
@@ -36,10 +39,6 @@ class _FakeClient:
         self.bootstrap_calls += 1
         self.auth.cookies["oai-did"] = "server-issued-device"
         return 200, b"", ""
-
-    @staticmethod
-    def _emit_event(*args, **kwargs):
-        return None
 
 
 def test_bootstrap_reuses_existing_oai_did_without_network() -> None:
@@ -106,3 +105,16 @@ def test_turnstile_gate_allows_non_turnstile_requirements() -> None:
 
     assert requirements["turnstile"]["required"] is False
     assert proof == "proof"
+
+
+def test_sensitive_web_session_headers_are_redacted_in_sanitized_traces() -> None:
+    client = _FakeClient()
+
+    def original(_self, key, value):
+        return value
+
+    sanitize = redact_web_session_headers(original)
+
+    assert sanitize(client, "oai-device-id", "device-secret") == "<redacted>"
+    assert sanitize(client, "x-conduit-token", "conduit-secret") == "<redacted>"
+    assert sanitize(client, "accept", "application/json") == "application/json"

--- a/tests/test_web_session_gate.py
+++ b/tests/test_web_session_gate.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from chatgpt_web_adapter import AuthData, RequestError
+from chatgpt_web_adapter.web_session import bootstrap_web_session, gate_get_ready_requirements
+
+
+class _FakeClient:
+    def __init__(self, *, cookies=None, turnstile_token=None) -> None:
+        self.auth = AuthData(
+            accessToken="token",
+            cookies=cookies or {},
+            turnstile_token=turnstile_token,
+        )
+        self.base_headers = {"content-type": "application/json"}
+        self.bootstrap_calls = 0
+        self._web_session_bootstrapped = False
+
+    def _build_headers(self, extra=None):
+        headers = dict(self.base_headers)
+        if self.auth.cookies:
+            headers["cookie"] = "; ".join(
+                f"{key}={value}" for key, value in self.auth.cookies.items()
+            )
+        if extra:
+            headers.update({key: value for key, value in extra.items() if value is not None})
+        return headers
+
+    def _run_curl(self, method, url, headers, *, follow_redirects=False):
+        assert method == "GET"
+        assert url == "https://chatgpt.com/"
+        assert follow_redirects is True
+        self.bootstrap_calls += 1
+        self.auth.cookies["oai-did"] = "server-issued-device"
+        return 200, b"", ""
+
+    @staticmethod
+    def _emit_event(*args, **kwargs):
+        return None
+
+
+def test_bootstrap_reuses_existing_oai_did_without_network() -> None:
+    client = _FakeClient(cookies={"oai-did": "existing-device"})
+
+    assert bootstrap_web_session(client) is True
+    assert client.bootstrap_calls == 0
+    assert client.base_headers["oai-device-id"] == "existing-device"
+
+
+def test_bootstrap_fetches_server_device_cookie_once() -> None:
+    client = _FakeClient()
+
+    assert bootstrap_web_session(client) is True
+    assert bootstrap_web_session(client) is True
+    assert client.bootstrap_calls == 1
+    assert client.base_headers["oai-device-id"] == "server-issued-device"
+
+
+def test_turnstile_gate_blocks_before_write_without_browser_token() -> None:
+    client = _FakeClient(cookies={"oai-did": "device"})
+    original_calls = []
+
+    def original(_self):
+        original_calls.append(True)
+        return {"token": "requirements", "turnstile": {"required": True}}, "proof"
+
+    gated = gate_get_ready_requirements(original)
+
+    with pytest.raises(RequestError) as exc_info:
+        gated(client)
+
+    assert original_calls == [True]
+    assert exc_info.value.request_stage == "turnstile_gate"
+    assert "TURNSTILE_REQUIRED" in str(exc_info.value)
+
+
+def test_turnstile_gate_accepts_legitimate_supplied_browser_token() -> None:
+    client = _FakeClient(
+        cookies={"oai-did": "device"},
+        turnstile_token="browser-derived-token",
+    )
+
+    def original(_self):
+        return {"token": "requirements", "turnstile": {"required": True}}, "proof"
+
+    gated = gate_get_ready_requirements(original)
+
+    requirements, proof = gated(client)
+
+    assert requirements["turnstile"]["required"] is True
+    assert proof == "proof"
+
+
+def test_turnstile_gate_allows_non_turnstile_requirements() -> None:
+    client = _FakeClient(cookies={"oai-did": "device"})
+
+    def original(_self):
+        return {"token": "requirements", "turnstile": {"required": False}}, "proof"
+
+    gated = gate_get_ready_requirements(original)
+
+    requirements, proof = gated(client)
+
+    assert requirements["turnstile"]["required"] is False
+    assert proof == "proof"


### PR DESCRIPTION
## Summary

Repairs the current ChatGPT web-session boundary discovered while validating GPT-5.6 live contracts.

- accepts raw `/api/auth/session` material more usefully by mapping `sessionToken` into recognized web-session cookies when explicit cookies are absent
- preserves explicit/chunked browser cookies
- bootstraps server-issued `oai-did` and mirrors it into `oai-device-id`
- detects mandatory Turnstile requirements before the conversation write and returns an explicit `TURNSTILE_REQUIRED` failure instead of a late `403 Unusual activity`
- does **not** synthesize, solve, or bypass Turnstile; only legitimate browser-derived challenge evidence is accepted
- adds read-only/attach-only contract probing and `WRITE_BLOCKED_TURNSTILE` fallback so model-contract evidence can still be captured without a write
- redacts `oai-device-id` and `x-conduit-token` from sanitized debug traces
- documents the current session setup and adds regression coverage for auth/session mapping, the write gate, and read-only probe behavior

## Live evidence motivating this repair

A current `/backend-api/sentinel/chat-requirements` response returned:

- proof-of-work required: `true`
- Turnstile required: `true`
- Arkose required: `false`

Using attach-only probing against UI-selected GPT-5.6 Sol conversations successfully observed:

- Medium → `gpt-5-6-thinking` / `standard`
- High → `gpt-5-6-thinking` / `extended`

This PR intentionally does not change model defaults or aliases; that belongs in PR7.10 after this compatibility repair is validated.

## Scope boundary

`conversation/prepare` is already implemented for approval flows, but this PR does not yet force it into ordinary text sends. We first want CI plus current live evidence to separate the session/Turnstile failure from any independent conduit/prepare protocol drift.

## Validation

Targeted auth/session, gate, and live-probe regression tests were added. Full CI should be treated as the authoritative validation for this branch.