### PR TITLE
PR7.11b: Probe two-phase Sentinel requirements contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+- diagnostics: added a privacy-safe probe for the current two-phase Sentinel `chat-requirements/prepare` contract; it records only status/key/presence structure and stops before challenge finalization or any conversation write
+- compatibility: live browser evidence now records a current `chat-requirements/prepare -> chat-requirements/finalize` Sentinel sequence; the legacy single-step requirements path remains unchanged in production but is not considered live-validated for the current prepared-write contract
 - compatibility: ordinary text writes to existing conversations now use the live-observed `conversation/prepare` -> conduit-token -> fresh chat-requirements/Turnstile -> `/f/conversation` sequence; warmup-prefetched requirements are discarded before prepare, while new-chat and multimodal writes remain unchanged pending independent evidence
 - compatibility: prepared existing-conversation writes reuse one user message id across `partial_query` and the final message, require `client_prepare_state: success`, and fail closed before the final write on prepare/conduit/Turnstile failures
 - compatibility: any `stream_handoff` observed on the prepared existing-text path forces bounded conversation recovery even when the initial stream already contains a text prefix and assistant id; recovered prefix extensions emit only the missing token suffix

--- a/docs/sentinel_two_phase_contract_probe.md
+++ b/docs/sentinel_two_phase_contract_probe.md
@@ -109,8 +109,11 @@ one structural `sentinel-prepare` trace.
 
 `TWO_PHASE_SENTINEL_PREPARE_OBSERVED`
 
-: HTTP success plus the observed `prepare_token`, `turnstile`, `proofofwork`, and
-  `so` blocks.
+: HTTP success plus a non-empty observed `persona` and `prepare_token`, with
+  every live-observed top-level and nested structural key still present in the
+  `turnstile`, `proofofwork`, and `so` blocks. Additional server keys are allowed.
+  Challenge `required` booleans are recorded but are not frozen into the pass
+  criterion because server policy may vary by session or risk context.
 
 `SENTINEL_PREPARE_PARTIAL_SHAPE`
 

--- a/docs/sentinel_two_phase_contract_probe.md
+++ b/docs/sentinel_two_phase_contract_probe.md
@@ -1,0 +1,135 @@
+# Two-Phase Sentinel Chat-Requirements Contract Probe
+
+PR7.11b freezes live-observed structure for the current ChatGPT web Sentinel
+requirements flow without solving, replaying, or finalizing browser challenges.
+
+## Live-observed sequence
+
+A successful browser turn observed on 2026-08-09 used this ordering:
+
+```text
+POST /backend-api/f/conversation/prepare
+POST /backend-api/sentinel/chat-requirements/prepare
+POST /backend-api/sentinel/chat-requirements/finalize
+POST /backend-api/f/conversation
+```
+
+UI/autocomplete/list/telemetry requests may interleave with this sequence and are
+not treated as write-contract requirements.
+
+The current production adapter still uses the legacy single-step
+`/backend-api/sentinel/chat-requirements` path. PR7.11b does not change that
+production path; it records the current two-phase evidence so a later integration
+PR can replace it deliberately.
+
+## Observed request/response shapes
+
+Sentinel prepare request:
+
+```json
+{
+  "p": "<opaque-or-null>"
+}
+```
+
+Sentinel prepare response top-level keys:
+
+```text
+persona
+prepare_token
+turnstile
+proofofwork
+so
+```
+
+Observed nested shape:
+
+```text
+turnstile:
+  required
+  dx
+
+proofofwork:
+  required
+  seed
+  difficulty
+
+so:
+  required
+  collector_dx
+  snapshot_dx
+```
+
+Sentinel finalize request top-level keys:
+
+```text
+prepare_token
+proofofwork
+turnstile
+```
+
+Sentinel finalize response top-level keys:
+
+```text
+persona
+token
+expire_after
+expire_at
+```
+
+The observed `prepare_token`, challenge descriptors, challenge responses, and final
+requirements token are turn-scoped evidence. PR7.11b deliberately does not claim
+which values are cryptographically bound to one another beyond the observed
+request/response flow.
+
+## Probe boundary
+
+`examples/probe_sentinel_requirements_contract.py` performs only the Sentinel
+`/prepare` request. It stops before:
+
+- Sentinel `/finalize`;
+- any Turnstile replay or challenge solving;
+- any final `/f/conversation` write.
+
+The report records only status, key names, presence booleans, and required flags.
+It never records:
+
+- `prepare_token`;
+- `turnstile.dx`;
+- PoW seed/difficulty values;
+- `so.collector_dx` or `so.snapshot_dx`;
+- raw request/response bodies;
+- final requirements tokens.
+
+When generic HTTP debug tracing is enabled, the prepare request is executed under
+the existing execution-context-local trace suppression boundary and replaced with
+one structural `sentinel-prepare` trace.
+
+## Verdicts
+
+`TWO_PHASE_SENTINEL_PREPARE_OBSERVED`
+
+: HTTP success plus the observed `prepare_token`, `turnstile`, `proofofwork`, and
+  `so` blocks.
+
+`SENTINEL_PREPARE_PARTIAL_SHAPE`
+
+: HTTP success but one or more observed structural fields are absent.
+
+`SENTINEL_PREPARE_REJECTED`
+
+: non-successful Sentinel prepare request.
+
+## Governance
+
+The following remain explicit non-goals for PR7.11b:
+
+- Turnstile solving or bypass;
+- browser challenge replay;
+- production send-path integration;
+- treating any challenge value as independently reusable;
+- claiming the legacy single-step endpoint is universally removed.
+
+The current evidence does establish that a successful current browser write uses
+the two-phase `prepare -> finalize` Sentinel flow, while the adapter's legacy
+single-step flow is not live-validated for that prepared-write contract.

--- a/examples/probe_sentinel_requirements_contract.py
+++ b/examples/probe_sentinel_requirements_contract.py
@@ -7,21 +7,10 @@ from pathlib import Path
 from chatgpt_web_adapter import (
     ChatGPTWebClient,
     probe_sentinel_requirements_prepare,
+    sentinel_requirements as sentinel_contract,
 )
 
 SCHEMA = "chatgpt-web-adapter.sentinel-requirements-contract-probe.v1"
-
-OBSERVED_FINALIZE_REQUEST_KEYS = [
-    "prepare_token",
-    "proofofwork",
-    "turnstile",
-]
-OBSERVED_FINALIZE_RESPONSE_KEYS = [
-    "persona",
-    "token",
-    "expire_after",
-    "expire_at",
-]
 
 
 def build_report(result) -> dict:
@@ -40,6 +29,7 @@ def build_report(result) -> dict:
         "sentinel_prepare": {
             "status_code": result.status_code,
             "status_ok": result.status_ok,
+            "observed_shape_matches": result.observed_shape_matches,
             "persona_present": result.persona_present,
             "prepare_token_present": result.prepare_token_present,
             "response_keys": list(result.response_keys),
@@ -60,8 +50,8 @@ def build_report(result) -> dict:
             },
         },
         "browser_observed_finalize_contract": {
-            "request_keys": OBSERVED_FINALIZE_REQUEST_KEYS,
-            "response_keys": OBSERVED_FINALIZE_RESPONSE_KEYS,
+            "request_keys": list(sentinel_contract.OBSERVED_FINALIZE_REQUEST_KEYS),
+            "response_keys": list(sentinel_contract.OBSERVED_FINALIZE_RESPONSE_KEYS),
             "network_invocation_attempted_by_probe": False,
         },
         "governance": {
@@ -70,22 +60,6 @@ def build_report(result) -> dict:
             "legacy_single_step_current_write_live_validated": False,
         },
     }
-
-
-def verdict(report: dict) -> str:
-    prepare = report["sentinel_prepare"]
-    full_shape = (
-        prepare["status_ok"]
-        and prepare["prepare_token_present"]
-        and prepare["turnstile"]["present"]
-        and prepare["proofofwork"]["present"]
-        and prepare["so"]["present"]
-    )
-    if full_shape:
-        return "TWO_PHASE_SENTINEL_PREPARE_OBSERVED"
-    if prepare["status_ok"]:
-        return "SENTINEL_PREPARE_PARTIAL_SHAPE"
-    return "SENTINEL_PREPARE_REJECTED"
 
 
 def main() -> None:
@@ -106,7 +80,7 @@ def main() -> None:
     client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
     result = probe_sentinel_requirements_prepare(client)
     report = build_report(result)
-    report["verdict"] = verdict(report)
+    report["verdict"] = result.verdict
 
     output = Path(args.output)
     output.write_text(

--- a/examples/probe_sentinel_requirements_contract.py
+++ b/examples/probe_sentinel_requirements_contract.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 from chatgpt_web_adapter import (
     ChatGPTWebClient,
+    OBSERVED_FINALIZE_REQUEST_KEYS,
+    OBSERVED_FINALIZE_RESPONSE_KEYS,
     probe_sentinel_requirements_prepare,
-    sentinel_requirements as sentinel_contract,
 )
 
 SCHEMA = "chatgpt-web-adapter.sentinel-requirements-contract-probe.v1"
@@ -50,8 +51,8 @@ def build_report(result) -> dict:
             },
         },
         "browser_observed_finalize_contract": {
-            "request_keys": list(sentinel_contract.OBSERVED_FINALIZE_REQUEST_KEYS),
-            "response_keys": list(sentinel_contract.OBSERVED_FINALIZE_RESPONSE_KEYS),
+            "request_keys": list(OBSERVED_FINALIZE_REQUEST_KEYS),
+            "response_keys": list(OBSERVED_FINALIZE_RESPONSE_KEYS),
             "network_invocation_attempted_by_probe": False,
         },
         "governance": {

--- a/examples/probe_sentinel_requirements_contract.py
+++ b/examples/probe_sentinel_requirements_contract.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from chatgpt_web_adapter import (
+    ChatGPTWebClient,
+    probe_sentinel_requirements_prepare,
+)
+
+SCHEMA = "chatgpt-web-adapter.sentinel-requirements-contract-probe.v1"
+
+OBSERVED_FINALIZE_REQUEST_KEYS = [
+    "prepare_token",
+    "proofofwork",
+    "turnstile",
+]
+OBSERVED_FINALIZE_RESPONSE_KEYS = [
+    "persona",
+    "token",
+    "expire_after",
+    "expire_at",
+]
+
+
+def build_report(result) -> dict:
+    return {
+        "schema": SCHEMA,
+        "probe": {
+            "sentinel_prepare_attempted": True,
+            "sentinel_finalize_attempted": False,
+            "conversation_write_attempted": False,
+            "raw_request_recorded": False,
+            "raw_response_recorded": False,
+            "prepare_token_recorded": False,
+            "challenge_values_recorded": False,
+            "final_requirements_token_recorded": False,
+        },
+        "sentinel_prepare": {
+            "status_code": result.status_code,
+            "status_ok": result.status_ok,
+            "persona_present": result.persona_present,
+            "prepare_token_present": result.prepare_token_present,
+            "response_keys": list(result.response_keys),
+            "turnstile": {
+                "present": result.turnstile_present,
+                "required": result.turnstile_required,
+                "keys": list(result.turnstile_keys),
+            },
+            "proofofwork": {
+                "present": result.proofofwork_present,
+                "required": result.proofofwork_required,
+                "keys": list(result.proofofwork_keys),
+            },
+            "so": {
+                "present": result.so_present,
+                "required": result.so_required,
+                "keys": list(result.so_keys),
+            },
+        },
+        "browser_observed_finalize_contract": {
+            "request_keys": OBSERVED_FINALIZE_REQUEST_KEYS,
+            "response_keys": OBSERVED_FINALIZE_RESPONSE_KEYS,
+            "network_invocation_attempted_by_probe": False,
+        },
+        "governance": {
+            "challenge_solver_present": False,
+            "challenge_replay_attempted": False,
+            "legacy_single_step_current_write_live_validated": False,
+        },
+    }
+
+
+def verdict(report: dict) -> str:
+    prepare = report["sentinel_prepare"]
+    full_shape = (
+        prepare["status_ok"]
+        and prepare["prepare_token_present"]
+        and prepare["turnstile"]["present"]
+        and prepare["proofofwork"]["present"]
+        and prepare["so"]["present"]
+    )
+    if full_shape:
+        return "TWO_PHASE_SENTINEL_PREPARE_OBSERVED"
+    if prepare["status_ok"]:
+        return "SENTINEL_PREPARE_PARTIAL_SHAPE"
+    return "SENTINEL_PREPARE_REJECTED"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Probe the current two-phase Sentinel chat-requirements prepare "
+            "contract without finalizing challenges or sending a conversation turn."
+        )
+    )
+    parser.add_argument("--auth-file", default="auth_data.json")
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument(
+        "--output",
+        default="sentinel_requirements_contract_probe.json",
+    )
+    args = parser.parse_args()
+
+    client = ChatGPTWebClient(auth_file=args.auth_file, timeout=args.timeout)
+    result = probe_sentinel_requirements_prepare(client)
+    report = build_report(result)
+    report["verdict"] = verdict(report)
+
+    output = Path(args.output)
+    output.write_text(
+        json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    print(f"report: {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -11,6 +11,8 @@ from .conversation_prepare import PrepareResult, prepare_text_turn
 from .diagnostic_metrics import send_with_expanded_metrics as _send_with_expanded_metrics
 from .prepared_text_send import send_existing_text_prepared as _send_existing_text_prepared
 from .sentinel_requirements import (
+    OBSERVED_FINALIZE_REQUEST_KEYS,
+    OBSERVED_FINALIZE_RESPONSE_KEYS,
     SentinelPrepareProbeResult,
     probe_sentinel_requirements_prepare,
 )
@@ -171,6 +173,8 @@ EXPERIMENTAL_PREPARE_EXPORTS = [
 ]
 
 EXPERIMENTAL_SENTINEL_EXPORTS = [
+    "OBSERVED_FINALIZE_REQUEST_KEYS",
+    "OBSERVED_FINALIZE_RESPONSE_KEYS",
     "SentinelPrepareProbeResult",
     "probe_sentinel_requirements_prepare",
 ]

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -10,6 +10,10 @@ from .client import ChatGPTWebClient
 from .conversation_prepare import PrepareResult, prepare_text_turn
 from .diagnostic_metrics import send_with_expanded_metrics as _send_with_expanded_metrics
 from .prepared_text_send import send_existing_text_prepared as _send_existing_text_prepared
+from .sentinel_requirements import (
+    SentinelPrepareProbeResult,
+    probe_sentinel_requirements_prepare,
+)
 from .conversation_send import send_to_conversation as _send_to_conversation
 from .exceptions import (
     AuthError,
@@ -166,6 +170,11 @@ EXPERIMENTAL_PREPARE_EXPORTS = [
     "prepare_text_turn",
 ]
 
+EXPERIMENTAL_SENTINEL_EXPORTS = [
+    "SentinelPrepareProbeResult",
+    "probe_sentinel_requirements_prepare",
+]
+
 SUPPORT_EXPORTS = [
     "DEFAULT_AUTH_FILE",
     "DEFAULT_MODEL",
@@ -181,5 +190,6 @@ __all__ = [
     *EXPERIMENTAL_REQUIRED_ACTION_EXPORTS,
     *EXPERIMENTAL_RAW_PAYLOAD_EXPORTS,
     *EXPERIMENTAL_PREPARE_EXPORTS,
+    *EXPERIMENTAL_SENTINEL_EXPORTS,
     *SUPPORT_EXPORTS,
 ]

--- a/src/chatgpt_web_adapter/sentinel_requirements.py
+++ b/src/chatgpt_web_adapter/sentinel_requirements.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from . import client as client_mod
+from .auth import CHAT_URL
+from .web_session import suppress_web_session_debug_trace
+
+SENTINEL_PREPARE_PATH = "/backend-api/sentinel/chat-requirements/prepare"
+SENTINEL_FINALIZE_PATH = "/backend-api/sentinel/chat-requirements/finalize"
+
+OBSERVED_PREPARE_REQUEST_KEYS = ("p",)
+OBSERVED_FINALIZE_REQUEST_KEYS = (
+    "prepare_token",
+    "proofofwork",
+    "turnstile",
+)
+OBSERVED_FINALIZE_RESPONSE_KEYS = (
+    "persona",
+    "token",
+    "expire_after",
+    "expire_at",
+)
+
+
+@dataclass(frozen=True)
+class SentinelPrepareProbeResult:
+    """Structural result of the current two-phase Sentinel prepare request.
+
+    Credential and challenge values are deliberately not retained. This type is
+    evidence-only; it does not solve, replay, or finalize browser challenges.
+    """
+
+    status_code: int
+    status_ok: bool
+    persona_present: bool
+    prepare_token_present: bool
+    response_keys: tuple[str, ...]
+    turnstile_present: bool
+    turnstile_required: bool
+    turnstile_keys: tuple[str, ...]
+    proofofwork_present: bool
+    proofofwork_required: bool
+    proofofwork_keys: tuple[str, ...]
+    so_present: bool
+    so_required: bool
+    so_keys: tuple[str, ...]
+
+
+def _mapping_keys(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, dict):
+        return ()
+    return tuple(sorted(str(key) for key in value))
+
+
+def _required(value: Any) -> bool:
+    return bool(value.get("required")) if isinstance(value, dict) else False
+
+
+def _build_prepare_probe_result(status: int, data: Any) -> SentinelPrepareProbeResult:
+    response = data if isinstance(data, dict) else {}
+    prepare_token = response.get("prepare_token")
+    turnstile = response.get("turnstile")
+    proofofwork = response.get("proofofwork")
+    so = response.get("so")
+    return SentinelPrepareProbeResult(
+        status_code=int(status),
+        status_ok=200 <= int(status) < 300 and isinstance(data, dict),
+        persona_present=isinstance(response.get("persona"), str)
+        and bool(response.get("persona")),
+        prepare_token_present=isinstance(prepare_token, str)
+        and bool(prepare_token.strip()),
+        response_keys=_mapping_keys(response),
+        turnstile_present=isinstance(turnstile, dict),
+        turnstile_required=_required(turnstile),
+        turnstile_keys=_mapping_keys(turnstile),
+        proofofwork_present=isinstance(proofofwork, dict),
+        proofofwork_required=_required(proofofwork),
+        proofofwork_keys=_mapping_keys(proofofwork),
+        so_present=isinstance(so, dict),
+        so_required=_required(so),
+        so_keys=_mapping_keys(so),
+    )
+
+
+def build_sentinel_prepare_headers(client: Any) -> dict[str, str]:
+    return client._build_headers(
+        {
+            "accept": "*/*",
+            "content-type": "application/json",
+            "origin": CHAT_URL.rstrip("/"),
+            "referer": CHAT_URL,
+            "x-openai-target-path": SENTINEL_PREPARE_PATH,
+            "x-openai-target-route": SENTINEL_PREPARE_PATH,
+        }
+    )
+
+
+def probe_sentinel_requirements_prepare(client: Any) -> SentinelPrepareProbeResult:
+    """Probe only the current Sentinel prepare phase and retain structure only.
+
+    The browser-observed finalize phase requires turn-scoped challenge evidence.
+    This helper intentionally stops before finalize and before any conversation
+    write; it never synthesizes or replays Turnstile/Sentinel challenge values.
+    """
+
+    req_input = None
+    proof_token = getattr(getattr(client, "auth", None), "proof_token", None)
+    if isinstance(proof_token, list):
+        try:
+            req_input = client_mod._get_requirements_token(proof_token)
+        except Exception:
+            req_input = None
+
+    headers = build_sentinel_prepare_headers(client)
+    payload = {"p": req_input}
+
+    trace_dir_marker = object()
+    trace_dir = getattr(client, "debug_trace_dir", trace_dir_marker)
+    trace_enabled = trace_dir is not trace_dir_marker and trace_dir is not None
+
+    with suppress_web_session_debug_trace():
+        status, data = client._json_request(
+            "POST",
+            f"{CHAT_URL.rstrip('/')}{SENTINEL_PREPARE_PATH}",
+            payload,
+            headers,
+        )
+
+    result = _build_prepare_probe_result(int(status), data)
+
+    if trace_enabled:
+        writer = getattr(client, "_write_debug_trace", None)
+        if callable(writer):
+            writer(
+                "sentinel-prepare",
+                {
+                    "method": "POST",
+                    "url": f"{CHAT_URL.rstrip('/')}{SENTINEL_PREPARE_PATH}",
+                    "request_keys": list(OBSERVED_PREPARE_REQUEST_KEYS),
+                    "p_present": req_input is not None,
+                    "response_status": result.status_code,
+                    "response_keys": list(result.response_keys),
+                    "prepare_token_present": result.prepare_token_present,
+                    "turnstile_present": result.turnstile_present,
+                    "turnstile_required": result.turnstile_required,
+                    "turnstile_keys": list(result.turnstile_keys),
+                    "proofofwork_present": result.proofofwork_present,
+                    "proofofwork_required": result.proofofwork_required,
+                    "proofofwork_keys": list(result.proofofwork_keys),
+                    "so_present": result.so_present,
+                    "so_required": result.so_required,
+                    "so_keys": list(result.so_keys),
+                    "raw_request_recorded": False,
+                    "raw_response_recorded": False,
+                    "challenge_values_recorded": False,
+                },
+            )
+    return result

--- a/src/chatgpt_web_adapter/sentinel_requirements.py
+++ b/src/chatgpt_web_adapter/sentinel_requirements.py
@@ -11,6 +11,16 @@ SENTINEL_PREPARE_PATH = "/backend-api/sentinel/chat-requirements/prepare"
 SENTINEL_FINALIZE_PATH = "/backend-api/sentinel/chat-requirements/finalize"
 
 OBSERVED_PREPARE_REQUEST_KEYS = ("p",)
+OBSERVED_PREPARE_RESPONSE_KEYS = (
+    "persona",
+    "prepare_token",
+    "proofofwork",
+    "so",
+    "turnstile",
+)
+OBSERVED_TURNSTILE_KEYS = ("dx", "required")
+OBSERVED_PROOFOFWORK_KEYS = ("difficulty", "required", "seed")
+OBSERVED_SO_KEYS = ("collector_dx", "required", "snapshot_dx")
 OBSERVED_FINALIZE_REQUEST_KEYS = (
     "prepare_token",
     "proofofwork",
@@ -22,6 +32,13 @@ OBSERVED_FINALIZE_RESPONSE_KEYS = (
     "expire_after",
     "expire_at",
 )
+
+
+def _contains_observed_keys(
+    actual: tuple[str, ...],
+    expected: tuple[str, ...],
+) -> bool:
+    return set(expected).issubset(actual)
 
 
 @dataclass(frozen=True)
@@ -46,6 +63,48 @@ class SentinelPrepareProbeResult:
     so_present: bool
     so_required: bool
     so_keys: tuple[str, ...]
+
+    @property
+    def observed_shape_matches(self) -> bool:
+        """Whether all live-observed structural keys are still present.
+
+        Extra keys are allowed so additive server changes do not cause a false
+        rejection. Challenge ``required`` values are deliberately not frozen:
+        their booleans may vary by current server policy/session risk.
+        """
+
+        return (
+            self.status_ok
+            and self.persona_present
+            and self.prepare_token_present
+            and _contains_observed_keys(
+                self.response_keys,
+                OBSERVED_PREPARE_RESPONSE_KEYS,
+            )
+            and self.turnstile_present
+            and _contains_observed_keys(
+                self.turnstile_keys,
+                OBSERVED_TURNSTILE_KEYS,
+            )
+            and self.proofofwork_present
+            and _contains_observed_keys(
+                self.proofofwork_keys,
+                OBSERVED_PROOFOFWORK_KEYS,
+            )
+            and self.so_present
+            and _contains_observed_keys(
+                self.so_keys,
+                OBSERVED_SO_KEYS,
+            )
+        )
+
+    @property
+    def verdict(self) -> str:
+        if self.observed_shape_matches:
+            return "TWO_PHASE_SENTINEL_PREPARE_OBSERVED"
+        if self.status_ok:
+            return "SENTINEL_PREPARE_PARTIAL_SHAPE"
+        return "SENTINEL_PREPARE_REJECTED"
 
 
 def _mapping_keys(value: Any) -> tuple[str, ...]:
@@ -152,6 +211,7 @@ def probe_sentinel_requirements_prepare(client: Any) -> SentinelPrepareProbeResu
                     "so_present": result.so_present,
                     "so_required": result.so_required,
                     "so_keys": list(result.so_keys),
+                    "observed_shape_matches": result.observed_shape_matches,
                     "raw_request_recorded": False,
                     "raw_response_recorded": False,
                     "challenge_values_recorded": False,

--- a/tests/test_sentinel_requirements_contract.py
+++ b/tests/test_sentinel_requirements_contract.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import chatgpt_web_adapter as adapter
+
+
+def _response(secret_prefix: str = "secret") -> dict:
+    return {
+        "persona": "chatgpt-paid",
+        "prepare_token": f"{secret_prefix}-prepare-token",
+        "turnstile": {
+            "required": True,
+            "dx": f"{secret_prefix}-turnstile-dx",
+        },
+        "proofofwork": {
+            "required": True,
+            "seed": f"{secret_prefix}-pow-seed",
+            "difficulty": "06eb35",
+        },
+        "so": {
+            "required": True,
+            "collector_dx": f"{secret_prefix}-collector",
+            "snapshot_dx": f"{secret_prefix}-snapshot",
+        },
+    }
+
+
+def test_sentinel_prepare_probe_retains_structure_only(tmp_path: Path) -> None:
+    class TraceClient(adapter.ChatGPTWebClient):
+        def __init__(self) -> None:
+            self.auth = SimpleNamespace(proof_token=None)
+            self.debug_trace_dir = tmp_path
+            self.debug_trace_sanitize = False
+            self._debug_trace_counter = 0
+
+        @staticmethod
+        def _build_headers(extra):
+            return {key: value for key, value in extra.items() if value is not None}
+
+        def _json_request(self, method, url, payload, headers):
+            response = _response()
+            self._write_debug_trace(
+                "http",
+                {
+                    "request_body": payload,
+                    "response_body": response,
+                },
+            )
+            return 200, response
+
+    result = adapter.probe_sentinel_requirements_prepare(TraceClient())
+
+    assert result.status_ok is True
+    assert result.prepare_token_present is True
+    assert result.turnstile_required is True
+    assert result.proofofwork_required is True
+    assert result.so_required is True
+    assert result.response_keys == (
+        "persona",
+        "prepare_token",
+        "proofofwork",
+        "so",
+        "turnstile",
+    )
+    assert result.turnstile_keys == ("dx", "required")
+    assert result.proofofwork_keys == ("difficulty", "required", "seed")
+    assert result.so_keys == ("collector_dx", "required", "snapshot_dx")
+
+    traces = sorted(tmp_path.glob("*.json"))
+    assert len(traces) == 1
+    rendered = traces[0].read_text(encoding="utf-8")
+    for secret in (
+        "secret-prepare-token",
+        "secret-turnstile-dx",
+        "secret-pow-seed",
+        "secret-collector",
+        "secret-snapshot",
+    ):
+        assert secret not in rendered
+
+    payload = json.loads(rendered)
+    assert payload["raw_request_recorded"] is False
+    assert payload["raw_response_recorded"] is False
+    assert payload["challenge_values_recorded"] is False
+    assert payload["prepare_token_present"] is True
+
+
+def test_sentinel_prepare_probe_uses_observed_request_shape(monkeypatch) -> None:
+    captured = {}
+
+    class Client:
+        auth = SimpleNamespace(proof_token=["browser-fingerprint"])
+        debug_trace_dir = None
+
+        @staticmethod
+        def _build_headers(extra):
+            return {key: value for key, value in extra.items() if value is not None}
+
+        @staticmethod
+        def _json_request(method, url, payload, headers):
+            captured.update(
+                method=method,
+                url=url,
+                payload=payload,
+                headers=headers,
+            )
+            return 200, _response("different")
+
+    import chatgpt_web_adapter.sentinel_requirements as sentinel
+
+    monkeypatch.setattr(
+        sentinel.client_mod,
+        "_get_requirements_token",
+        lambda value: "derived-p",
+    )
+
+    adapter.probe_sentinel_requirements_prepare(Client())
+
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith(
+        "/backend-api/sentinel/chat-requirements/prepare"
+    )
+    assert captured["payload"] == {"p": "derived-p"}
+    assert captured["headers"]["x-openai-target-path"].endswith(
+        "/sentinel/chat-requirements/prepare"
+    )
+    assert captured["headers"]["x-openai-target-route"].endswith(
+        "/sentinel/chat-requirements/prepare"
+    )
+
+
+def test_two_phase_finalize_shape_is_observed_not_executed() -> None:
+    import chatgpt_web_adapter.sentinel_requirements as sentinel
+
+    assert sentinel.OBSERVED_FINALIZE_REQUEST_KEYS == (
+        "prepare_token",
+        "proofofwork",
+        "turnstile",
+    )
+    assert sentinel.OBSERVED_FINALIZE_RESPONSE_KEYS == (
+        "persona",
+        "token",
+        "expire_after",
+        "expire_at",
+    )

--- a/tests/test_sentinel_requirements_contract.py
+++ b/tests/test_sentinel_requirements_contract.py
@@ -18,7 +18,7 @@ def _response(secret_prefix: str = "secret") -> dict:
         "proofofwork": {
             "required": True,
             "seed": f"{secret_prefix}-pow-seed",
-            "difficulty": "06eb35",
+            "difficulty": f"{secret_prefix}-pow-difficulty",
         },
         "so": {
             "required": True,
@@ -28,10 +28,22 @@ def _response(secret_prefix: str = "secret") -> dict:
     }
 
 
-def test_sentinel_prepare_probe_retains_structure_only(tmp_path: Path) -> None:
+def test_sentinel_prepare_probe_retains_structure_only(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    import chatgpt_web_adapter.sentinel_requirements as sentinel
+
+    derived_p = "secret-derived-p"
+    monkeypatch.setattr(
+        sentinel.client_mod,
+        "_get_requirements_token",
+        lambda value: derived_p,
+    )
+
     class TraceClient(adapter.ChatGPTWebClient):
         def __init__(self) -> None:
-            self.auth = SimpleNamespace(proof_token=None)
+            self.auth = SimpleNamespace(proof_token=["browser-fingerprint"])
             self.debug_trace_dir = tmp_path
             self.debug_trace_sanitize = False
             self._debug_trace_counter = 0
@@ -41,6 +53,7 @@ def test_sentinel_prepare_probe_retains_structure_only(tmp_path: Path) -> None:
             return {key: value for key, value in extra.items() if value is not None}
 
         def _json_request(self, method, url, payload, headers):
+            assert payload == {"p": derived_p}
             response = _response()
             self._write_debug_trace(
                 "http",
@@ -54,6 +67,8 @@ def test_sentinel_prepare_probe_retains_structure_only(tmp_path: Path) -> None:
     result = adapter.probe_sentinel_requirements_prepare(TraceClient())
 
     assert result.status_ok is True
+    assert result.observed_shape_matches is True
+    assert result.verdict == "TWO_PHASE_SENTINEL_PREPARE_OBSERVED"
     assert result.prepare_token_present is True
     assert result.turnstile_required is True
     assert result.proofofwork_required is True
@@ -73,15 +88,19 @@ def test_sentinel_prepare_probe_retains_structure_only(tmp_path: Path) -> None:
     assert len(traces) == 1
     rendered = traces[0].read_text(encoding="utf-8")
     for secret in (
+        derived_p,
         "secret-prepare-token",
         "secret-turnstile-dx",
         "secret-pow-seed",
+        "secret-pow-difficulty",
         "secret-collector",
         "secret-snapshot",
     ):
         assert secret not in rendered
 
     payload = json.loads(rendered)
+    assert payload["p_present"] is True
+    assert payload["observed_shape_matches"] is True
     assert payload["raw_request_recorded"] is False
     assert payload["raw_response_recorded"] is False
     assert payload["challenge_values_recorded"] is False
@@ -117,8 +136,10 @@ def test_sentinel_prepare_probe_uses_observed_request_shape(monkeypatch) -> None
         lambda value: "derived-p",
     )
 
-    adapter.probe_sentinel_requirements_prepare(Client())
+    result = adapter.probe_sentinel_requirements_prepare(Client())
 
+    assert result.observed_shape_matches is True
+    assert result.verdict == "TWO_PHASE_SENTINEL_PREPARE_OBSERVED"
     assert captured["method"] == "POST"
     assert captured["url"].endswith(
         "/backend-api/sentinel/chat-requirements/prepare"
@@ -132,8 +153,32 @@ def test_sentinel_prepare_probe_uses_observed_request_shape(monkeypatch) -> None
     )
 
 
-def test_two_phase_finalize_shape_is_observed_not_executed() -> None:
-    import chatgpt_web_adapter.sentinel_requirements as sentinel
+def test_sentinel_prepare_verdict_detects_nested_schema_drift() -> None:
+    response = _response("drift")
+    del response["turnstile"]["dx"]
+
+    class Client:
+        auth = SimpleNamespace(proof_token=None)
+        debug_trace_dir = None
+
+        @staticmethod
+        def _build_headers(extra):
+            return {key: value for key, value in extra.items() if value is not None}
+
+        @staticmethod
+        def _json_request(method, url, payload, headers):
+            return 200, response
+
+    result = adapter.probe_sentinel_requirements_prepare(Client())
+
+    assert result.status_ok is True
+    assert result.turnstile_present is True
+    assert result.observed_shape_matches is False
+    assert result.verdict == "SENTINEL_PREPARE_PARTIAL_SHAPE"
+
+
+def test_two_phase_finalize_shape_is_canonical_in_sentinel_module() -> None:
+    from chatgpt_web_adapter import sentinel_requirements as sentinel
 
     assert sentinel.OBSERVED_FINALIZE_REQUEST_KEYS == (
         "prepare_token",

--- a/tests/test_sentinel_requirements_contract.py
+++ b/tests/test_sentinel_requirements_contract.py
@@ -177,17 +177,53 @@ def test_sentinel_prepare_verdict_detects_nested_schema_drift() -> None:
     assert result.verdict == "SENTINEL_PREPARE_PARTIAL_SHAPE"
 
 
-def test_two_phase_finalize_shape_is_canonical_in_sentinel_module() -> None:
-    from chatgpt_web_adapter import sentinel_requirements as sentinel
+def test_sentinel_prepare_allows_additive_keys_and_nonrequired_challenges() -> None:
+    response = _response("additive")
+    response["server_extension"] = {"version": 2}
+    response["turnstile"]["required"] = False
+    response["turnstile"]["extra"] = "ignored"
+    response["proofofwork"]["required"] = False
+    response["proofofwork"]["extra"] = "ignored"
+    response["so"]["required"] = False
+    response["so"]["extra"] = "ignored"
 
-    assert sentinel.OBSERVED_FINALIZE_REQUEST_KEYS == (
+    class Client:
+        auth = SimpleNamespace(proof_token=None)
+        debug_trace_dir = None
+
+        @staticmethod
+        def _build_headers(extra):
+            return {key: value for key, value in extra.items() if value is not None}
+
+        @staticmethod
+        def _json_request(method, url, payload, headers):
+            return 200, response
+
+    result = adapter.probe_sentinel_requirements_prepare(Client())
+
+    assert result.status_ok is True
+    assert result.turnstile_required is False
+    assert result.proofofwork_required is False
+    assert result.so_required is False
+    assert "server_extension" in result.response_keys
+    assert "extra" in result.turnstile_keys
+    assert "extra" in result.proofofwork_keys
+    assert "extra" in result.so_keys
+    assert result.observed_shape_matches is True
+    assert result.verdict == "TWO_PHASE_SENTINEL_PREPARE_OBSERVED"
+
+
+def test_two_phase_finalize_shape_is_public_contract() -> None:
+    assert adapter.OBSERVED_FINALIZE_REQUEST_KEYS == (
         "prepare_token",
         "proofofwork",
         "turnstile",
     )
-    assert sentinel.OBSERVED_FINALIZE_RESPONSE_KEYS == (
+    assert adapter.OBSERVED_FINALIZE_RESPONSE_KEYS == (
         "persona",
         "token",
         "expire_after",
         "expire_at",
     )
+    assert "OBSERVED_FINALIZE_REQUEST_KEYS" in adapter.__all__
+    assert "OBSERVED_FINALIZE_RESPONSE_KEYS" in adapter.__all__


### PR DESCRIPTION
## Summary

- add a privacy-safe probe for the current two-phase Sentinel `chat-requirements/prepare` contract
- record only structural status/key/presence evidence; never persist `prepare_token`, challenge values, raw request/response bodies, or final requirements tokens
- freeze the browser-observed `/prepare -> /finalize` request/response schema without invoking `/finalize`
- explicitly keep Turnstile solving, browser challenge replay, and production send-path integration out of scope
- document that the legacy single-step requirements path remains in production but is not live-validated for the current prepared-write contract

## Live evidence

A successful current browser turn was observed with the ordering:

```text
POST /backend-api/f/conversation/prepare
POST /backend-api/sentinel/chat-requirements/prepare
POST /backend-api/sentinel/chat-requirements/finalize
POST /backend-api/f/conversation
```

Observed Sentinel prepare response structure includes:

- `persona`
- `prepare_token`
- `turnstile { required, dx }`
- `proofofwork { required, seed, difficulty }`
- `so { required, collector_dx, snapshot_dx }`

Observed finalize request top-level keys:

- `prepare_token`
- `proofofwork`
- `turnstile`

Observed finalize response top-level keys:

- `persona`
- `token`
- `expire_after`
- `expire_at`

## Probe boundary

The new live probe calls only `/backend-api/sentinel/chat-requirements/prepare` and then stops. It does not:

- call Sentinel `/finalize`
- solve or bypass Turnstile
- replay browser challenge credentials
- send `/f/conversation`
- modify the production `_get_ready_requirements()` path

## Regression coverage

- observed prepare request shape (`{"p": ...}`)
- structural prepare response parsing
- privacy-safe trace replacement with challenge values absent
- observed finalize schema is represented but never executed
- public package exports for the experimental probe

This is a stacked draft PR on PR7.11a so the diff contains only PR7.11b evidence/probe work.