### PR TITLE
Release 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+## 0.1.6 - 2026-08-11
+
 - feat: added an optional `ZendriverSentinelBundleProvider` (`chatgpt-web-adapter[browser]`) that captures a complete unused bundle from the official ChatGPT page without submitting a message or persisting one-shot credentials
 - compatibility: finalized-bundle providers can now bypass SDK-side prepare/finalize entirely, while the lower-level current-prepare challenge-provider boundary remains available for custom integrations
 - compatibility: prepared ordinary-text writes to existing conversations now consume one current two-phase finalized Sentinel bundle (`requirements` + proof + Turnstile) and never call the legacy single-step requirements path; new-chat and multimodal sends remain unchanged

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatgpt-web-adapter"
-version = "0.1.5"
+version = "0.1.6"
 description = "Python SDK for controlling existing ChatGPT web sessions without browser UI."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare chatgpt-web-adapter 0.1.6 for release.

## Changes

- bump project version from 0.1.5 to 0.1.6;
- move accumulated Unreleased notes into the dated 0.1.6 changelog section.

## Validation

- 625 tests passed;
- sdist and wheel built successfully in an isolated environment;
- twine check passed for both artifacts;
- clean wheel installation reports version 0.1.6;
- public ChatGPTWebClient and ZendriverSentinelBundleProvider exports import successfully;
- browser optional dependency metadata is present;
- live existing-conversation send returned exactly SDK_SMOKE_OK;
- live attach, message read, and status checks passed.

## Release

After this PR is merged, publish GitHub Release v0.1.6. The existing Trusted Publishing workflow will build, validate, and upload the package to PyPI.