### PR TITLE
PR7.11: Add ordinary text prepare contract probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+- diagnostics: added an ordinary-text `conversation/prepare` contract probe that records structural evidence without serializing prompt text, ids, raw responses, or conduit-token values
+- compatibility: added a reusable text prepare/conduit boundary using the observed `partial_query` shape and initial `x-conduit-token: no-token`, while deliberately leaving normal `send()` unwired pending live validation
 - models: the default reasoning path now uses the live-observed GPT-5.6 web slug `gpt-5-6-thinking`; Medium maps to `standard` and High maps to `extended`
 - models: added an evidence-backed capability registry and `gpt-5.6` / `thinking` convenience aliases while keeping unknown explicit model slugs pass-through and leaving unobserved Extra High unmapped
 - auth: raw ChatGPT `/api/auth/session` dumps now best-effort map `sessionToken` to the web session cookie while preserving explicit/chunked browser cookies

--- a/docs/text_prepare_contract_probe.md
+++ b/docs/text_prepare_contract_probe.md
@@ -1,0 +1,67 @@
+# Ordinary Text Prepare / Conduit Contract Probe
+
+PR7.11 isolates the current ChatGPT Web `conversation/prepare` boundary before
+changing the SDK's ordinary `send()` path.
+
+Current browser observations show an ordinary text prepare request shaped around:
+
+- `POST /backend-api/f/conversation/prepare`
+- `x-conduit-token: no-token` on the initial prepare call
+- a user-message-shaped `partial_query`
+- `client_prepare_state: success`
+- a short-lived `conduit_token` in the response
+
+This PR deliberately does **not** feed that token into normal `send()` yet. The
+probe exists to verify the contract against a current authenticated session first.
+
+## Run
+
+```powershell
+python .\examples\probe_prepare_contract.py `
+  "https://chatgpt.com/c/<conversation-id>" `
+  --output .\gpt56-prepare.json
+```
+
+The command attaches the existing conversation to recover the current model and
+reasoning mode, then issues only the prepare request. It does not submit the turn
+to `/backend-api/f/conversation`.
+
+Expected evidence:
+
+```json
+{
+  "prepare": {
+    "status_code": 200,
+    "status_ok": true,
+    "conduit_token_present": true,
+    "partial_query_present": true,
+    "partial_query_text_recorded": false,
+    "client_prepare_state": "success",
+    "x_conduit_initial_mode": "no-token"
+  },
+  "verdict": "PREPARE_CONTRACT_OBSERVED"
+}
+```
+
+## Privacy boundary
+
+The report never records:
+
+- prompt text or the `partial_query` body
+- conduit-token values
+- conversation/message ids
+- auth/session tokens or cookies
+- raw response bodies
+
+Only structural booleans, status, safe response key names, and the prepare-state
+label are retained.
+
+## Exit criterion
+
+`PREPARE_CONTRACT_OBSERVED` requires both a successful prepare response and the
+presence of a conduit token. Once that is reproduced on a current live session,
+a follow-up PR can wire prepare into ordinary `send()` and separately validate
+Sentinel/Turnstile ordering and final conversation headers.
+
+The explicit regression invariant for PR7.11 is that ordinary `send()` remains
+unwired to the prepare boundary.

--- a/examples/probe_prepare_contract.py
+++ b/examples/probe_prepare_contract.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from chatgpt_web_adapter import ChatGPTWebClient, DEFAULT_MODEL
+from chatgpt_web_adapter.conversation_prepare import prepare_text_turn
+
+SCHEMA = "chatgpt-web-adapter.prepare-contract-probe.v1"
+DEFAULT_PROMPT = "Reply exactly: prepare-probe-ok"
+
+
+def build_report(result, payload: dict) -> dict:
+    partial_query = payload.get("partial_query")
+    return {
+        "schema": SCHEMA,
+        "probe": {
+            "write_attempted": False,
+            "prepare_attempted": True,
+            "prompt_text_recorded": False,
+            "raw_response_recorded": False,
+            "conduit_token_recorded": False,
+        },
+        "prepare": {
+            "status_code": result.status_code,
+            "status_ok": result.status_ok,
+            "conduit_token_present": result.conduit_token_present,
+            "response_keys": list(result.response_keys),
+            "partial_query_present": isinstance(partial_query, dict),
+            "partial_query_text_recorded": False,
+            "client_prepare_state": payload.get("client_prepare_state"),
+            "x_conduit_initial_mode": "no-token",
+            "conversation_id_present": bool(payload.get("conversation_id")),
+            "thinking_effort_present": bool(payload.get("thinking_effort")),
+        },
+    }
+
+
+def verdict(report: dict) -> str:
+    prepare = report["prepare"]
+    if prepare["status_ok"] and prepare["conduit_token_present"]:
+        return "PREPARE_CONTRACT_OBSERVED"
+    if prepare["status_ok"]:
+        return "PREPARE_OK_NO_CONDUIT"
+    return "PREPARE_REJECTED"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Probe the ordinary ChatGPT text prepare/conduit contract without sending the turn.")
+    parser.add_argument("conversation", help="Existing ChatGPT conversation URL or raw id.")
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument("--output", default="prepare_contract_probe.json")
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    attached = client.attach_conversation(args.conversation)
+    model = attached.detected_model or DEFAULT_MODEL
+    reasoning = attached.detected_reasoning_effort
+    result, payload = prepare_text_turn(
+        client,
+        args.prompt,
+        model=model,
+        conversation=attached.conversation,
+        reasoning_effort=reasoning,
+    )
+    report = build_report(result, payload)
+    report["verdict"] = verdict(report)
+    output = Path(args.output)
+    output.write_text(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    print(f"report: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/probe_prepare_contract.py
+++ b/examples/probe_prepare_contract.py
@@ -4,8 +4,11 @@ import argparse
 import json
 from pathlib import Path
 
-from chatgpt_web_adapter import ChatGPTWebClient, DEFAULT_MODEL
-from chatgpt_web_adapter.conversation_prepare import prepare_text_turn
+from chatgpt_web_adapter import (
+    ChatGPTWebClient,
+    DEFAULT_MODEL,
+    prepare_text_turn,
+)
 
 SCHEMA = "chatgpt-web-adapter.prepare-contract-probe.v1"
 DEFAULT_PROMPT = "Reply exactly: prepare-probe-ok"

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -7,6 +7,7 @@ from .approval_types import ApprovalEvent, ApprovalResult, ApprovalRound
 from .attach import attach_conversation as _attach_conversation
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
 from .client import ChatGPTWebClient
+from .conversation_prepare import PrepareResult, prepare_text_turn
 from .conversation_send import send_to_conversation as _send_to_conversation
 from .diagnostic_metrics import send_with_expanded_metrics as _send_with_expanded_metrics
 from .exceptions import (
@@ -151,6 +152,11 @@ EXPERIMENTAL_RAW_PAYLOAD_EXPORTS = [
     "validate_payload",
 ]
 
+EXPERIMENTAL_PREPARE_EXPORTS = [
+    "PrepareResult",
+    "prepare_text_turn",
+]
+
 SUPPORT_EXPORTS = [
     "DEFAULT_AUTH_FILE",
     "DEFAULT_MODEL",
@@ -165,5 +171,6 @@ __all__ = [
     *EXPERIMENTAL_APPROVAL_EXPORTS,
     *EXPERIMENTAL_REQUIRED_ACTION_EXPORTS,
     *EXPERIMENTAL_RAW_PAYLOAD_EXPORTS,
+    *EXPERIMENTAL_PREPARE_EXPORTS,
     *SUPPORT_EXPORTS,
 ]

--- a/src/chatgpt_web_adapter/conversation_prepare.py
+++ b/src/chatgpt_web_adapter/conversation_prepare.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import copy
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from .auth import CHAT_URL
+from .client import CHAT_CONVERSATION_PREPARE_URL
+from .types import ChatConversation
+
+PREPARE_PATH = "/backend-api/f/conversation/prepare"
+
+
+@dataclass(frozen=True)
+class PrepareResult:
+    """Result of an evidence-only conversation prepare request.
+
+    ``conduit_token`` is intentionally excluded from repr and should never be
+    serialized into diagnostic artifacts. It exists only so a later transport
+    integration can reuse this boundary without reworking the response parser.
+    """
+
+    status_code: int
+    status_ok: bool
+    conduit_token_present: bool
+    response_keys: tuple[str, ...] = ()
+    conduit_token: str | None = field(default=None, repr=False, compare=False)
+
+
+def _conversation_dict(value: ChatConversation | dict[str, Any] | None) -> dict[str, Any]:
+    if isinstance(value, ChatConversation):
+        return value.to_dict()
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
+def _partial_query(prompt: str, *, message_id: str | None = None) -> dict[str, Any]:
+    return {
+        "id": message_id or str(uuid.uuid4()),
+        "author": {"role": "user"},
+        "content": {"content_type": "text", "parts": [str(prompt)]},
+    }
+
+
+def build_text_prepare_payload(
+    prompt: str,
+    *,
+    model: str,
+    conversation: ChatConversation | dict[str, Any] | None = None,
+    reasoning_effort: str | None = None,
+    web_search: bool = False,
+    temporary: bool = False,
+    timezone: str | None = None,
+    timezone_offset_min: int | None = None,
+    partial_query_message_id: str | None = None,
+) -> dict[str, Any]:
+    """Build the observed ordinary-text ``conversation/prepare`` payload shape.
+
+    This is deliberately separate from ``send()``. PR7.11 uses it to probe the
+    prepare/conduit contract without silently changing the normal write path.
+    """
+
+    conversation_dict = _conversation_dict(conversation)
+    parent_message_id = (
+        conversation_dict.get("parent_message_id")
+        or conversation_dict.get("message_id")
+        or "client-created-root"
+    )
+    payload: dict[str, Any] = {
+        "action": "next",
+        "fork_from_shared_post": False,
+        "parent_message_id": parent_message_id,
+        "model": str(model),
+        "client_prepare_state": "success",
+        "conversation_mode": {"kind": "primary_assistant"},
+        "system_hints": ["search"] if web_search else [],
+        "partial_query": _partial_query(prompt, message_id=partial_query_message_id),
+        "supports_buffering": True,
+        "supported_encodings": ["v1"],
+        "client_contextual_info": {"app_name": "chatgpt.com"},
+    }
+    conversation_id = conversation_dict.get("conversation_id")
+    if isinstance(conversation_id, str) and conversation_id:
+        payload["conversation_id"] = conversation_id
+    if temporary:
+        payload["history_and_training_disabled"] = True
+    if reasoning_effort is not None:
+        payload["thinking_effort"] = reasoning_effort
+    if timezone is not None:
+        payload["timezone"] = timezone
+    if timezone_offset_min is not None:
+        payload["timezone_offset_min"] = int(timezone_offset_min)
+    return payload
+
+
+def build_prepare_headers(client: Any, *, conversation_id: str | None = None) -> dict[str, str]:
+    referer = CHAT_URL
+    if conversation_id:
+        referer = f"{CHAT_URL.rstrip('/')}/c/{conversation_id}"
+    return client._build_headers(
+        {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "origin": CHAT_URL.rstrip("/"),
+            "referer": referer,
+            "x-conduit-token": "no-token",
+            "x-openai-target-path": PREPARE_PATH,
+            "x-openai-target-route": PREPARE_PATH,
+        }
+    )
+
+
+def prepare_text_turn(
+    client: Any,
+    prompt: str,
+    *,
+    model: str,
+    conversation: ChatConversation | dict[str, Any] | None = None,
+    reasoning_effort: str | None = None,
+    web_search: bool = False,
+    temporary: bool = False,
+    timezone: str | None = None,
+    timezone_offset_min: int | None = None,
+    partial_query_message_id: str | None = None,
+) -> tuple[PrepareResult, dict[str, Any]]:
+    """Issue only the prepare request and return structural evidence plus payload.
+
+    The returned payload contains the prompt and must not be serialized into a
+    diagnostic report. Callers should retain only structural booleans/counts.
+    """
+
+    payload = build_text_prepare_payload(
+        prompt,
+        model=model,
+        conversation=conversation,
+        reasoning_effort=reasoning_effort,
+        web_search=web_search,
+        temporary=temporary,
+        timezone=timezone,
+        timezone_offset_min=timezone_offset_min,
+        partial_query_message_id=partial_query_message_id,
+    )
+    conversation_id = payload.get("conversation_id")
+    headers = build_prepare_headers(
+        client,
+        conversation_id=conversation_id if isinstance(conversation_id, str) else None,
+    )
+    status, data = client._json_request("POST", CHAT_CONVERSATION_PREPARE_URL, payload, headers)
+    response = data if isinstance(data, dict) else {}
+    conduit_token = response.get("conduit_token")
+    if not isinstance(conduit_token, str) or not conduit_token.strip():
+        conduit_token = None
+    result = PrepareResult(
+        status_code=int(status),
+        status_ok=200 <= int(status) < 300 and response.get("status") in {None, "ok"},
+        conduit_token_present=conduit_token is not None,
+        response_keys=tuple(sorted(str(key) for key in response)),
+        conduit_token=conduit_token,
+    )
+    return result, copy.deepcopy(payload)

--- a/tests/test_conversation_prepare.py
+++ b/tests/test_conversation_prepare.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import inspect
+
+import chatgpt_web_adapter as adapter
+from chatgpt_web_adapter.conversation_prepare import (
+    build_prepare_headers,
+    build_text_prepare_payload,
+    prepare_text_turn,
+)
+
+
+def test_build_text_prepare_payload_matches_observed_partial_query_shape() -> None:
+    payload = build_text_prepare_payload(
+        "hello",
+        model="gpt-5-6-thinking",
+        conversation={"conversation_id": "conv-1", "message_id": "parent-1"},
+        reasoning_effort="extended",
+        partial_query_message_id="user-1",
+    )
+
+    assert payload["action"] == "next"
+    assert payload["fork_from_shared_post"] is False
+    assert payload["parent_message_id"] == "parent-1"
+    assert payload["conversation_id"] == "conv-1"
+    assert payload["model"] == "gpt-5-6-thinking"
+    assert payload["client_prepare_state"] == "success"
+    assert payload["partial_query"] == {
+        "id": "user-1",
+        "author": {"role": "user"},
+        "content": {"content_type": "text", "parts": ["hello"]},
+    }
+    assert payload["thinking_effort"] == "extended"
+
+
+def test_build_text_prepare_payload_uses_client_created_root_for_new_turn() -> None:
+    payload = build_text_prepare_payload("hello", model="gpt-5-3-mini")
+    assert payload["parent_message_id"] == "client-created-root"
+    assert "conversation_id" not in payload
+
+
+def test_build_prepare_headers_uses_no_token_and_target_route() -> None:
+    class Client:
+        def _build_headers(self, extra):
+            return {key: value for key, value in extra.items() if value is not None}
+
+    headers = build_prepare_headers(Client(), conversation_id="conv-1")
+    assert headers["x-conduit-token"] == "no-token"
+    assert headers["x-openai-target-path"] == "/backend-api/f/conversation/prepare"
+    assert headers["x-openai-target-route"] == "/backend-api/f/conversation/prepare"
+    assert headers["referer"].endswith("/c/conv-1")
+
+
+def test_prepare_text_turn_retains_token_only_in_memory() -> None:
+    class Client:
+        def _build_headers(self, extra):
+            return {key: value for key, value in extra.items() if value is not None}
+
+        def _json_request(self, method, url, payload, headers):
+            assert method == "POST"
+            assert url.endswith("/backend-api/f/conversation/prepare")
+            assert headers["x-conduit-token"] == "no-token"
+            return 200, {"status": "ok", "conduit_token": "secret-conduit"}
+
+    result, payload = prepare_text_turn(
+        Client(),
+        "secret prompt",
+        model="gpt-5-6-thinking",
+        conversation={"conversation_id": "conv-1", "message_id": "parent-1"},
+        reasoning_effort="standard",
+        partial_query_message_id="user-1",
+    )
+    assert result.status_ok is True
+    assert result.conduit_token_present is True
+    assert result.conduit_token == "secret-conduit"
+    assert "secret-conduit" not in repr(result)
+    assert payload["partial_query"]["content"]["parts"] == ["secret prompt"]
+
+
+def test_normal_send_is_not_wired_to_prepare_boundary() -> None:
+    source = inspect.getsource(adapter.ChatGPTWebClient.send)
+    assert "prepare_text_turn" not in source
+    assert "CHAT_CONVERSATION_PREPARE_URL" not in source

--- a/tests/test_prepare_contract_probe_example.py
+++ b/tests/test_prepare_contract_probe_example.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from chatgpt_web_adapter.conversation_prepare import PrepareResult
+
+
+def _load_probe_module():
+    path = Path(__file__).resolve().parents[1] / "examples" / "probe_prepare_contract.py"
+    spec = importlib.util.spec_from_file_location("probe_prepare_contract", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prepare_probe_report_does_not_serialize_prompt_or_conduit_token() -> None:
+    probe = _load_probe_module()
+    result = PrepareResult(
+        status_code=200,
+        status_ok=True,
+        conduit_token_present=True,
+        response_keys=("conduit_token", "status"),
+        conduit_token="secret-conduit-token",
+    )
+    payload = {
+        "conversation_id": "secret-conversation-id",
+        "client_prepare_state": "success",
+        "thinking_effort": "extended",
+        "partial_query": {
+            "id": "secret-message-id",
+            "author": {"role": "user"},
+            "content": {"content_type": "text", "parts": ["secret prompt text"]},
+        },
+    }
+
+    report = probe.build_report(result, payload)
+    rendered = str(report)
+    assert probe.verdict(report) == "PREPARE_CONTRACT_OBSERVED"
+    assert "secret-conduit-token" not in rendered
+    assert "secret prompt text" not in rendered
+    assert "secret-conversation-id" not in rendered
+    assert "secret-message-id" not in rendered
+    assert report["prepare"]["conduit_token_present"] is True
+    assert report["prepare"]["partial_query_present"] is True
+    assert report["prepare"]["partial_query_text_recorded"] is False
+
+
+def test_prepare_probe_reports_rejection_without_raw_body() -> None:
+    probe = _load_probe_module()
+    result = PrepareResult(
+        status_code=403,
+        status_ok=False,
+        conduit_token_present=False,
+        response_keys=("detail",),
+    )
+    report = probe.build_report(result, {"partial_query": {}, "client_prepare_state": "success"})
+    assert probe.verdict(report) == "PREPARE_REJECTED"
+    assert report["probe"]["raw_response_recorded"] is False


### PR DESCRIPTION
## Summary

- add an ordinary-text `conversation/prepare` probe for the current ChatGPT Web write path
- add a reusable prepare/conduit boundary without wiring it into normal `send()` yet
- model the live-observed user-message-shaped `partial_query`, `client_prepare_state: success`, and initial `x-conduit-token: no-token`
- retain conduit token values only in memory and never serialize them into diagnostic artifacts
- record only structural evidence: status, safe response keys, token presence, partial-query presence, and prepare-state labels
- add regression coverage proving normal `send()` remains unwired to prepare
- document the live-validation protocol and update the changelog

## Live evidence

The probe was run against a current authenticated GPT-5.6 conversation and returned:

- status code: `200`
- response status: `ok`
- `conduit_token` present: `true`
- `partial_query` present: `true`
- `conversation_id` present: `true`
- `thinking_effort` present: `true`
- `client_prepare_state`: `success`
- initial conduit mode: `no-token`
- verdict: `PREPARE_CONTRACT_OBSERVED`

The report did not record prompt text, raw response bodies, conversation/message IDs, auth/session material, or conduit-token values.

## Governance boundary

This PR deliberately does **not** change ordinary `send()` transport. The live prepare/conduit contract is established first; integration into the final `/backend-api/f/conversation` write belongs in PR7.11a together with Sentinel/Turnstile ordering validation.

## Validation

- targeted prepare payload/header/result tests added
- privacy regression verifies prompt, ids, and conduit-token values are absent from reports
- regression asserts normal `send()` does not call the prepare boundary
- repository-wide validation delegated to PR CI
