### PR TITLE
PR7.10: Add GPT-5.6 model capability registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+- models: the default reasoning path now uses the live-observed GPT-5.6 web slug `gpt-5-6-thinking`; Medium maps to `standard` and High maps to `extended`
+- models: added an evidence-backed capability registry and `gpt-5.6` / `thinking` convenience aliases while keeping unknown explicit model slugs pass-through and leaving unobserved Extra High unmapped
 - auth: raw ChatGPT `/api/auth/session` dumps now best-effort map `sessionToken` to the web session cookie while preserving explicit/chunked browser cookies
 - compatibility: web writes now synchronize `oai-did` to `oai-device-id` and fail early with `TURNSTILE_REQUIRED` when ChatGPT requires browser challenge evidence that was not supplied
 - diagnostics: live contract probes now preserve read-only model/reasoning evidence when a write is blocked by Turnstile and support explicit `--attach-only` capture

--- a/docs/live_model_contract_probe.md
+++ b/docs/live_model_contract_probe.md
@@ -131,11 +131,26 @@ Preserve the report and first determine whether the mismatch is caused by model
 routing, automatic switching, stale detector locations, or an actual backend
 contract change.
 
+## Frozen live evidence — 2026-08-07
+
+Attach-only probes against UI-selected GPT-5.6 Sol conversations produced the
+following private web contract:
+
+| UI selection | Private model slug | Private reasoning |
+| --- | --- | --- |
+| Medium | `gpt-5-6-thinking` | `standard` |
+| High | `gpt-5-6-thinking` | `extended` |
+
+PR7.10 promotes `gpt-5-6-thinking` to the convenience thinking default and stores
+these two observed reasoning mappings in the model capability registry.
+
+Extra High and Pro remain unobserved in this evidence set. The registry therefore
+does not invent mappings for them. Unknown explicit model slugs also remain
+pass-through, and model detection remains independent of registry membership so a
+future rollout can be observed before policy is updated.
+
 ## PR7.9 exit criteria
 
-PR7.9 can close when we have sanitized live evidence showing the current web
-contract for at least Medium and High, plus regression fixtures for any new
-metadata locations discovered by the probe.
-
-Only after that evidence should PR7.10 update the model capability registry and
-public convenience modes.
+PR7.9's minimum evidence requirement was satisfied by the Medium and High captures
+above. Additional modes should continue to be probed before they are added to the
+registry or exposed as convenience reasoning aliases.

--- a/examples/watch_conversation.py
+++ b/examples/watch_conversation.py
@@ -403,7 +403,7 @@ def main() -> None:
     parser.add_argument("prompt", nargs="?", help="Prompt to send.")
     parser.add_argument("--conversation", help="Existing conversation URL or raw id.")
     parser.add_argument("--auth-file", default="auth_data.json")
-    parser.add_argument("--model", default="gpt-5-5-thinking")
+    parser.add_argument("--model", default="thinking")
     parser.add_argument("--reasoning-effort", default="high")
     parser.add_argument("--timeout", type=int, default=180)
     parser.add_argument(

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from . import client as _client_module
 from . import errors
 from .approval_policy import ApprovalDecision, ApprovalPolicy
 from .approval_types import ApprovalEvent, ApprovalResult, ApprovalRound
 from .attach import attach_conversation as _attach_conversation
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
-from .client import DEFAULT_MODEL, ChatGPTWebClient
+from .client import ChatGPTWebClient
 from .conversation_send import send_to_conversation as _send_to_conversation
 from .diagnostic_metrics import send_with_expanded_metrics as _send_with_expanded_metrics
 from .exceptions import (
@@ -18,6 +19,13 @@ from .exceptions import (
 )
 from .export import export_conversation as _export_conversation
 from .messages import get_messages as _get_messages
+from .model_registry import (
+    DEFAULT_MODEL,
+    DEFAULT_THINKING_MODEL,
+    MODEL_ALIASES,
+    normalize_reasoning_effort as _normalize_reasoning_effort,
+    resolve_model as _resolve_model,
+)
 from .payload_builder import PayloadBuilder
 from .payload_validation import validate_payload
 from .policy_approval import ApprovalDeniedError
@@ -49,6 +57,15 @@ from .web_session import (
     gate_get_ready_requirements as _gate_get_ready_requirements,
     redact_web_session_headers as _redact_web_session_headers,
 )
+
+# The registry is the canonical model-policy source. Keep the legacy monolithic
+# client module synchronized at package import time until its policy constants can
+# be physically removed without mixing that refactor into the live-contract PR.
+_client_module.DEFAULT_MODEL = DEFAULT_MODEL
+_client_module.DEFAULT_THINKING_MODEL = DEFAULT_THINKING_MODEL
+_client_module.MODEL_ALIASES = MODEL_ALIASES
+ChatGPTWebClient._normalize_reasoning_effort = staticmethod(_normalize_reasoning_effort)
+ChatGPTWebClient._resolve_model = staticmethod(_resolve_model)
 
 _original_send = ChatGPTWebClient.send
 _original_approve_pending_action = ChatGPTWebClient.approve_pending_action

--- a/src/chatgpt_web_adapter/model_registry.py
+++ b/src/chatgpt_web_adapter/model_registry.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+DEFAULT_MODEL = "gpt-5-3-mini"
+DEFAULT_THINKING_MODEL = "gpt-5-6-thinking"
+
+
+@dataclass(frozen=True)
+class ModelCapability:
+    """Evidence-backed convenience policy for one known ChatGPT web model slug.
+
+    The registry is advisory policy, not a detector whitelist. Unknown explicit
+    model slugs must remain pass-through so newly rolled out web models can still
+    be observed before the registry is updated.
+    """
+
+    slug: str
+    family: str
+    ui_name: str
+    reasoning_modes: Mapping[str, str]
+    evidence: str
+
+
+_GPT56_REASONING_MODES = MappingProxyType(
+    {
+        "medium": "standard",
+        "high": "extended",
+    }
+)
+
+MODEL_CAPABILITIES: Mapping[str, ModelCapability] = MappingProxyType(
+    {
+        DEFAULT_THINKING_MODEL: ModelCapability(
+            slug=DEFAULT_THINKING_MODEL,
+            family="gpt-5.6",
+            ui_name="GPT-5.6 Sol",
+            reasoning_modes=_GPT56_REASONING_MODES,
+            evidence="live-attach-2026-08-07",
+        ),
+    }
+)
+
+MODEL_ALIASES: Mapping[str, str] = MappingProxyType(
+    {
+        "instant": DEFAULT_MODEL,
+        "thinking": DEFAULT_THINKING_MODEL,
+        "gpt-5.6": DEFAULT_THINKING_MODEL,
+        "gpt-5.1": "gpt-5-1",
+        "gpt-4.1": "gpt-4.1",
+        "gpt-4.1-mini": "gpt-4.1-mini",
+        "gpt-4.5": "gpt-4.5",
+    }
+)
+
+REASONING_ALIASES: Mapping[str, str | None] = MappingProxyType(
+    {
+        "": None,
+        "off": None,
+        "none": None,
+        "-": None,
+        "instant": None,
+        "medium": "standard",
+        "high": "extended",
+        "standard": "standard",
+        "extended": "extended",
+    }
+)
+
+
+def normalize_reasoning_effort(reasoning_effort: str | None) -> str | None:
+    normalized = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
+    if normalized is None:
+        return None
+    if normalized not in REASONING_ALIASES:
+        raise ValueError(
+            "reasoning_effort must be one of: instant, medium, high, standard, extended, off/none/-"
+        )
+    return REASONING_ALIASES[normalized]
+
+
+def resolve_model(model: str | None, reasoning_effort: str | None) -> str:
+    """Resolve public convenience input without rejecting unknown explicit slugs."""
+
+    if isinstance(model, str):
+        model_name = model.strip()
+        if not model_name:
+            raise ValueError("model must not be empty")
+        return MODEL_ALIASES.get(model_name.lower(), model_name)
+
+    normalized_effort = normalize_reasoning_effort(reasoning_effort)
+    if normalized_effort is not None:
+        return DEFAULT_THINKING_MODEL
+    return DEFAULT_MODEL
+
+
+def get_model_capability(model: str) -> ModelCapability | None:
+    if not isinstance(model, str):
+        return None
+    model_name = model.strip()
+    if not model_name:
+        return None
+    resolved = MODEL_ALIASES.get(model_name.lower(), model_name)
+    return MODEL_CAPABILITIES.get(resolved)

--- a/src/chatgpt_web_adapter/payload_builder.py
+++ b/src/chatgpt_web_adapter/payload_builder.py
@@ -5,7 +5,10 @@ import time
 import uuid
 from typing import Any
 
-from .client import DEFAULT_MODEL, DEFAULT_THINKING_MODEL, MODEL_ALIASES
+from .model_registry import (
+    normalize_reasoning_effort as _normalize_reasoning_effort_policy,
+    resolve_model as _resolve_model_policy,
+)
 from .types import ChatConversation
 
 
@@ -26,28 +29,11 @@ def _required_str(value: Any, field_name: str) -> str:
 
 
 def _normalize_model(model: str | None, reasoning_effort: str | None) -> str:
-    if isinstance(model, str):
-        model_name = _required_str(model, "model")
-        return MODEL_ALIASES.get(model_name.lower(), MODEL_ALIASES.get(model_name, model_name))
-    normalized_effort = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
-    if normalized_effort in {"medium", "high", "standard", "extended"}:
-        return DEFAULT_THINKING_MODEL
-    return DEFAULT_MODEL
+    return _resolve_model_policy(model, reasoning_effort)
 
 
 def _normalize_reasoning_effort(reasoning_effort: str | None) -> str | None:
-    normalized = reasoning_effort.strip().lower() if isinstance(reasoning_effort, str) else None
-    if normalized == "medium":
-        normalized = "standard"
-    elif normalized == "high":
-        normalized = "extended"
-    elif normalized in {"", "off", "none", "-", "instant"}:
-        normalized = None
-    if normalized not in {None, "standard", "extended"}:
-        raise ValueError(
-            "reasoning_effort must be one of: instant, medium, high, standard, extended, off/none/-"
-        )
-    return normalized
+    return _normalize_reasoning_effort_policy(reasoning_effort)
 
 
 def _message_metadata(metadata: dict[str, Any] | None, *, system_hints: list[str] | None = None) -> dict[str, Any]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -658,8 +658,8 @@ def test_send_instant_mode_uses_minimal_payload_without_thinking_effort(
 @pytest.mark.parametrize(
     ("reasoning_effort", "expected_model", "expected_effort"),
     [
-        ("medium", "gpt-5-5-thinking", "standard"),
-        ("high", "gpt-5-5-thinking", "extended"),
+        ("medium", "gpt-5-6-thinking", "standard"),
+        ("high", "gpt-5-6-thinking", "extended"),
     ],
 )
 def test_send_ui_reasoning_modes_map_to_current_backend_values(
@@ -811,7 +811,7 @@ def test_send_recovers_conversation_id_from_top_level_sse_fields(
     assert response.conversation.conversation_id == "conv-top-level"
     assert response.conversation.message_id == "assistant-top-level"
     assert response.request.conversation_id == "conv-top-level"
-    assert response.request.sent_model == "gpt-5-5-thinking"
+    assert response.request.sent_model == "gpt-5-6-thinking"
     assert response.request.sent_reasoning_effort == "extended"
 
 
@@ -860,7 +860,7 @@ def test_send_recovers_message_id_text_and_metadata_after_stream_handoff(
     assert response.conversation.message_id == "assistant-final"
     assert response.conversation.parent_message_id == "assistant-final"
     assert response.request.conversation_id == "conv-123"
-    assert response.request.sent_model == "gpt-5-5-thinking"
+    assert response.request.sent_model == "gpt-5-6-thinking"
     assert response.request.sent_reasoning_effort == "extended"
     assert response.request.observed_model == "gpt-5-5-thinking"
     assert response.request.observed_reasoning_effort == "extended"

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+
+from chatgpt_web_adapter.model_detection import detect_model_from_conversation_payload
+from chatgpt_web_adapter.model_registry import (
+    DEFAULT_MODEL,
+    DEFAULT_THINKING_MODEL,
+    MODEL_CAPABILITIES,
+    get_model_capability,
+    normalize_reasoning_effort,
+    resolve_model,
+)
+
+
+def test_default_models_match_current_policy() -> None:
+    assert DEFAULT_MODEL == "gpt-5-3-mini"
+    assert DEFAULT_THINKING_MODEL == "gpt-5-6-thinking"
+
+
+def test_gpt56_capability_records_live_ui_contract() -> None:
+    capability = MODEL_CAPABILITIES["gpt-5-6-thinking"]
+
+    assert capability.family == "gpt-5.6"
+    assert capability.ui_name == "GPT-5.6 Sol"
+    assert capability.reasoning_modes == {
+        "medium": "standard",
+        "high": "extended",
+    }
+    assert capability.evidence == "live-attach-2026-08-07"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("off", None),
+        ("none", None),
+        ("-", None),
+        ("instant", None),
+        ("medium", "standard"),
+        ("standard", "standard"),
+        ("high", "extended"),
+        ("extended", "extended"),
+        (" HIGH ", "extended"),
+    ],
+)
+def test_reasoning_aliases_are_normalized(value: str | None, expected: str | None) -> None:
+    assert normalize_reasoning_effort(value) == expected
+
+
+def test_unobserved_extra_high_is_not_guessed() -> None:
+    with pytest.raises(ValueError, match="reasoning_effort must be one of"):
+        normalize_reasoning_effort("extra-high")
+
+
+@pytest.mark.parametrize("mode", ["medium", "high", "standard", "extended"])
+def test_reasoning_modes_use_live_gpt56_thinking_default(mode: str) -> None:
+    assert resolve_model(None, mode) == "gpt-5-6-thinking"
+
+
+def test_no_reasoning_uses_instant_default() -> None:
+    assert resolve_model(None, None) == "gpt-5-3-mini"
+    assert resolve_model(None, "instant") == "gpt-5-3-mini"
+
+
+@pytest.mark.parametrize("alias", ["thinking", "gpt-5.6", "GPT-5.6"])
+def test_gpt56_convenience_aliases_resolve_to_observed_slug(alias: str) -> None:
+    assert resolve_model(alias, None) == "gpt-5-6-thinking"
+
+
+def test_legacy_explicit_thinking_slug_remains_pass_through() -> None:
+    assert resolve_model("gpt-5-5-thinking", "high") == "gpt-5-5-thinking"
+
+
+def test_unknown_future_explicit_slug_remains_pass_through() -> None:
+    assert resolve_model("gpt-9-unknown-web", "high") == "gpt-9-unknown-web"
+
+
+def test_empty_explicit_model_is_rejected() -> None:
+    with pytest.raises(ValueError, match="model must not be empty"):
+        resolve_model("   ", None)
+
+
+def test_capability_lookup_accepts_aliases_without_whitelisting_unknown_models() -> None:
+    assert get_model_capability("thinking") is MODEL_CAPABILITIES["gpt-5-6-thinking"]
+    assert get_model_capability("gpt-9-unknown-web") is None
+
+
+def test_model_detector_is_independent_of_registry_membership() -> None:
+    payload = {
+        "current_node": "assistant-current",
+        "mapping": {
+            "assistant-current": {
+                "message": {
+                    "id": "assistant-current",
+                    "author": {"role": "assistant"},
+                    "metadata": {"model_slug": "gpt-9-unknown-web"},
+                }
+            }
+        },
+    }
+
+    assert detect_model_from_conversation_payload(payload) == "gpt-9-unknown-web"

--- a/tests/test_payload_builder.py
+++ b/tests/test_payload_builder.py
@@ -196,8 +196,8 @@ def test_new_chat_instant_mode_omits_thinking_effort_and_uses_instant_model() ->
 @pytest.mark.parametrize(
     ("reasoning_effort", "expected_model", "expected_effort"),
     [
-        ("medium", "gpt-5-5-thinking", "standard"),
-        ("high", "gpt-5-5-thinking", "extended"),
+        ("medium", "gpt-5-6-thinking", "standard"),
+        ("high", "gpt-5-6-thinking", "extended"),
     ],
 )
 def test_new_chat_ui_reasoning_modes_map_to_current_backend_values(


### PR DESCRIPTION
## Summary

- add an evidence-backed model capability registry as the canonical model/reasoning policy layer
- promote the current thinking default to the live-observed private web slug `gpt-5-6-thinking`
- freeze the observed GPT-5.6 Sol mappings: Medium -> `standard`, High -> `extended`
- add `thinking` and `gpt-5.6` convenience aliases while preserving explicit legacy and unknown model slugs as pass-through
- keep model detection independent from the registry so unknown future private slugs remain detectable/preservable
- centralize model/reasoning resolution for both the client and `PayloadBuilder`
- leave Extra High/Pro unmapped until live evidence exists
- update watcher defaults, documentation, changelog, and regression coverage

## Live evidence

Attach-only probes observed on 2026-08-07:

| ChatGPT UI | Private web model | Private reasoning |
| --- | --- | --- |
| GPT-5.6 Sol Medium | `gpt-5-6-thinking` | `standard` |
| GPT-5.6 Sol High | `gpt-5-6-thinking` | `extended` |

The probes were read-only and therefore establish the attach-side model contract, not the ordinary write/stream transport contract.

## Governance invariants

- registry policy is not a detector whitelist
- explicit private slugs remain pass-through
- unknown future slugs remain pass-through/detectable
- unobserved reasoning tiers are not guessed
- `preserve_model` behavior remains independent from current defaults

## Validation

- targeted model-registry policy regression suite: 27/27 passed during implementation
- PayloadBuilder Medium/High and legacy pass-through smoke checks passed during implementation
- repository-wide validation delegated to PR CI
