### PR TITLE
feat: harden browser sessions for 0.1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - name: Check out repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+## 0.1.7 - 2026-08-11
+
+- auth: persist structured `browserCookies` with domain/path/expiry metadata while retaining the backward-compatible flat `cookies` map
+- auth: report persistent-profile health and structured cookie count through `auth status`
+- browser: serialize cross-process access to the persistent Chromium profile and close its CDP connection without the benign duplicate-close warning
+- sentinel: retry transient browser capture failures, expose privacy-safe stage diagnostics, and support the `auto_sentinel` client shortcut with optional headless capture
+- live: verify first-turn system prompts, new chat, continuation, attach/read/status, headless text writes, PNG/JPEG/GIF/WebP uploads, multiple images, and image continuation against the current web backend
+- packaging: add Python 3.14 to package metadata and the Linux/Windows CI matrix
 - auth: refresh expired or missing web access tokens through `/api/auth/session`, rotate session credentials in memory, and atomically update `auth_data.json`; `refresh_auth()` provides an explicit refresh boundary
 - compatibility: route normal new-chat and multimodal `send()` calls through the observed conversation prepare/conduit flow when a Sentinel provider is installed
 - compatibility: new-chat prepare now uses the observed `client-created-root`, `client_prepare_state=none`, debounced/window-focus shape without a legacy partial query or initial conduit header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+- auth: refresh expired or missing web access tokens through `/api/auth/session`, rotate session credentials in memory, and atomically update `auth_data.json`; `refresh_auth()` provides an explicit refresh boundary
+- compatibility: route normal new-chat and multimodal `send()` calls through the observed conversation prepare/conduit flow when a Sentinel provider is installed
+- compatibility: new-chat prepare now uses the observed `client-created-root`, `client_prepare_state=none`, debounced/window-focus shape without a legacy partial query or initial conduit header
+- compatibility: finalized Sentinel bundles now protect new-chat and image writes as well as existing ordinary-text continuation writes
+- compatibility: browser Sentinel capture now uses trusted keyboard input and reads finalize bodies from the exact `ResponseReceived` request instead of relying on Zendriver's unstable `LoadingFinished` dispatch
+- tests: add contract coverage for auth rotation/persistence, protected new-chat creation, and the full create/upload/finalize multimodal path
+
 ## 0.1.6 - 2026-08-11
 
 - feat: added an optional `ZendriverSentinelBundleProvider` (`chatgpt-web-adapter[browser]`) that captures a complete unused bundle from the official ChatGPT page without submitting a message or persisting one-shot credentials

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Experimental features:
 - `validate_payload()`
 - `send_payload()`
 
-Current prepared existing-conversation writes can opt into the official-page
-Sentinel path:
+Current new-chat, continuation, and multimodal writes can opt into the
+official-page Sentinel path:
 
 ```bash
 pip install "chatgpt-web-adapter[browser]"
@@ -83,7 +83,7 @@ from chatgpt_web_adapter import ChatGPTWebClient, ZendriverSentinelBundleProvide
 
 client = ChatGPTWebClient(auth_file="auth_data.json")
 client.set_sentinel_bundle_provider(ZendriverSentinelBundleProvider())
-client.prefetch_sentinel_bundle()
+response = client.send("Start a new chat from the SDK.")
 ```
 
 This provider observes a fresh prepare/finalize bundle produced by ChatGPT's own
@@ -134,7 +134,7 @@ The stable core is the main surface intended for building tools on top of an exi
 
 - Python 3.10+
 - system `curl` available in `PATH`
-- valid `auth_data.json` with `accessToken`, or an optional `.env` fallback with `accessToken`
+- valid `auth_data.json` with `accessToken` and a ChatGPT session cookie/token; the access token is refreshed automatically when it expires
 
 ## Install
 
@@ -152,9 +152,10 @@ pytest -q
 ## Quick Start
 
 ```python
-from chatgpt_web_adapter import ChatGPTWebClient
+from chatgpt_web_adapter import ChatGPTWebClient, ZendriverSentinelBundleProvider
 
 client = ChatGPTWebClient(auth_file="auth_data.json")
+client.set_sentinel_bundle_provider(ZendriverSentinelBundleProvider())
 
 response = client.send(
     "Give me a short summary of this project.",
@@ -166,7 +167,10 @@ print(response.text)
 
 ## Authentication at a Glance
 
-`chatgpt-web-adapter` does not log you in and does not capture auth by itself. It only reuses existing `chatgpt.com` web-session data.
+`chatgpt-web-adapter` does not log you in. It reuses an existing `chatgpt.com`
+web session. When the access token is missing or near expiry, the client calls
+`/api/auth/session`, rotates the in-memory session credentials, and atomically
+updates the same `auth_data.json` by default.
 
 Recommended `auth_data.json` shape:
 
@@ -184,6 +188,8 @@ Recommended `auth_data.json` shape:
 
 - `accessToken` is the ChatGPT web access token from your browser session. It is not an official OpenAI API key.
 - `cookies` and `headers` should come from the same account/session as the token.
+- Automatic refresh requires `__Secure-next-auth.session-token` (including chunked variants) or a top-level `sessionToken` in the file.
+- Call `client.refresh_auth()` to refresh immediately. Pass `auto_refresh_auth=False` or `persist_refreshed_auth=False` to opt out of automatic refresh or file updates.
 - `.env` is optional, not required. If present, `accessToken=...` is used only as a fallback when the file token is missing or expired.
 - Older files that still use `api_key` are accepted for backward compatibility, but new examples and new files should use `accessToken`.
 - If you need to generate this file, capture it with `webchat-openai-cli` and then reuse it here.
@@ -215,6 +221,16 @@ response = client.send_to_conversation(
     "Continue from this point.",
 )
 
+print(response.text)
+```
+
+### Send an Image in a New Chat
+
+```python
+response = client.send(
+    "What is shown in this image?",
+    media=["screenshot.png"],
+)
 print(response.text)
 ```
 
@@ -288,7 +304,10 @@ The example script includes:
 
 ## Auth Notes
 
-This repository only consumes existing auth data. If you still need browser-based capture, generate `auth_data.json` with `webchat-openai-cli` first and then reuse it here.
+This repository still requires one initially authenticated browser session. If you
+need to generate the first `auth_data.json`, capture it with
+`webchat-openai-cli`; subsequent access-token refreshes can be handled by the SDK
+while that session cookie remains valid.
 
 ## Detailed Guide
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ Python SDK for controlling existing ChatGPT web sessions without browser UI.
 
 `chatgpt-web-adapter` is a small Python SDK with a dependency-free core for sending prompts, continuing conversations, reading conversation state, uploading images, and handling selected ChatGPT web workflows from Python.
 
-It is designed for tools that already have valid ChatGPT web-session auth data and want to avoid driving the browser UI.
+It is designed for terminal tools that use a reusable ChatGPT web session. The
+optional browser extra can create that session once and recover it later; normal
+requests continue without browser UI.
 
 ## What This Is
 
 `chatgpt-web-adapter` wraps the existing ChatGPT web backend behavior used by a logged-in web session. It focuses on reusable transport, request formatting, response parsing, and conversation helpers.
 
-The package intentionally does not include the CLI, localization, auth capture, or local chat-history management from `webchat-openai-cli`. Browser support is limited to an optional experimental Sentinel provider for current prepared writes.
+The package includes a small auth-management CLI and optional browser bootstrap.
+It does not include localization or local chat-history management from
+`webchat-openai-cli`.
 
 ## When It Is Useful
 
@@ -44,7 +48,6 @@ The package intentionally does not include the CLI, localization, auth capture, 
 
 - the official OpenAI API
 - a replacement for the OpenAI Python SDK
-- a login or auth-capture tool
 - a browser automation framework
 - a stable contract for undocumented ChatGPT web internals
 
@@ -87,7 +90,8 @@ response = client.send("Start a new chat from the SDK.")
 ```
 
 This provider observes a fresh prepare/finalize bundle produced by ChatGPT's own
-page, never submits a message, and keeps the one-shot credentials in memory only.
+page, blocks the browser's conversation POST, and keeps the unused one-shot
+credentials in memory only.
 It is experimental because the web contract and page behavior are undocumented.
 
 The stable core is the main surface intended for building tools on top of an existing ChatGPT web session. Experimental features are exposed because they are useful, but they rely more directly on changing web-client behavior.
@@ -124,6 +128,7 @@ The stable core is the main surface intended for building tools on top of an exi
 - conversation continuation with returned conversation metadata
 - attach/read/status helpers for existing conversations
 - `auth_data.json` and `.env` auth loading
+- one-time browser login and automatic session refresh
 - image uploads from local paths, `Path`, URL, data URI, or raw bytes
 - experimental browserless tool-approval helpers for web-agent flows
 - experimental raw payload escape hatch for advanced users
@@ -134,7 +139,7 @@ The stable core is the main surface intended for building tools on top of an exi
 
 - Python 3.10+
 - system `curl` available in `PATH`
-- valid `auth_data.json` with `accessToken` and a ChatGPT session cookie/token; the access token is refreshed automatically when it expires
+- either a valid `auth_data.json`, or the optional browser extra for first login
 
 ## Install
 
@@ -152,10 +157,16 @@ pytest -q
 ## Quick Start
 
 ```python
-from chatgpt_web_adapter import ChatGPTWebClient, ZendriverSentinelBundleProvider
+from chatgpt_web_adapter import (
+    ChatGPTWebClient,
+    ZendriverSentinelBundleProvider,
+    default_browser_profile_dir,
+)
 
 client = ChatGPTWebClient(auth_file="auth_data.json")
-client.set_sentinel_bundle_provider(ZendriverSentinelBundleProvider())
+client.set_sentinel_bundle_provider(
+    ZendriverSentinelBundleProvider(profile_dir=default_browser_profile_dir())
+)
 
 response = client.send(
     "Give me a short summary of this project.",
@@ -167,10 +178,18 @@ print(response.text)
 
 ## Authentication at a Glance
 
-`chatgpt-web-adapter` does not log you in. It reuses an existing `chatgpt.com`
-web session. When the access token is missing or near expiry, the client calls
-`/api/auth/session`, rotates the in-memory session credentials, and atomically
-updates the same `auth_data.json` by default.
+Install the browser extra and authorize once:
+
+```bash
+pip install "chatgpt-web-adapter[browser]"
+chatgpt-web-adapter auth login --auth-file auth_data.json
+```
+
+The command opens a persistent Chromium profile, waits for you to finish the
+normal ChatGPT login, and saves reusable cookies and tokens without sending a
+probe chat message. When the access token is missing or near expiry, the client calls
+`/api/auth/session`, updates the access/session metadata, preserves the
+browser-issued cookie jar, and atomically updates the same `auth_data.json`.
 
 Recommended `auth_data.json` shape:
 
@@ -190,9 +209,10 @@ Recommended `auth_data.json` shape:
 - `cookies` and `headers` should come from the same account/session as the token.
 - Automatic refresh requires `__Secure-next-auth.session-token` (including chunked variants) or a top-level `sessionToken` in the file.
 - Call `client.refresh_auth()` to refresh immediately. Pass `auto_refresh_auth=False` or `persist_refreshed_auth=False` to opt out of automatic refresh or file updates.
+- Pass `auto_login=True` to `ChatGPTWebClient` to reopen the persistent browser profile only when auth is missing or session refresh fails.
 - `.env` is optional, not required. If present, `accessToken=...` is used only as a fallback when the file token is missing or expired.
 - Older files that still use `api_key` are accepted for backward compatibility, but new examples and new files should use `accessToken`.
-- If you need to generate this file, capture it with `webchat-openai-cli` and then reuse it here.
+- Inspect or refresh auth without exposing tokens with `chatgpt-web-adapter auth status` and `chatgpt-web-adapter auth refresh`.
 
 ## Common Workflows
 
@@ -304,10 +324,9 @@ The example script includes:
 
 ## Auth Notes
 
-This repository still requires one initially authenticated browser session. If you
-need to generate the first `auth_data.json`, capture it with
-`webchat-openai-cli`; subsequent access-token refreshes can be handled by the SDK
-while that session cookie remains valid.
+The optional browser extra creates the initial `auth_data.json` itself. Subsequent
+access-token refreshes are browserless while the session cookie remains valid.
+Interactive login is needed again only after ChatGPT rejects the reusable session.
 
 ## Detailed Guide
 

--- a/README.md
+++ b/README.md
@@ -82,16 +82,9 @@ pip install "chatgpt-web-adapter[browser]"
 ```
 
 ```python
-from chatgpt_web_adapter import (
-    ChatGPTWebClient,
-    ZendriverSentinelBundleProvider,
-    default_browser_profile_dir,
-)
+from chatgpt_web_adapter import ChatGPTWebClient
 
-client = ChatGPTWebClient(auth_file="auth_data.json")
-client.set_sentinel_bundle_provider(
-    ZendriverSentinelBundleProvider(profile_dir=default_browser_profile_dir())
-)
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_sentinel=True)
 response = client.send("Start a new chat from the SDK.")
 ```
 
@@ -163,16 +156,9 @@ pytest -q
 ## Quick Start
 
 ```python
-from chatgpt_web_adapter import (
-    ChatGPTWebClient,
-    ZendriverSentinelBundleProvider,
-    default_browser_profile_dir,
-)
+from chatgpt_web_adapter import ChatGPTWebClient
 
-client = ChatGPTWebClient(auth_file="auth_data.json")
-client.set_sentinel_bundle_provider(
-    ZendriverSentinelBundleProvider(profile_dir=default_browser_profile_dir())
-)
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_sentinel=True)
 
 response = client.send(
     "Give me a short summary of this project.",
@@ -208,6 +194,15 @@ Recommended `auth_data.json` shape:
   "cookies": {
     "__Secure-next-auth.session-token": "..."
   },
+  "browserCookies": [
+    {
+      "name": "__Secure-next-auth.session-token.0",
+      "value": "...",
+      "domain": ".chatgpt.com",
+      "path": "/",
+      "secure": true
+    }
+  ],
   "headers": {
     "user-agent": "Mozilla/5.0 ..."
   }
@@ -216,12 +211,14 @@ Recommended `auth_data.json` shape:
 
 - `accessToken` is the ChatGPT web access token from your browser session. It is not an official OpenAI API key.
 - `cookies` and `headers` should come from the same account/session as the token.
+- `browserCookies` preserves domain/path/expiry metadata needed to recreate a browser session without flattening scoped cookie chunks. Older files without it remain supported.
 - Automatic refresh requires `__Secure-next-auth.session-token` (including chunked variants) or a top-level `sessionToken` in the file.
 - Call `client.refresh_auth()` to refresh immediately. Pass `auto_refresh_auth=False` or `persist_refreshed_auth=False` to opt out of automatic refresh or file updates.
 - Pass `auto_login=True` to `ChatGPTWebClient` to reopen the persistent browser profile only when auth is missing or session refresh fails.
 - `.env` is optional, not required. If present, `accessToken=...` is used only as a fallback when the file token is missing or expired.
 - Older files that still use `api_key` are accepted for backward compatibility, but new examples and new files should use `accessToken`.
 - Inspect or refresh auth without exposing tokens with `chatgpt-web-adapter auth status` and `chatgpt-web-adapter auth refresh`.
+- After the first interactive login, `auto_sentinel=True, sentinel_headless=True` can run protected writes without a visible browser window. Chromium is still required as the browser engine.
 
 ## Common Workflows
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,16 @@ pip install "chatgpt-web-adapter[browser]"
 ```
 
 ```python
-from chatgpt_web_adapter import ChatGPTWebClient, ZendriverSentinelBundleProvider
+from chatgpt_web_adapter import (
+    ChatGPTWebClient,
+    ZendriverSentinelBundleProvider,
+    default_browser_profile_dir,
+)
 
 client = ChatGPTWebClient(auth_file="auth_data.json")
-client.set_sentinel_bundle_provider(ZendriverSentinelBundleProvider())
+client.set_sentinel_bundle_provider(
+    ZendriverSentinelBundleProvider(profile_dir=default_browser_profile_dir())
+)
 response = client.send("Start a new chat from the SDK.")
 ```
 
@@ -184,6 +190,9 @@ Install the browser extra and authorize once:
 pip install "chatgpt-web-adapter[browser]"
 chatgpt-web-adapter auth login --auth-file auth_data.json
 ```
+
+Use `chatgpt-web-adapter auth login --force` when the saved session is rejected
+and you need a completely fresh interactive login.
 
 The command opens a persistent Chromium profile, waits for you to finish the
 normal ChatGPT login, and saves reusable cookies and tokens without sending a

--- a/USAGE.md
+++ b/USAGE.md
@@ -126,6 +126,10 @@ chatgpt-web-adapter auth login --auth-file auth_data.json
 chatgpt-web-adapter auth status --auth-file auth_data.json
 ```
 
+If the saved browser session is inconsistent or revoked, run
+`chatgpt-web-adapter auth login --force --auth-file auth_data.json` and complete
+the fresh login in the SDK browser profile.
+
 You can authenticate in three main ways:
 
 1. Run `chatgpt-web-adapter auth login` once.
@@ -267,10 +271,16 @@ This is intended for local diagnostics and live smoke work. When enabled, the cl
 ## Basic Chat Request
 
 ```python
-from chatgpt_web_adapter import ChatGPTWebClient, ZendriverSentinelBundleProvider
+from chatgpt_web_adapter import (
+    ChatGPTWebClient,
+    ZendriverSentinelBundleProvider,
+    default_browser_profile_dir,
+)
 
 client = ChatGPTWebClient(auth_file="auth_data.json")
-client.set_sentinel_bundle_provider(ZendriverSentinelBundleProvider())
+client.set_sentinel_bundle_provider(
+    ZendriverSentinelBundleProvider(profile_dir=default_browser_profile_dir())
+)
 
 response = client.send(
     "Give me a short summary of this project.",
@@ -707,10 +717,16 @@ For current protected ChatGPT writes, configure the same
 ```python
 from pathlib import Path
 
-from chatgpt_web_adapter import ChatGPTWebClient, ZendriverSentinelBundleProvider
+from chatgpt_web_adapter import (
+    ChatGPTWebClient,
+    ZendriverSentinelBundleProvider,
+    default_browser_profile_dir,
+)
 
 client = ChatGPTWebClient(auth_file="auth_data.json")
-client.set_sentinel_bundle_provider(ZendriverSentinelBundleProvider())
+client.set_sentinel_bundle_provider(
+    ZendriverSentinelBundleProvider(profile_dir=default_browser_profile_dir())
+)
 
 response = client.send(
     "Describe what is shown in this image.",

--- a/USAGE.md
+++ b/USAGE.md
@@ -130,7 +130,7 @@ If the saved browser session is inconsistent or revoked, run
 `chatgpt-web-adapter auth login --force --auth-file auth_data.json` and complete
 the fresh login in the SDK browser profile.
 
-You can authenticate in three main ways:
+You can authenticate in five main ways:
 
 1. Run `chatgpt-web-adapter auth login` once.
 2. Let the client load and refresh `auth_data.json`.
@@ -158,6 +158,15 @@ Recommended captured shape:
   "cookies": {
     "__Secure-next-auth.session-token": "..."
   },
+  "browserCookies": [
+    {
+      "name": "__Secure-next-auth.session-token.0",
+      "value": "...",
+      "domain": ".chatgpt.com",
+      "path": "/",
+      "secure": true
+    }
+  ],
   "headers": {
     "user-agent": "Mozilla/5.0 ..."
   }
@@ -166,6 +175,7 @@ Recommended captured shape:
 
 - `accessToken` is the ChatGPT web access token from your browser session. It is not an official OpenAI API key.
 - `cookies` and `headers` should come from the same account/session as the token.
+- `browserCookies` is written by `auth login` and preserves domain-scoped browser cookie metadata. It is optional for backward compatibility but preferred for portable browser-session restoration.
 - Persisted `proof_token` and `turnstile_token` values are discarded when auth is saved; current Sentinel credentials are one-shot data acquired separately.
 - Older files that still use `api_key` are accepted for backward compatibility, but new files should use `accessToken`.
 
@@ -214,6 +224,17 @@ To make missing or server-revoked auth reopen the persistent browser profile:
 client = ChatGPTWebClient(auth_file="auth_data.json", auto_login=True)
 ```
 
+For protected new-chat, continuation, and media writes, enable automatic use of
+the persistent browser profile:
+
+```python
+client = ChatGPTWebClient(
+    auth_file="auth_data.json",
+    auto_sentinel=True,
+    sentinel_headless=True,
+)
+```
+
 ### Pass a Preloaded `AuthData`
 
 ```python
@@ -252,6 +273,10 @@ Constructor arguments:
 - `auto_login`: open the persistent browser profile when auth is missing or refresh fails, defaults to `False`
 - `browser_profile_dir`: override the per-user persistent browser profile directory
 - `browser_login_timeout`: seconds to wait for interactive login, defaults to `300`
+- `auto_sentinel`: configure the official-page Sentinel provider against the persistent profile, defaults to `False`
+- `sentinel_timeout`: timeout for each browser capture attempt, defaults to `60`
+- `sentinel_max_attempts`: retry count for transient browser capture failures, defaults to `2`
+- `sentinel_headless`: run post-login Sentinel capture without a visible browser window, defaults to `False`
 
 ### Optional Sanitized Debug Traces
 
@@ -271,16 +296,9 @@ This is intended for local diagnostics and live smoke work. When enabled, the cl
 ## Basic Chat Request
 
 ```python
-from chatgpt_web_adapter import (
-    ChatGPTWebClient,
-    ZendriverSentinelBundleProvider,
-    default_browser_profile_dir,
-)
+from chatgpt_web_adapter import ChatGPTWebClient
 
-client = ChatGPTWebClient(auth_file="auth_data.json")
-client.set_sentinel_bundle_provider(
-    ZendriverSentinelBundleProvider(profile_dir=default_browser_profile_dir())
-)
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_sentinel=True)
 
 response = client.send(
     "Give me a short summary of this project.",
@@ -291,9 +309,10 @@ print(response.text)
 ```
 
 Install the provider with `pip install "chatgpt-web-adapter[browser]"`. It opens
-an isolated temporary browser, obtains one unused official-page Sentinel bundle,
-and never clicks submit. The ChatGPT web contract is undocumented, so this
-capture layer can require compatibility updates when the site changes.
+the SDK's persistent profile, obtains one unused official-page Sentinel bundle,
+blocks the browser's own conversation write, and keeps one-shot credentials in
+memory only. The ChatGPT web contract is undocumented, so this capture layer can
+require compatibility updates when the site changes.
 
 ## Read the Response Object
 
@@ -708,25 +727,18 @@ The current media helper is image-focused. Supported formats are:
 - GIF
 - WebP
 
-For current protected ChatGPT writes, configure the same
-`ZendriverSentinelBundleProvider` shown in Basic Chat Request before calling
-`send()`; it also protects the file-backed multimodal final write.
+For current protected ChatGPT writes, use the same `auto_sentinel=True` client
+configuration shown in Basic Chat Request; it also protects the file-backed
+multimodal final write.
 
 ### Local Image from `Path`
 
 ```python
 from pathlib import Path
 
-from chatgpt_web_adapter import (
-    ChatGPTWebClient,
-    ZendriverSentinelBundleProvider,
-    default_browser_profile_dir,
-)
+from chatgpt_web_adapter import ChatGPTWebClient
 
-client = ChatGPTWebClient(auth_file="auth_data.json")
-client.set_sentinel_bundle_provider(
-    ZendriverSentinelBundleProvider(profile_dir=default_browser_profile_dir())
-)
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_sentinel=True)
 
 response = client.send(
     "Describe what is shown in this image.",
@@ -739,7 +751,7 @@ response = client.send(
 ```python
 from chatgpt_web_adapter import ChatGPTWebClient
 
-client = ChatGPTWebClient(auth_file="auth_data.json")
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_sentinel=True)
 
 response = client.send(
     "Summarize the chart in this image.",
@@ -754,7 +766,7 @@ The SDK follows redirects when downloading remote media before upload.
 ```python
 from chatgpt_web_adapter import ChatGPTWebClient
 
-client = ChatGPTWebClient(auth_file="auth_data.json")
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_sentinel=True)
 
 data_uri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
 
@@ -771,7 +783,7 @@ from pathlib import Path
 
 from chatgpt_web_adapter import ChatGPTWebClient
 
-client = ChatGPTWebClient(auth_file="auth_data.json")
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_sentinel=True)
 image_bytes = Path("examples/diagram.webp").read_bytes()
 
 response = client.send(
@@ -787,7 +799,7 @@ from pathlib import Path
 
 from chatgpt_web_adapter import ChatGPTWebClient
 
-client = ChatGPTWebClient(auth_file="auth_data.json")
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_sentinel=True)
 
 response = client.send(
     "Compare these two images.",
@@ -984,7 +996,7 @@ print(follow_up.text)
 - `response.metrics` values are measured in seconds.
 - If the backend requires a Turnstile token and your auth data does not contain one, the request can fail.
 - If `debug_trace_dir` is enabled, the client writes local trace JSON files for transport diagnostics.
-- This package is intentionally small; if you need auth capture or a CLI workflow, use a separate tool and feed its auth output into this SDK.
+- Initial auth capture and token refresh are built in through the optional browser extra and `chatgpt-web-adapter auth` commands.
 
 For operational verification and release hygiene, see:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -55,7 +55,7 @@ Current capabilities:
 Non-goals of this package:
 
 - no CLI
-- no browser automation
+- no mandatory browser runtime for read-only/legacy paths; current protected writes can use the optional browser Sentinel provider
 - no auth capture flow
 - no local chat-history storage
 - no async client
@@ -115,13 +115,17 @@ pytest -q
 
 ## Authentication
 
-The SDK consumes existing auth data. It does not create or refresh sessions by itself.
+The SDK consumes an existing authenticated web session; it does not perform the
+initial login. If the access token is missing or near expiry and the file contains
+a session cookie/token, client construction refreshes credentials through
+`/api/auth/session` and atomically updates `auth_data.json` by default.
 
 You can authenticate in three main ways:
 
 1. Let the client load `auth_data.json`.
 2. Let the client load `accessToken` from `.env` as an optional fallback.
 3. Pass an `AuthData` object directly.
+4. Call `client.refresh_auth()` when an immediate refresh is required.
 
 ### `auth_data.json`
 
@@ -226,6 +230,8 @@ Constructor arguments:
 - `curl_bin`: override the detected `curl` executable
 - `debug_trace_dir`: optional local directory for sanitized debug trace JSON files
 - `debug_trace_sanitize`: redact auth/session headers in debug traces, defaults to `True`
+- `auto_refresh_auth`: refresh a missing/near-expiry access token from the session endpoint, defaults to `True`
+- `persist_refreshed_auth`: atomically update `auth_data.json` after automatic refresh, defaults to `True`
 
 ### Optional Sanitized Debug Traces
 
@@ -245,9 +251,10 @@ This is intended for local diagnostics and live smoke work. When enabled, the cl
 ## Basic Chat Request
 
 ```python
-from chatgpt_web_adapter import ChatGPTWebClient
+from chatgpt_web_adapter import ChatGPTWebClient, ZendriverSentinelBundleProvider
 
 client = ChatGPTWebClient(auth_file="auth_data.json")
+client.set_sentinel_bundle_provider(ZendriverSentinelBundleProvider())
 
 response = client.send(
     "Give me a short summary of this project.",
@@ -256,6 +263,11 @@ response = client.send(
 
 print(response.text)
 ```
+
+Install the provider with `pip install "chatgpt-web-adapter[browser]"`. It opens
+an isolated temporary browser, obtains one unused official-page Sentinel bundle,
+and never clicks submit. The ChatGPT web contract is undocumented, so this
+capture layer can require compatibility updates when the site changes.
 
 ## Read the Response Object
 
@@ -670,14 +682,19 @@ The current media helper is image-focused. Supported formats are:
 - GIF
 - WebP
 
+For current protected ChatGPT writes, configure the same
+`ZendriverSentinelBundleProvider` shown in Basic Chat Request before calling
+`send()`; it also protects the file-backed multimodal final write.
+
 ### Local Image from `Path`
 
 ```python
 from pathlib import Path
 
-from chatgpt_web_adapter import ChatGPTWebClient
+from chatgpt_web_adapter import ChatGPTWebClient, ZendriverSentinelBundleProvider
 
 client = ChatGPTWebClient(auth_file="auth_data.json")
+client.set_sentinel_bundle_provider(ZendriverSentinelBundleProvider())
 
 response = client.send(
     "Describe what is shown in this image.",

--- a/USAGE.md
+++ b/USAGE.md
@@ -115,21 +115,28 @@ pytest -q
 
 ## Authentication
 
-The SDK consumes an existing authenticated web session; it does not perform the
-initial login. If the access token is missing or near expiry and the file contains
-a session cookie/token, client construction refreshes credentials through
-`/api/auth/session` and atomically updates `auth_data.json` by default.
+The SDK can create the initial authenticated session with its optional browser
+extra. After that, client construction refreshes missing or near-expiry access
+tokens through `/api/auth/session`, preserves browser-issued cookies, and
+atomically updates `auth_data.json`.
+
+```bash
+pip install "chatgpt-web-adapter[browser]"
+chatgpt-web-adapter auth login --auth-file auth_data.json
+chatgpt-web-adapter auth status --auth-file auth_data.json
+```
 
 You can authenticate in three main ways:
 
-1. Let the client load `auth_data.json`.
-2. Let the client load `accessToken` from `.env` as an optional fallback.
-3. Pass an `AuthData` object directly.
-4. Call `client.refresh_auth()` when an immediate refresh is required.
+1. Run `chatgpt-web-adapter auth login` once.
+2. Let the client load and refresh `auth_data.json`.
+3. Let the client load `accessToken` from `.env` as an optional fallback.
+4. Pass an `AuthData` object directly.
+5. Call `client.refresh_auth()` when an immediate refresh is required.
 
 ### `auth_data.json`
 
-In practice, the easiest path is to reuse an existing file captured by another tool, for example `webchat-openai-cli`.
+The recommended path is to let the SDK create this file with `auth login`.
 
 Minimal workable shape:
 
@@ -155,7 +162,7 @@ Recommended captured shape:
 
 - `accessToken` is the ChatGPT web access token from your browser session. It is not an official OpenAI API key.
 - `cookies` and `headers` should come from the same account/session as the token.
-- If your captured file also includes `proof_token` or `turnstile_token`, keep them. The SDK can use those fields when the backend requires them.
+- Persisted `proof_token` and `turnstile_token` values are discarded when auth is saved; current Sentinel credentials are one-shot data acquired separately.
 - Older files that still use `api_key` are accepted for backward compatibility, but new files should use `accessToken`.
 
 ### `.env`
@@ -197,6 +204,12 @@ from chatgpt_web_adapter import ChatGPTWebClient
 client = ChatGPTWebClient(auth_file="auth_data.json")
 ```
 
+To make missing or server-revoked auth reopen the persistent browser profile:
+
+```python
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_login=True)
+```
+
 ### Pass a Preloaded `AuthData`
 
 ```python
@@ -232,6 +245,9 @@ Constructor arguments:
 - `debug_trace_sanitize`: redact auth/session headers in debug traces, defaults to `True`
 - `auto_refresh_auth`: refresh a missing/near-expiry access token from the session endpoint, defaults to `True`
 - `persist_refreshed_auth`: atomically update `auth_data.json` after automatic refresh, defaults to `True`
+- `auto_login`: open the persistent browser profile when auth is missing or refresh fails, defaults to `False`
+- `browser_profile_dir`: override the per-user persistent browser profile directory
+- `browser_login_timeout`: seconds to wait for interactive login, defaults to `300`
 
 ### Optional Sanitized Debug Traces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,9 @@
 Primary files:
 
 - `src/chatgpt_web_adapter/auth.py`
+- `src/chatgpt_web_adapter/auth_browser.py`
+- `src/chatgpt_web_adapter/auth_refresh.py`
+- `src/chatgpt_web_adapter/auth_store.py`
 - `src/chatgpt_web_adapter/types.py`
 
 Responsibilities:
@@ -15,8 +18,12 @@ Responsibilities:
 - fall back to `.env` when needed
 - normalize access token, cookies, and headers
 - detect expired JWT-like access tokens when possible
+- bootstrap the first session through an optional persistent browser profile
+- refresh access/session credentials without browser interaction
+- atomically persist reusable credentials while excluding one-shot Sentinel data
 
-This layer should stay narrowly focused on consuming existing auth material. It should not grow into login automation or browser-based capture logic.
+Interactive browser use is confined to auth bootstrap/recovery. It observes
+`/api/auth/session` and cookies but does not submit a probe chat message.
 
 ## Layer 2: Transport
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,9 +21,13 @@ Responsibilities:
 - bootstrap the first session through an optional persistent browser profile
 - refresh access/session credentials without browser interaction
 - atomically persist reusable credentials while excluding one-shot Sentinel data
+- preserve structured browser-cookie scope alongside the backward-compatible flat cookie map
+- serialize access to one persistent Chromium profile across processes
 
-Interactive browser use is confined to auth bootstrap/recovery. It observes
-`/api/auth/session` and cookies but does not submit a probe chat message.
+Interactive browser use is confined to auth bootstrap/recovery. Protected writes
+may launch the same profile visibly or headlessly to observe a fresh official
+Sentinel prepare/finalize transaction. The browser's conversation request is
+blocked; the unused one-shot bundle is handed to the SDK in memory.
 
 ## Layer 2: Transport
 

--- a/docs/live_smoke_checklist.md
+++ b/docs/live_smoke_checklist.md
@@ -20,6 +20,7 @@ Use this checklist when `chatgpt.com` behavior may have changed or before a rele
   - streamed text is correct
   - `conversation_id` is returned
   - `finish_reason` is parsed
+  - a first-turn `system` instruction is honored
 - If broken, inspect:
   - `chat-requirements`
   - send payload shape
@@ -53,21 +54,28 @@ Use this checklist when `chatgpt.com` behavior may have changed or before a rele
 
 ### 4. Image Upload
 
-- Send a tiny PNG with a simple prompt
+- Send PNG, JPEG, GIF, and WebP inputs, including multiple images and an image continuation
 - Confirm:
   - file creation succeeds
   - upload succeeds
   - multimodal request succeeds
   - assistant reply completes normally
+  - continuation preserves the conversation id
 - If broken, inspect:
   - `/backend-api/files`
   - upload/finalize flow
   - attachment metadata
   - multimodal message structure
 
+### 5. Headless Sentinel
+
+- After one interactive login, send a harmless prompt with `sentinel_headless=True`
+- Confirm prepare and finalize are observed and the write completes without a visible browser
+- This validates no-GUI operation; Chromium remains a runtime requirement
+
 ## Experimental Scenarios
 
-### 5. Approval Flow
+### 6. Approval Flow
 
 - Run only if approval helpers are relevant to current work.
 - Use a low-risk, disposable connector target.

--- a/docs/sentinel_bundle_lifecycle.md
+++ b/docs/sentinel_bundle_lifecycle.md
@@ -226,22 +226,21 @@ TTL fields cannot extend a credential beyond either server limit.
 
 ## Turn trace and conversation prepare
 
-PR7.11c creates one turn trace id before `conversation/prepare` and sends the same
-value on the final `/f/conversation` request. The adapter continues to use its
-live-accepted synchronous `x-conduit-token: no-token` prepare model.
+The adapter creates one turn trace id before `conversation/prepare` and sends the
+same value on the final `/f/conversation` request. Existing-conversation text
+prepares use the live-accepted initial `x-conduit-token: no-token`. New-chat and
+multimodal prepares use the separately observed shape without an initial conduit
+header or `partial_query`; their final write uses the conduit returned by prepare.
 
 The adapter may still intentionally reuse its locally created user-message id in
 `partial_query` and in the final payload, but this is an implementation choice,
 not a browser contract invariant.
 
-## Unchanged paths
+## Remaining unchanged paths
 
-The following remain on the legacy requirements/send behavior pending independent
-evidence:
-
-- new-chat `ChatGPTWebClient.send()`;
-- existing-conversation media sends;
-- approval flows.
+New-chat and multimodal `ChatGPTWebClient.send()` writes now share the finalized
+bundle transaction when a Sentinel provider is installed. Approval flows remain
+on their existing behavior pending independent evidence.
 
 `/sentinel/req` integration, Turnstile/SO bypass, and PR7.12 WebSocket work remain
 outside this transaction-layer change.

--- a/docs/sentinel_bundle_lifecycle.md
+++ b/docs/sentinel_bundle_lifecycle.md
@@ -178,22 +178,18 @@ captured from the official page's own prepare/finalize transaction. The optional
 message or persisting one-shot credentials:
 
 ```python
-from chatgpt_web_adapter import (
-    ChatGPTWebClient,
-    ZendriverSentinelBundleProvider,
-)
+from chatgpt_web_adapter import ChatGPTWebClient
 
-client = ChatGPTWebClient(auth_file="auth_data.json")
-client.set_sentinel_bundle_provider(ZendriverSentinelBundleProvider())
+client = ChatGPTWebClient(auth_file="auth_data.json", auto_sentinel=True)
 client.prefetch_sentinel_bundle()
 ```
 
-Install it with `pip install "chatgpt-web-adapter[browser]"`. The provider uses an
-isolated temporary browser profile seeded from `client.auth.cookies`, observes the
-official finalize request/response in memory, synchronizes ordinary ChatGPT cookies
-(including `oai-did`) back into the in-memory client, and closes the browser. It may open
-a visible browser window because `headless=False` is the safe default for browser
-challenge execution.
+Install it with `pip install "chatgpt-web-adapter[browser]"`. The automatic mode
+uses the persistent auth profile under a cross-process lock, observes the official
+finalize request/response in memory, synchronizes scoped ChatGPT cookies (including
+`oai-did`) back into the client and auth file, and closes the browser. It may open a
+visible browser window because `sentinel_headless=False` is the compatibility default;
+after initial login, `sentinel_headless=True` is supported and live-smoke tested.
 
 The lower-level current-prepare evidence boundary remains available for custom
 integrations. It receives a `SentinelChallengeContext` containing the exact

--- a/docs/text_prepare_contract_probe.md
+++ b/docs/text_prepare_contract_probe.md
@@ -63,9 +63,10 @@ The live PR7.11 run reproduced `PREPARE_CONTRACT_OBSERVED`: prepare returned HTT
 200 with `status=ok` and a conduit token while the report retained only structural
 evidence.
 
-PR7.11a therefore integrates this contract only into ordinary text writes to an
-existing conversation. The direct new-chat `ChatGPTWebClient.send()` path and
-multimodal writes remain outside that integration pending independent evidence.
+The original PR7.11a integration covered only ordinary text writes to an existing
+conversation. Later live HAR evidence added the distinct new-chat prepare shape,
+and normal new-chat and multimodal `ChatGPTWebClient.send()` writes now use that
+shape whenever a finalized Sentinel bundle provider is installed.
 
 The original PR7.11 regression remains useful: the evidence-only probe itself
 still performs no final conversation write.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatgpt-web-adapter"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python SDK for controlling existing ChatGPT web sessions without browser UI."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ Changelog = "https://github.com/kymuco/chatgpt-web-adapter/blob/main/CHANGELOG.m
 test = ["pytest>=8"]
 browser = ["zendriver==0.15.3"]
 
+[project.scripts]
+chatgpt-web-adapter = "chatgpt_web_adapter.cli:main"
+
 [tool.setuptools]
 package-dir = { "" = "src" }
 

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -6,6 +6,10 @@ from .approval_policy import ApprovalDecision, ApprovalPolicy
 from .approval_types import ApprovalEvent, ApprovalResult, ApprovalRound
 from .attach import attach_conversation as _attach_conversation
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
+from .auth_refresh import (
+    AuthRefreshResult,
+    refresh_auth_session as _refresh_auth_session,
+)
 from .browser_sentinel import ZendriverSentinelBundleProvider
 from .client import ChatGPTWebClient
 from .conversation_prepare import PrepareResult, prepare_text_turn
@@ -111,6 +115,7 @@ ChatGPTWebClient.prefetch_sentinel_bundle = _prefetch_finalized_sentinel_bundle
 ChatGPTWebClient.start_sentinel_bundle_refill = _start_finalized_sentinel_bundle_refill
 ChatGPTWebClient.set_sentinel_challenge_provider = _set_sentinel_challenge_provider
 ChatGPTWebClient.set_sentinel_bundle_provider = _set_sentinel_bundle_provider
+ChatGPTWebClient.refresh_auth = _refresh_auth_session
 ChatGPTWebClient._build_headers = _gate_prepared_build_headers(_original_build_headers)
 ChatGPTWebClient._sanitize_header_value = _redact_ephemeral_write_headers(
     _redact_web_session_headers(_original_sanitize_header_value)
@@ -127,7 +132,9 @@ ChatGPTWebClient.get_messages = _get_messages
 ChatGPTWebClient.get_pending_approval = _get_pending_approval
 ChatGPTWebClient.get_required_action = _get_required_action
 ChatGPTWebClient.get_status = _get_status
-ChatGPTWebClient.send = _send_with_expanded_metrics(_original_send)
+ChatGPTWebClient.send = _send_with_expanded_metrics(
+    _gate_prepared_text_send(_original_send, require_provider=False)
+)
 ChatGPTWebClient._send_existing_text_prepared = _send_with_expanded_metrics(
     _gate_prepared_text_send(_send_existing_text_prepared)
 )
@@ -212,6 +219,7 @@ EXPERIMENTAL_SENTINEL_EXPORTS = [
 ]
 
 SUPPORT_EXPORTS = [
+    "AuthRefreshResult",
     "DEFAULT_AUTH_FILE",
     "DEFAULT_MODEL",
     "load_auth_data",

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -6,10 +6,12 @@ from .approval_policy import ApprovalDecision, ApprovalPolicy
 from .approval_types import ApprovalEvent, ApprovalResult, ApprovalRound
 from .attach import attach_conversation as _attach_conversation
 from .auth import DEFAULT_AUTH_FILE, load_auth_data
+from .auth_browser import BrowserLoginResult, browser_login, default_browser_profile_dir
 from .auth_refresh import (
     AuthRefreshResult,
     refresh_auth_session as _refresh_auth_session,
 )
+from .auth_status import AuthStatus, get_auth_status
 from .browser_sentinel import ZendriverSentinelBundleProvider
 from .client import ChatGPTWebClient
 from .conversation_prepare import PrepareResult, prepare_text_turn
@@ -219,9 +221,14 @@ EXPERIMENTAL_SENTINEL_EXPORTS = [
 ]
 
 SUPPORT_EXPORTS = [
+    "AuthStatus",
     "AuthRefreshResult",
+    "BrowserLoginResult",
     "DEFAULT_AUTH_FILE",
     "DEFAULT_MODEL",
+    "browser_login",
+    "default_browser_profile_dir",
+    "get_auth_status",
     "load_auth_data",
 ]
 

--- a/src/chatgpt_web_adapter/auth.py
+++ b/src/chatgpt_web_adapter/auth.py
@@ -86,6 +86,13 @@ def _has_session_cookie(auth: AuthData) -> bool:
     )
 
 
+def _normalize_session_cookies(auth: AuthData) -> None:
+    """Prefer browser-issued chunked cookies over a non-chunked fallback."""
+
+    if any(name.startswith(f"{CHATGPT_SESSION_COOKIE}.") for name in auth.cookies):
+        auth.cookies.pop(CHATGPT_SESSION_COOKIE, None)
+
+
 def _seed_session_cookie_from_auth_file(auth: AuthData, auth_path: Path) -> None:
     """Best-effort mapping for a raw ``/api/auth/session`` JSON dump.
 
@@ -123,6 +130,7 @@ def load_auth_data(
         raise AuthError(f"Failed to parse auth data from {auth_path}: {error}") from error
 
     _seed_session_cookie_from_auth_file(auth, auth_path)
+    _normalize_session_cookies(auth)
 
     candidates: list[tuple[str, str]] = []
     if auth.accessToken:

--- a/src/chatgpt_web_adapter/auth.py
+++ b/src/chatgpt_web_adapter/auth.py
@@ -107,7 +107,11 @@ def _seed_session_cookie_from_auth_file(auth: AuthData, auth_path: Path) -> None
         auth.cookies[CHATGPT_SESSION_COOKIE] = session_token.strip()
 
 
-def load_auth_data(auth_file: str | Path = DEFAULT_AUTH_FILE) -> AuthData:
+def load_auth_data(
+    auth_file: str | Path = DEFAULT_AUTH_FILE,
+    *,
+    allow_expired_session_refresh: bool = False,
+) -> AuthData:
     auth_path = Path(auth_file)
     try:
         auth = AuthData.from_json(auth_path)
@@ -127,6 +131,8 @@ def load_auth_data(auth_file: str | Path = DEFAULT_AUTH_FILE) -> AuthData:
     if env_access_token and env_access_token != auth.accessToken:
         candidates.append((".env:accessToken", env_access_token))
 
+    auth.accessToken = None
+    auth.accessTokenSource = None
     expired_sources: list[str] = []
     now_utc = datetime.now(timezone.utc)
     for source, token in candidates:
@@ -142,6 +148,8 @@ def load_auth_data(auth_file: str | Path = DEFAULT_AUTH_FILE) -> AuthData:
         break
 
     if not auth.accessToken:
+        if allow_expired_session_refresh and _has_session_cookie(auth):
+            return auth
         if expired_sources:
             raise AuthError(
                 "All available access tokens are expired: "

--- a/src/chatgpt_web_adapter/auth_browser.py
+++ b/src/chatgpt_web_adapter/auth_browser.py
@@ -143,6 +143,7 @@ async def _browser_login_async(
     headless: bool,
     browser_executable_path: str | Path | None,
     persist: bool,
+    reuse_existing_auth: bool,
 ) -> BrowserLoginResult:
     zendriver = _import_zendriver()
     profile_dir.mkdir(parents=True, exist_ok=True)
@@ -154,7 +155,7 @@ async def _browser_login_async(
     try:
         seed_cookies: dict[str, str] = {}
         seed_expires: float | None = None
-        if auth_file.is_file():
+        if reuse_existing_auth and auth_file.is_file():
             try:
                 seed_auth = load_auth_data(
                     auth_file, allow_expired_session_refresh=True
@@ -163,7 +164,16 @@ async def _browser_login_async(
                 seed_expires = _session_expiry_timestamp(seed_auth.expires)
             except (AuthError, OSError, ValueError):
                 seed_cookies = {}
-        if seed_cookies:
+        if not reuse_existing_auth:
+            page = await browser.get("about:blank")
+            existing = await page.send(zendriver.cdp.network.get_all_cookies())
+            await _delete_session_cookies(
+                page,
+                zendriver,
+                [getattr(cookie, "name", "") for cookie in existing],
+            )
+            await page.get(CHAT_URL)
+        elif seed_cookies:
             page = await browser.get("about:blank")
             await _delete_session_cookies(page, zendriver, seed_auth.cookies)
             cookie_params = [
@@ -310,6 +320,7 @@ def browser_login(
     headless: bool = False,
     browser_executable_path: str | Path | None = None,
     persist: bool = True,
+    reuse_existing_auth: bool = True,
 ) -> BrowserLoginResult:
     """Open ChatGPT once, wait for sign-in, and persist reusable session auth."""
 
@@ -326,6 +337,7 @@ def browser_login(
                 headless=bool(headless),
                 browser_executable_path=browser_executable_path,
                 persist=bool(persist),
+                reuse_existing_auth=bool(reuse_existing_auth),
             )
         )
     raise AuthError("Synchronous browser_login cannot run inside an active asyncio event loop")

--- a/src/chatgpt_web_adapter/auth_browser.py
+++ b/src/chatgpt_web_adapter/auth_browser.py
@@ -11,6 +11,12 @@ from typing import Any
 
 from .auth import CHATGPT_SESSION_COOKIE, CHAT_URL, DEFAULT_AUTH_FILE, load_auth_data
 from .auth_store import persist_auth_data
+from .browser_cookies import (
+    browser_cookie_params,
+    flatten_browser_cookies,
+    serialize_browser_cookies,
+)
+from .browser_profile_lock import BrowserProfileLock
 from .exceptions import AuthError
 from .types import AuthData
 
@@ -54,21 +60,7 @@ def _import_zendriver() -> Any:
 
 
 def _cookie_dict(browser_cookies: Any) -> dict[str, str]:
-    captured: dict[str, str] = {}
-    if not isinstance(browser_cookies, list):
-        return captured
-    for cookie in browser_cookies:
-        domain = getattr(cookie, "domain", "")
-        name = getattr(cookie, "name", None)
-        value = getattr(cookie, "value", None)
-        if (
-            isinstance(domain, str)
-            and domain.lstrip(".").lower().endswith("chatgpt.com")
-            and isinstance(name, str)
-            and isinstance(value, str)
-        ):
-            captured[name] = value
-    return captured
+    return flatten_browser_cookies(serialize_browser_cookies(browser_cookies))
 
 
 def _valid_session_payload(value: Any) -> dict[str, Any] | None:
@@ -116,6 +108,11 @@ async def _graceful_browser_stop(browser: Any, zendriver: Any) -> None:
             await asyncio.sleep(0.1)
     except Exception:
         pass
+    try:
+        if not bool(getattr(connection, "closed", False)):
+            await connection.aclose()
+    except Exception:
+        pass
     await browser.stop()
 
 
@@ -144,16 +141,24 @@ async def _browser_login_async(
     browser_executable_path: str | Path | None,
     persist: bool,
     reuse_existing_auth: bool,
+    profile_lock_timeout: float,
 ) -> BrowserLoginResult:
     zendriver = _import_zendriver()
     profile_dir.mkdir(parents=True, exist_ok=True)
-    browser = await zendriver.start(
-        user_data_dir=str(profile_dir),
-        headless=headless,
-        browser_executable_path=browser_executable_path,
-    )
+    profile_lock = BrowserProfileLock(profile_dir, timeout=profile_lock_timeout)
     try:
+        await asyncio.to_thread(profile_lock.acquire)
+    except TimeoutError as error:
+        raise AuthError(str(error)) from error
+    browser: Any = None
+    try:
+        browser = await zendriver.start(
+            user_data_dir=str(profile_dir),
+            headless=headless,
+            browser_executable_path=browser_executable_path,
+        )
         seed_cookies: dict[str, str] = {}
+        seed_browser_cookies: list[dict[str, Any]] = []
         seed_expires: float | None = None
         if reuse_existing_auth and auth_file.is_file():
             try:
@@ -161,6 +166,7 @@ async def _browser_login_async(
                     auth_file, allow_expired_session_refresh=True
                 )
                 seed_cookies = seed_auth.cookies
+                seed_browser_cookies = seed_auth.browserCookies
                 seed_expires = _session_expiry_timestamp(seed_auth.expires)
             except (AuthError, OSError, ValueError):
                 seed_cookies = {}
@@ -176,21 +182,12 @@ async def _browser_login_async(
         elif seed_cookies:
             page = await browser.get("about:blank")
             await _delete_session_cookies(page, zendriver, seed_auth.cookies)
-            cookie_params = [
-                zendriver.cdp.network.CookieParam(
-                    name=str(name),
-                    value=str(value),
-                    url=CHAT_URL,
-                    secure=True,
-                    expires=(
-                        zendriver.cdp.network.TimeSinceEpoch(seed_expires)
-                        if seed_expires is not None
-                        else None
-                    ),
-                )
-                for name, value in seed_cookies.items()
-                if name is not None and value is not None
-            ]
+            cookie_params = browser_cookie_params(
+                zendriver.cdp,
+                seed_browser_cookies,
+                seed_cookies,
+                fallback_expires=seed_expires,
+            )
             await page.send(zendriver.cdp.network.set_cookies(cookie_params))
             await page.get(CHAT_URL)
         else:
@@ -228,7 +225,8 @@ async def _browser_login_async(
             )
 
         browser_cookies = await page.send(zendriver.cdp.network.get_all_cookies())
-        cookies = _cookie_dict(browser_cookies)
+        browser_cookie_records = serialize_browser_cookies(browser_cookies)
+        cookies = flatten_browser_cookies(browser_cookie_records)
         if not cookies:
             raise AuthError("Browser login succeeded but no ChatGPT cookies were captured")
         session_expiry = _session_expiry_timestamp(session.get("expires"))
@@ -257,6 +255,11 @@ async def _browser_login_async(
                 cookie
                 for cookie in captured_session_objects
                 if getattr(cookie, "name", "") != CHATGPT_SESSION_COOKIE
+            ]
+            browser_cookie_records = [
+                record
+                for record in browser_cookie_records
+                if record.get("name") != CHATGPT_SESSION_COOKIE
             ]
         user_agent = await page.evaluate(
             "window.navigator.userAgent", return_by_value=True
@@ -292,6 +295,7 @@ async def _browser_login_async(
             accessToken=session["accessToken"].strip(),
             accessTokenSource="browser-login:accessToken",
             cookies=cookies,
+            browserCookies=browser_cookie_records,
             headers=headers,
             expires=session.get("expires"),
         )
@@ -309,7 +313,9 @@ async def _browser_login_async(
             persisted=bool(persist),
         )
     finally:
-        await _graceful_browser_stop(browser, zendriver)
+        if browser is not None:
+            await _graceful_browser_stop(browser, zendriver)
+        await asyncio.to_thread(profile_lock.release)
 
 
 def browser_login(
@@ -321,6 +327,7 @@ def browser_login(
     browser_executable_path: str | Path | None = None,
     persist: bool = True,
     reuse_existing_auth: bool = True,
+    profile_lock_timeout: float = 30.0,
 ) -> BrowserLoginResult:
     """Open ChatGPT once, wait for sign-in, and persist reusable session auth."""
 
@@ -338,6 +345,7 @@ def browser_login(
                 browser_executable_path=browser_executable_path,
                 persist=bool(persist),
                 reuse_existing_auth=bool(reuse_existing_auth),
+                profile_lock_timeout=float(profile_lock_timeout),
             )
         )
     raise AuthError("Synchronous browser_login cannot run inside an active asyncio event loop")

--- a/src/chatgpt_web_adapter/auth_browser.py
+++ b/src/chatgpt_web_adapter/auth_browser.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .auth import CHATGPT_SESSION_COOKIE, CHAT_URL, DEFAULT_AUTH_FILE, load_auth_data
+from .auth_store import persist_auth_data
+from .exceptions import AuthError
+from .types import AuthData
+
+SESSION_SCRIPT = """
+fetch('/api/auth/session', {credentials: 'include', cache: 'no-store'})
+  .then(async response => ({status: response.status, body: await response.json()}))
+  .catch(error => ({status: 0, error: String(error)}))
+"""
+
+
+@dataclass(frozen=True)
+class BrowserLoginResult:
+    auth: AuthData
+    auth_file: Path
+    profile_dir: Path
+    persisted: bool
+
+
+def default_browser_profile_dir() -> Path:
+    configured = os.getenv("CHATGPT_WEB_ADAPTER_PROFILE_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    if sys.platform == "win32":
+        root = Path(os.getenv("LOCALAPPDATA") or (Path.home() / "AppData" / "Local"))
+        return root / "chatgpt-web-adapter" / "browser-profile"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "chatgpt-web-adapter" / "browser-profile"
+    state_root = Path(os.getenv("XDG_STATE_HOME") or (Path.home() / ".local" / "state"))
+    return state_root / "chatgpt-web-adapter" / "browser-profile"
+
+
+def _import_zendriver() -> Any:
+    try:
+        import zendriver
+    except ImportError as error:
+        raise AuthError(
+            "Browser login requires the optional browser extra: "
+            "pip install 'chatgpt-web-adapter[browser]'"
+        ) from error
+    return zendriver
+
+
+def _cookie_dict(browser_cookies: Any) -> dict[str, str]:
+    captured: dict[str, str] = {}
+    if not isinstance(browser_cookies, list):
+        return captured
+    for cookie in browser_cookies:
+        domain = getattr(cookie, "domain", "")
+        name = getattr(cookie, "name", None)
+        value = getattr(cookie, "value", None)
+        if (
+            isinstance(domain, str)
+            and domain.lstrip(".").lower().endswith("chatgpt.com")
+            and isinstance(name, str)
+            and isinstance(value, str)
+        ):
+            captured[name] = value
+    return captured
+
+
+def _valid_session_payload(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict) or int(value.get("status") or 0) != 200:
+        return None
+    body = value.get("body")
+    if not isinstance(body, dict):
+        return None
+    access_token = body.get("accessToken")
+    session_token = body.get("sessionToken")
+    if not isinstance(access_token, str) or not access_token.strip():
+        return None
+    if not isinstance(session_token, str) or not session_token.strip():
+        return None
+    return body
+
+
+def _session_expiry_timestamp(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+async def _graceful_browser_stop(browser: Any, zendriver: Any) -> None:
+    """Give Chromium time to flush a custom profile before zendriver terminates it."""
+
+    connection = getattr(browser, "connection", None)
+    process = getattr(browser, "_process", None)
+    if connection is None or process is None:
+        await browser.stop()
+        return
+    try:
+        await connection.send(zendriver.cdp.browser.close())
+        for _ in range(100):
+            if getattr(process, "returncode", None) is not None:
+                break
+            await asyncio.sleep(0.1)
+    except Exception:
+        pass
+    await browser.stop()
+
+
+async def _delete_session_cookies(page: Any, zendriver: Any, names: Any) -> None:
+    for name in names:
+        if name == CHATGPT_SESSION_COOKIE or str(name).startswith(
+            f"{CHATGPT_SESSION_COOKIE}."
+        ):
+            for domain in ("chatgpt.com", ".chatgpt.com"):
+                try:
+                    await page.send(
+                        zendriver.cdp.network.delete_cookies(
+                            str(name), domain=domain, path="/"
+                        )
+                    )
+                except Exception:
+                    pass
+
+
+async def _browser_login_async(
+    *,
+    auth_file: Path,
+    profile_dir: Path,
+    timeout: float,
+    headless: bool,
+    browser_executable_path: str | Path | None,
+    persist: bool,
+) -> BrowserLoginResult:
+    zendriver = _import_zendriver()
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    browser = await zendriver.start(
+        user_data_dir=str(profile_dir),
+        headless=headless,
+        browser_executable_path=browser_executable_path,
+    )
+    try:
+        seed_cookies: dict[str, str] = {}
+        seed_expires: float | None = None
+        if auth_file.is_file():
+            try:
+                seed_auth = load_auth_data(
+                    auth_file, allow_expired_session_refresh=True
+                )
+                seed_cookies = seed_auth.cookies
+                seed_expires = _session_expiry_timestamp(seed_auth.expires)
+            except (AuthError, OSError, ValueError):
+                seed_cookies = {}
+        if seed_cookies:
+            page = await browser.get("about:blank")
+            await _delete_session_cookies(page, zendriver, seed_auth.cookies)
+            cookie_params = [
+                zendriver.cdp.network.CookieParam(
+                    name=str(name),
+                    value=str(value),
+                    url=CHAT_URL,
+                    secure=True,
+                    expires=(
+                        zendriver.cdp.network.TimeSinceEpoch(seed_expires)
+                        if seed_expires is not None
+                        else None
+                    ),
+                )
+                for name, value in seed_cookies.items()
+                if name is not None and value is not None
+            ]
+            await page.send(zendriver.cdp.network.set_cookies(cookie_params))
+            await page.get(CHAT_URL)
+        else:
+            page = await browser.get(CHAT_URL)
+        deadline = time.monotonic() + timeout
+        seeded_session_deadline = time.monotonic() + 8.0 if seed_cookies else None
+        cleared_invalid_seed = False
+        session: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            try:
+                session = _valid_session_payload(
+                    await page.evaluate(
+                        SESSION_SCRIPT,
+                        await_promise=True,
+                        return_by_value=True,
+                    )
+                )
+            except Exception:
+                session = None
+            if session is not None:
+                break
+            if (
+                seeded_session_deadline is not None
+                and not cleared_invalid_seed
+                and time.monotonic() >= seeded_session_deadline
+            ):
+                await _delete_session_cookies(page, zendriver, seed_auth.cookies)
+                cleared_invalid_seed = True
+                await page.get(CHAT_URL)
+            await asyncio.sleep(1.0)
+        if session is None:
+            raise AuthError(
+                "Browser login timed out. Complete sign-in in the opened ChatGPT window "
+                "and keep it open until authorization is saved."
+            )
+
+        browser_cookies = await page.send(zendriver.cdp.network.get_all_cookies())
+        cookies = _cookie_dict(browser_cookies)
+        if not cookies:
+            raise AuthError("Browser login succeeded but no ChatGPT cookies were captured")
+        session_expiry = _session_expiry_timestamp(session.get("expires"))
+        captured_session_cookies = {
+            name: value
+            for name, value in cookies.items()
+            if name == CHATGPT_SESSION_COOKIE
+            or name.startswith(f"{CHATGPT_SESSION_COOKIE}.")
+        }
+        captured_session_objects = [
+            cookie
+            for cookie in browser_cookies
+            if getattr(cookie, "name", "") == CHATGPT_SESSION_COOKIE
+            or getattr(cookie, "name", "").startswith(f"{CHATGPT_SESSION_COOKIE}.")
+        ]
+        if any(
+            getattr(cookie, "name", "").startswith(f"{CHATGPT_SESSION_COOKIE}.")
+            for cookie in captured_session_objects
+        ):
+            await _delete_session_cookies(
+                page, zendriver, [CHATGPT_SESSION_COOKIE]
+            )
+            cookies.pop(CHATGPT_SESSION_COOKIE, None)
+            captured_session_cookies.pop(CHATGPT_SESSION_COOKIE, None)
+            captured_session_objects = [
+                cookie
+                for cookie in captured_session_objects
+                if getattr(cookie, "name", "") != CHATGPT_SESSION_COOKIE
+            ]
+        user_agent = await page.evaluate(
+            "window.navigator.userAgent", return_by_value=True
+        )
+        if captured_session_cookies and session_expiry is not None:
+            await page.get("about:blank")
+            await page.send(
+                zendriver.cdp.network.set_cookies(
+                    [
+                        zendriver.cdp.network.CookieParam(
+                            name=str(getattr(cookie, "name")),
+                            value=str(getattr(cookie, "value")),
+                            domain=str(getattr(cookie, "domain")),
+                            path=str(getattr(cookie, "path", "/")),
+                            secure=bool(getattr(cookie, "secure", True)),
+                            http_only=bool(getattr(cookie, "http_only", True)),
+                            expires=zendriver.cdp.network.TimeSinceEpoch(
+                                session_expiry
+                            ),
+                        )
+                        for cookie in captured_session_objects
+                    ]
+                )
+            )
+        headers = {
+            "accept": "*/*",
+            "accept-language": "en-US,en;q=0.8",
+            "referer": CHAT_URL,
+        }
+        if isinstance(user_agent, str) and user_agent.strip():
+            headers["user-agent"] = user_agent.strip()
+        auth = AuthData(
+            accessToken=session["accessToken"].strip(),
+            accessTokenSource="browser-login:accessToken",
+            cookies=cookies,
+            headers=headers,
+            expires=session.get("expires"),
+        )
+        if persist:
+            persist_auth_data(
+                auth,
+                auth_file,
+                session_token=session["sessionToken"].strip(),
+                session_expires_at=session.get("expires"),
+            )
+        return BrowserLoginResult(
+            auth=auth,
+            auth_file=auth_file,
+            profile_dir=profile_dir,
+            persisted=bool(persist),
+        )
+    finally:
+        await _graceful_browser_stop(browser, zendriver)
+
+
+def browser_login(
+    auth_file: str | Path = DEFAULT_AUTH_FILE,
+    *,
+    profile_dir: str | Path | None = None,
+    timeout: float = 300.0,
+    headless: bool = False,
+    browser_executable_path: str | Path | None = None,
+    persist: bool = True,
+) -> BrowserLoginResult:
+    """Open ChatGPT once, wait for sign-in, and persist reusable session auth."""
+
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(
+            _browser_login_async(
+                auth_file=Path(auth_file),
+                profile_dir=Path(profile_dir) if profile_dir is not None else default_browser_profile_dir(),
+                timeout=float(timeout),
+                headless=bool(headless),
+                browser_executable_path=browser_executable_path,
+                persist=bool(persist),
+            )
+        )
+    raise AuthError("Synchronous browser_login cannot run inside an active asyncio event loop")

--- a/src/chatgpt_web_adapter/auth_refresh.py
+++ b/src/chatgpt_web_adapter/auth_refresh.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .auth import (
+    CHATGPT_SESSION_COOKIE,
+    CHAT_URL,
+    _get_access_token_expiry,
+)
+from .exceptions import AuthError
+from .web_session import _sync_device_header, suppress_web_session_debug_trace
+
+SESSION_URL = f"{CHAT_URL.rstrip('/')}/api/auth/session"
+AUTH_REFRESH_SKEW_SECONDS = 300
+_AUTH_FILE_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class AuthRefreshResult:
+    status_code: int
+    access_token_present: bool
+    session_token_rotated: bool
+    expires_present: bool
+    persisted: bool
+
+
+def auth_needs_refresh(access_token: str | None, *, now: datetime | None = None) -> bool:
+    if not isinstance(access_token, str) or not access_token.strip():
+        return True
+    expires_at = _get_access_token_expiry(access_token)
+    if expires_at is None:
+        return False
+    current = datetime.now(timezone.utc) if now is None else now.astimezone(timezone.utc)
+    return expires_at <= current + timedelta(seconds=AUTH_REFRESH_SKEW_SECONDS)
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing_mode: int | None = None
+    try:
+        existing_mode = path.stat().st_mode
+    except OSError:
+        pass
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+            temporary_path = Path(stream.name)
+        if existing_mode is not None:
+            os.chmod(temporary_path, existing_mode)
+        elif os.name != "nt":
+            os.chmod(temporary_path, 0o600)
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _persist_refreshed_auth(
+    client: Any,
+    path: Path,
+    response: dict[str, Any],
+) -> None:
+    with _AUTH_FILE_LOCK:
+        try:
+            current = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
+        except (OSError, ValueError) as error:
+            raise AuthError(f"Failed to read auth data before refresh: {error}") from error
+        if not isinstance(current, dict):
+            current = {}
+        current["accessToken"] = response["accessToken"].strip()
+        current["sessionToken"] = response["sessionToken"].strip()
+        if response.get("expires") is not None:
+            current["expires"] = response["expires"]
+        current["cookies"] = dict(getattr(client.auth, "cookies", {}) or {})
+        current["headers"] = dict(getattr(client.auth, "headers", {}) or {})
+        current.pop("proof_token", None)
+        current.pop("turnstile_token", None)
+        _atomic_write_json(path, current)
+
+
+def refresh_auth_session(
+    client: Any,
+    *,
+    persist: bool = True,
+    auth_file: str | Path | None = None,
+) -> AuthRefreshResult:
+    """Refresh access/session credentials through the live session endpoint."""
+
+    cookies = getattr(getattr(client, "auth", None), "cookies", None)
+    if not isinstance(cookies, dict) or not any(
+        name == CHATGPT_SESSION_COOKIE or name.startswith(f"{CHATGPT_SESSION_COOKIE}.")
+        for name in cookies
+    ):
+        raise AuthError("Session refresh requires a ChatGPT session cookie")
+    previous_session = cookies.get(CHATGPT_SESSION_COOKIE)
+    headers = client._build_headers(
+        {
+            "accept": "application/json",
+            "content-type": None,
+            "origin": CHAT_URL.rstrip("/"),
+            "referer": CHAT_URL,
+        }
+    )
+    headers.pop("content-type", None)
+    with suppress_web_session_debug_trace():
+        status, data = client._json_request("GET", SESSION_URL, None, headers)
+    if int(status) != 200 or not isinstance(data, dict):
+        raise AuthError(f"ChatGPT session refresh failed: status={status}")
+    access_token = data.get("accessToken")
+    session_token = data.get("sessionToken")
+    if not isinstance(access_token, str) or not access_token.strip():
+        raise AuthError("ChatGPT session refresh response has no accessToken")
+    if not isinstance(session_token, str) or not session_token.strip():
+        raise AuthError("ChatGPT session refresh response has no sessionToken")
+
+    client.auth.accessToken = access_token.strip()
+    client.auth.accessTokenSource = "session-refresh:accessToken"
+    client.auth.expires = data.get("expires")
+    for name in list(client.auth.cookies):
+        if name == CHATGPT_SESSION_COOKIE or name.startswith(f"{CHATGPT_SESSION_COOKIE}."):
+            del client.auth.cookies[name]
+    client.auth.cookies[CHATGPT_SESSION_COOKIE] = session_token.strip()
+    _sync_device_header(client)
+
+    target = Path(auth_file) if auth_file is not None else getattr(client, "auth_file", None)
+    persisted = bool(persist and isinstance(target, Path))
+    if persisted:
+        _persist_refreshed_auth(client, target, data)
+    return AuthRefreshResult(
+        status_code=int(status),
+        access_token_present=True,
+        session_token_rotated=previous_session != session_token.strip(),
+        expires_present=data.get("expires") is not None,
+        persisted=persisted,
+    )

--- a/src/chatgpt_web_adapter/auth_refresh.py
+++ b/src/chatgpt_web_adapter/auth_refresh.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import json
-import os
-import tempfile
-import threading
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -15,11 +11,11 @@ from .auth import (
     _get_access_token_expiry,
 )
 from .exceptions import AuthError
+from .auth_store import persist_auth_data
 from .web_session import _sync_device_header, suppress_web_session_debug_trace
 
 SESSION_URL = f"{CHAT_URL.rstrip('/')}/api/auth/session"
 AUTH_REFRESH_SKEW_SECONDS = 300
-_AUTH_FILE_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -41,63 +37,17 @@ def auth_needs_refresh(access_token: str | None, *, now: datetime | None = None)
     return expires_at <= current + timedelta(seconds=AUTH_REFRESH_SKEW_SECONDS)
 
 
-def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    existing_mode: int | None = None
-    try:
-        existing_mode = path.stat().st_mode
-    except OSError:
-        pass
-    temporary_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w",
-            encoding="utf-8",
-            dir=path.parent,
-            prefix=f".{path.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as stream:
-            json.dump(payload, stream, ensure_ascii=False, indent=2)
-            stream.write("\n")
-            stream.flush()
-            os.fsync(stream.fileno())
-            temporary_path = Path(stream.name)
-        if existing_mode is not None:
-            os.chmod(temporary_path, existing_mode)
-        elif os.name != "nt":
-            os.chmod(temporary_path, 0o600)
-        os.replace(temporary_path, path)
-        temporary_path = None
-    finally:
-        if temporary_path is not None:
-            try:
-                temporary_path.unlink(missing_ok=True)
-            except OSError:
-                pass
-
-
 def _persist_refreshed_auth(
     client: Any,
     path: Path,
     response: dict[str, Any],
 ) -> None:
-    with _AUTH_FILE_LOCK:
-        try:
-            current = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
-        except (OSError, ValueError) as error:
-            raise AuthError(f"Failed to read auth data before refresh: {error}") from error
-        if not isinstance(current, dict):
-            current = {}
-        current["accessToken"] = response["accessToken"].strip()
-        current["sessionToken"] = response["sessionToken"].strip()
-        if response.get("expires") is not None:
-            current["expires"] = response["expires"]
-        current["cookies"] = dict(getattr(client.auth, "cookies", {}) or {})
-        current["headers"] = dict(getattr(client.auth, "headers", {}) or {})
-        current.pop("proof_token", None)
-        current.pop("turnstile_token", None)
-        _atomic_write_json(path, current)
+    persist_auth_data(
+        client.auth,
+        path,
+        session_token=response["sessionToken"].strip(),
+        session_expires_at=response.get("expires"),
+    )
 
 
 def refresh_auth_session(
@@ -138,10 +88,6 @@ def refresh_auth_session(
     client.auth.accessToken = access_token.strip()
     client.auth.accessTokenSource = "session-refresh:accessToken"
     client.auth.expires = data.get("expires")
-    for name in list(client.auth.cookies):
-        if name == CHATGPT_SESSION_COOKIE or name.startswith(f"{CHATGPT_SESSION_COOKIE}."):
-            del client.auth.cookies[name]
-    client.auth.cookies[CHATGPT_SESSION_COOKIE] = session_token.strip()
     _sync_device_header(client)
 
     target = Path(auth_file) if auth_file is not None else getattr(client, "auth_file", None)

--- a/src/chatgpt_web_adapter/auth_status.py
+++ b/src/chatgpt_web_adapter/auth_status.py
@@ -12,6 +12,7 @@ from .auth import (
     _get_access_token_expiry,
 )
 from .auth_refresh import auth_needs_refresh
+from .auth_browser import default_browser_profile_dir
 from .types import AuthData
 
 
@@ -24,12 +25,26 @@ class AuthStatus:
     access_token_needs_refresh: bool
     session_cookie_present: bool
     session_expires_at: Any = None
+    browser_cookie_count: int = 0
+    browser_profile_dir: Path | None = None
+    browser_profile_exists: bool = False
 
 
-def get_auth_status(auth_file: str | Path = DEFAULT_AUTH_FILE) -> AuthStatus:
+def get_auth_status(
+    auth_file: str | Path = DEFAULT_AUTH_FILE,
+    *,
+    profile_dir: str | Path | None = None,
+) -> AuthStatus:
     path = Path(auth_file)
+    profile = (
+        Path(profile_dir)
+        if profile_dir is not None
+        else default_browser_profile_dir()
+    )
     if not path.is_file():
-        return AuthStatus(path, False, False, None, True, False, None)
+        return AuthStatus(
+            path, False, False, None, True, False, None, 0, profile, profile.is_dir()
+        )
     auth = AuthData.from_json(path)
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
@@ -51,4 +66,7 @@ def get_auth_status(auth_file: str | Path = DEFAULT_AUTH_FILE) -> AuthStatus:
         access_token_needs_refresh=auth_needs_refresh(auth.accessToken),
         session_cookie_present=has_session,
         session_expires_at=auth.expires,
+        browser_cookie_count=len(auth.browserCookies),
+        browser_profile_dir=profile,
+        browser_profile_exists=profile.is_dir(),
     )

--- a/src/chatgpt_web_adapter/auth_status.py
+++ b/src/chatgpt_web_adapter/auth_status.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .auth import (
+    CHATGPT_SESSION_COOKIE,
+    DEFAULT_AUTH_FILE,
+    _get_access_token_expiry,
+)
+from .auth_refresh import auth_needs_refresh
+from .types import AuthData
+
+
+@dataclass(frozen=True)
+class AuthStatus:
+    auth_file: Path
+    file_exists: bool
+    access_token_present: bool
+    access_token_expires_at: datetime | None
+    access_token_needs_refresh: bool
+    session_cookie_present: bool
+    session_expires_at: Any = None
+
+
+def get_auth_status(auth_file: str | Path = DEFAULT_AUTH_FILE) -> AuthStatus:
+    path = Path(auth_file)
+    if not path.is_file():
+        return AuthStatus(path, False, False, None, True, False, None)
+    auth = AuthData.from_json(path)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        raw = {}
+    has_session = any(
+        name == CHATGPT_SESSION_COOKIE or name.startswith(f"{CHATGPT_SESSION_COOKIE}.")
+        for name in auth.cookies
+    )
+    if not has_session and isinstance(raw, dict):
+        session_token = raw.get("sessionToken")
+        has_session = isinstance(session_token, str) and bool(session_token.strip())
+    expires_at = _get_access_token_expiry(auth.accessToken)
+    return AuthStatus(
+        auth_file=path,
+        file_exists=True,
+        access_token_present=bool(auth.accessToken),
+        access_token_expires_at=expires_at,
+        access_token_needs_refresh=auth_needs_refresh(auth.accessToken),
+        session_cookie_present=has_session,
+        session_expires_at=auth.expires,
+    )

--- a/src/chatgpt_web_adapter/auth_store.py
+++ b/src/chatgpt_web_adapter/auth_store.py
@@ -70,6 +70,11 @@ def persist_auth_data(
 
         access_token = getattr(auth, "accessToken", None)
         cookies = dict(getattr(auth, "cookies", {}) or {})
+        browser_cookies = [
+            dict(item)
+            for item in (getattr(auth, "browserCookies", []) or [])
+            if isinstance(item, dict)
+        ]
         headers = dict(getattr(auth, "headers", {}) or {})
         if isinstance(access_token, str) and access_token.strip():
             current["accessToken"] = access_token.strip()
@@ -91,6 +96,7 @@ def persist_auth_data(
             current["sessionExpiresAt"] = session_expires_at
         current["timestamp"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         current["cookies"] = cookies
+        current["browserCookies"] = browser_cookies
         current["headers"] = headers
         current.pop("proof_token", None)
         current.pop("turnstile_token", None)

--- a/src/chatgpt_web_adapter/auth_store.py
+++ b/src/chatgpt_web_adapter/auth_store.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .auth import CHATGPT_SESSION_COOKIE, _get_access_token_expiry
+from .exceptions import AuthError
+
+_AUTH_FILE_LOCK = threading.Lock()
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing_mode: int | None = None
+    try:
+        existing_mode = path.stat().st_mode
+    except OSError:
+        pass
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            json.dump(payload, stream, ensure_ascii=False, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+            temporary_path = Path(stream.name)
+        if existing_mode is not None:
+            os.chmod(temporary_path, existing_mode)
+        elif os.name != "nt":
+            os.chmod(temporary_path, 0o600)
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def persist_auth_data(
+    auth: Any,
+    auth_file: str | Path,
+    *,
+    session_token: str | None = None,
+    session_expires_at: Any = None,
+) -> Path:
+    """Atomically persist reusable auth state while preserving unknown fields."""
+
+    path = Path(auth_file)
+    with _AUTH_FILE_LOCK:
+        try:
+            current = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
+        except (OSError, ValueError) as error:
+            raise AuthError(f"Failed to read auth data before saving: {error}") from error
+        if not isinstance(current, dict):
+            current = {}
+
+        access_token = getattr(auth, "accessToken", None)
+        cookies = dict(getattr(auth, "cookies", {}) or {})
+        headers = dict(getattr(auth, "headers", {}) or {})
+        if isinstance(access_token, str) and access_token.strip():
+            current["accessToken"] = access_token.strip()
+            access_expires = _get_access_token_expiry(access_token)
+            if access_expires is not None:
+                current["accessTokenExpiresAt"] = access_expires.isoformat().replace(
+                    "+00:00", "Z"
+                )
+        if session_token is None:
+            cookie_token = cookies.get(CHATGPT_SESSION_COOKIE)
+            if isinstance(cookie_token, str) and cookie_token.strip():
+                session_token = cookie_token
+        if isinstance(session_token, str) and session_token.strip():
+            current["sessionToken"] = session_token.strip()
+        if session_expires_at is None:
+            session_expires_at = getattr(auth, "expires", None)
+        if session_expires_at is not None:
+            current["expires"] = session_expires_at
+            current["sessionExpiresAt"] = session_expires_at
+        current["timestamp"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        current["cookies"] = cookies
+        current["headers"] = headers
+        current.pop("proof_token", None)
+        current.pop("turnstile_token", None)
+        _atomic_write_json(path, current)
+    return path

--- a/src/chatgpt_web_adapter/browser_cookies.py
+++ b/src/chatgpt_web_adapter/browser_cookies.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .auth import CHAT_URL
+
+_COOKIE_FIELDS = (
+    "name",
+    "value",
+    "domain",
+    "path",
+    "secure",
+    "http_only",
+    "same_site",
+    "expires",
+    "priority",
+    "same_party",
+    "source_scheme",
+    "source_port",
+)
+
+
+def serialize_browser_cookies(browser_cookies: Any) -> list[dict[str, Any]]:
+    """Keep portable CDP cookie attributes without persisting runtime objects."""
+
+    records: list[dict[str, Any]] = []
+    if not isinstance(browser_cookies, list):
+        return records
+    for cookie in browser_cookies:
+        domain = getattr(cookie, "domain", "")
+        name = getattr(cookie, "name", None)
+        value = getattr(cookie, "value", None)
+        if not (
+            isinstance(domain, str)
+            and domain.lstrip(".").lower().endswith("chatgpt.com")
+            and isinstance(name, str)
+            and isinstance(value, str)
+        ):
+            continue
+        record: dict[str, Any] = {}
+        for field in _COOKIE_FIELDS:
+            item = getattr(cookie, field, None)
+            if item is None:
+                continue
+            if hasattr(item, "value"):
+                item = item.value
+            if isinstance(item, (str, int, float, bool)):
+                record[field] = item
+        record.setdefault("path", "/")
+        records.append(record)
+    dotted_session_names = {
+        str(record.get("name"))
+        for record in records
+        if "session-token" in str(record.get("name", ""))
+        and str(record.get("domain", "")).startswith(".")
+    }
+    if dotted_session_names:
+        records = [
+            record
+            for record in records
+            if not (
+                str(record.get("name")) in dotted_session_names
+                and not str(record.get("domain", "")).startswith(".")
+            )
+        ]
+    return records
+
+
+def flatten_browser_cookies(records: Any) -> dict[str, str]:
+    cookies: dict[str, str] = {}
+    if not isinstance(records, list):
+        return cookies
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        name = record.get("name")
+        value = record.get("value")
+        domain = record.get("domain", "")
+        if (
+            isinstance(name, str)
+            and isinstance(value, str)
+            and isinstance(domain, str)
+            and domain.lstrip(".").lower().endswith("chatgpt.com")
+        ):
+            cookies[name] = value
+    return cookies
+
+
+def browser_cookie_params(
+    cdp: Any,
+    records: Any,
+    fallback_cookies: dict[str, str],
+    *,
+    fallback_expires: float | None = None,
+) -> list[Any]:
+    """Build CDP cookie parameters, preferring domain-aware saved records."""
+
+    params: list[Any] = []
+    if isinstance(records, list):
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            name = record.get("name")
+            value = record.get("value")
+            domain = record.get("domain")
+            if not all(isinstance(item, str) and item for item in (name, value, domain)):
+                continue
+            kwargs: dict[str, Any] = {
+                "name": name,
+                "value": value,
+                "domain": domain,
+                "path": str(record.get("path") or "/"),
+                "secure": bool(record.get("secure", True)),
+                "http_only": bool(record.get("http_only", False)),
+            }
+            expires = record.get("expires")
+            if isinstance(expires, (int, float)) and float(expires) > 0:
+                kwargs["expires"] = cdp.network.TimeSinceEpoch(float(expires))
+            elif fallback_expires is not None:
+                kwargs["expires"] = cdp.network.TimeSinceEpoch(fallback_expires)
+            enum_fields = (
+                ("same_site", "CookieSameSite"),
+                ("priority", "CookiePriority"),
+                ("source_scheme", "CookieSourceScheme"),
+            )
+            for field, enum_name in enum_fields:
+                enum_type = getattr(cdp.network, enum_name, None)
+                raw = record.get(field)
+                if enum_type is not None and isinstance(raw, str):
+                    try:
+                        kwargs[field] = enum_type(raw)
+                    except ValueError:
+                        pass
+            for field in ("same_party", "source_port"):
+                if field in record:
+                    kwargs[field] = record[field]
+            params.append(cdp.network.CookieParam(**kwargs))
+    if params:
+        return params
+    return [
+        cdp.network.CookieParam(
+            name=str(name),
+            value=str(value),
+            url=CHAT_URL,
+            secure=True,
+            expires=(
+                cdp.network.TimeSinceEpoch(fallback_expires)
+                if fallback_expires is not None
+                else None
+            ),
+        )
+        for name, value in fallback_cookies.items()
+        if name is not None and value is not None
+    ]

--- a/src/chatgpt_web_adapter/browser_profile_lock.py
+++ b/src/chatgpt_web_adapter/browser_profile_lock.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+
+class BrowserProfileLock:
+    """Cross-process exclusive lock for one Chromium user-data directory."""
+
+    def __init__(self, profile_dir: str | Path, *, timeout: float = 30.0) -> None:
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+        profile = Path(profile_dir)
+        self.path = profile.parent / f".{profile.name}.lock"
+        self.timeout = float(timeout)
+        self._stream = None
+
+    def acquire(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        stream = self.path.open("a+b")
+        if stream.tell() == 0:
+            stream.write(b"0")
+            stream.flush()
+        deadline = time.monotonic() + self.timeout
+        while True:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    stream.seek(0)
+                    msvcrt.locking(stream.fileno(), msvcrt.LK_NBLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(stream.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                self._stream = stream
+                return
+            except (BlockingIOError, OSError):
+                if time.monotonic() >= deadline:
+                    stream.close()
+                    raise TimeoutError(
+                        f"Browser profile is busy: {self.path.parent}"
+                    )
+                time.sleep(0.1)
+
+    def release(self) -> None:
+        stream = self._stream
+        if stream is None:
+            return
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                stream.seek(0)
+                msvcrt.locking(stream.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
+        finally:
+            stream.close()
+            self._stream = None
+
+    def __enter__(self) -> "BrowserProfileLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.release()

--- a/src/chatgpt_web_adapter/browser_sentinel.py
+++ b/src/chatgpt_web_adapter/browser_sentinel.py
@@ -5,10 +5,13 @@ import base64
 import json
 import tempfile
 import time
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
 from .auth import CHAT_URL
+from .auth_browser import _session_expiry_timestamp
+from .auth_store import persist_auth_data
 from .exceptions import RequestError
 from .sentinel_requirements import SENTINEL_FINALIZE_PATH
 from .sentinel_transaction import (
@@ -97,12 +100,14 @@ class ZendriverSentinelBundleProvider:
         timeout: float = 45.0,
         headless: bool = False,
         browser_executable_path: str | Path | None = None,
+        profile_dir: str | Path | None = None,
     ) -> None:
         if timeout <= 0:
             raise ValueError("timeout must be positive")
         self.timeout = float(timeout)
         self.headless = bool(headless)
         self.browser_executable_path = browser_executable_path
+        self.profile_dir = Path(profile_dir) if profile_dir is not None else None
 
     def __call__(self, client: Any) -> FinalizedSentinelBundle:
         try:
@@ -215,6 +220,36 @@ class ZendriverSentinelBundleProvider:
                 )
             )
 
+        def on_request_paused(event: Any, page: Any = None) -> None:
+            request = getattr(event, "request", None)
+            url = getattr(request, "url", "") if request is not None else ""
+
+            async def resolve_paused_request(command: Any) -> None:
+                try:
+                    await active_page.send(command)
+                except Exception:
+                    # The page may finish/cancel a paused request before the CDP
+                    # continuation task runs, especially during browser shutdown.
+                    pass
+
+            if url.rstrip("/").endswith(
+                ("/backend-api/f/conversation", "/backend-api/conversation")
+            ):
+                loop.create_task(
+                    resolve_paused_request(
+                        cdp.fetch.fail_request(
+                            event.request_id,
+                            cdp.network.ErrorReason.ABORTED,
+                        )
+                    )
+                )
+            else:
+                loop.create_task(
+                    resolve_paused_request(
+                        cdp.fetch.continue_request(event.request_id)
+                    )
+                )
+
         cookies = getattr(getattr(client, "auth", None), "cookies", None)
         if not isinstance(cookies, dict) or not cookies:
             raise RequestError(
@@ -223,7 +258,14 @@ class ZendriverSentinelBundleProvider:
                 request_stage="sentinel_bundle_provider",
             )
 
-        with tempfile.TemporaryDirectory(prefix="chatgpt-web-adapter-") as profile_dir:
+        profile_context = (
+            nullcontext(str(self.profile_dir))
+            if self.profile_dir is not None
+            else tempfile.TemporaryDirectory(prefix="chatgpt-web-adapter-")
+        )
+        if self.profile_dir is not None:
+            self.profile_dir.mkdir(parents=True, exist_ok=True)
+        with profile_context as profile_dir:
             browser = await zendriver.start(
                 user_data_dir=profile_dir,
                 headless=self.headless,
@@ -233,13 +275,32 @@ class ZendriverSentinelBundleProvider:
                 active_page = await browser.get("about:blank")
                 active_page.add_handler(cdp.network.RequestWillBeSent, on_request)
                 active_page.add_handler(cdp.network.ResponseReceived, on_response)
+                active_page.add_handler(cdp.fetch.RequestPaused, on_request_paused)
                 await active_page.send(cdp.network.enable())
+                await active_page.send(
+                    cdp.fetch.enable(
+                        patterns=[
+                            cdp.fetch.RequestPattern(
+                                url_pattern="*://chatgpt.com/backend-api/*conversation*",
+                                request_stage=cdp.fetch.RequestStage.REQUEST,
+                            )
+                        ]
+                    )
+                )
+                session_expiry = _session_expiry_timestamp(
+                    getattr(getattr(client, "auth", None), "expires", None)
+                )
                 cookie_params = [
                     cdp.network.CookieParam(
                         name=str(name),
                         value=str(value),
                         url=CHAT_URL,
                         secure=True,
+                        expires=(
+                            cdp.network.TimeSinceEpoch(session_expiry)
+                            if session_expiry is not None
+                            else None
+                        ),
                     )
                     for name, value in cookies.items()
                     if name is not None and value is not None
@@ -257,15 +318,29 @@ class ZendriverSentinelBundleProvider:
                 if not captured.done():
                     try:
                         probe_input = await active_page.select(
-                            '#prompt-textarea, [contenteditable="true"]',
+                            '#prompt-textarea, [contenteditable="true"], '
+                            'textarea[placeholder]',
                             timeout=min(10.0, self.timeout),
                         )
                         # Zendriver/CDP emits trusted keyboard events. A synthetic
                         # InputEvent can start finalize without ever receiving a
-                        # response on current ChatGPT clients.
+                        # response on some ChatGPT clients.
                         await probe_input.send_keys(".")
                     except Exception:
                         probe_input = None
+                if probe_input is not None and not captured.done():
+                    try:
+                        submit = await active_page.select(
+                            '[data-testid="send-button"], '
+                            '[data-testid="composer-submit-button"]',
+                            timeout=min(10.0, self.timeout),
+                        )
+                        # Current clients start finalize only on a trusted submit.
+                        # Fetch interception above aborts the actual conversation
+                        # POST, leaving the captured bundle unused for the SDK.
+                        await submit.click()
+                    except Exception:
+                        pass
                 bundle = await asyncio.wait_for(captured, timeout=self.timeout)
                 if probe_input is not None:
                     try:
@@ -274,6 +349,10 @@ class ZendriverSentinelBundleProvider:
                         pass
                 browser_cookies = await active_page.send(cdp.network.get_all_cookies())
                 _sync_chatgpt_cookies(client, browser_cookies)
+                if bool(getattr(client, "persist_browser_auth", False)):
+                    auth_file = getattr(client, "auth_file", None)
+                    if auth_file is not None:
+                        persist_auth_data(client.auth, auth_file)
                 return bundle
             except asyncio.TimeoutError as error:
                 raise RequestError(

--- a/src/chatgpt_web_adapter/browser_sentinel.py
+++ b/src/chatgpt_web_adapter/browser_sentinel.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from .auth import CHAT_URL
-from .auth_browser import _session_expiry_timestamp
+from .auth_browser import _graceful_browser_stop, _session_expiry_timestamp
 from .auth_store import persist_auth_data
 from .exceptions import RequestError
 from .sentinel_requirements import SENTINEL_FINALIZE_PATH
@@ -88,9 +88,11 @@ def _sync_chatgpt_cookies(client: Any, browser_cookies: Any) -> None:
 class ZendriverSentinelBundleProvider:
     """Capture one unused bundle produced by the official ChatGPT page.
 
-    The provider launches an isolated browser profile, seeds only the client's
-    supplied ChatGPT cookies, observes the official finalize transaction in
-    memory, and closes the browser. It never submits a chat message and never
+    The provider launches a browser profile, observes the official finalize
+    transaction in memory, and closes the browser. Temporary profiles are
+    seeded with the client's supplied ChatGPT cookies. Persistent profiles use
+    their own browser cookie jar so domain-scoped session cookie chunks are not
+    duplicated as host-only cookies. It never submits a chat message and never
     persists the captured one-shot credentials.
     """
 
@@ -120,6 +122,12 @@ class ZendriverSentinelBundleProvider:
             endpoint=SENTINEL_FINALIZE_PATH,
             request_stage="sentinel_bundle_provider",
         )
+
+    @property
+    def seeds_client_cookies(self) -> bool:
+        """Whether this provider must bootstrap an empty temporary profile."""
+
+        return self.profile_dir is None
 
     @staticmethod
     def _import_zendriver() -> Any:
@@ -263,6 +271,7 @@ class ZendriverSentinelBundleProvider:
             if self.profile_dir is not None
             else tempfile.TemporaryDirectory(prefix="chatgpt-web-adapter-")
         )
+
         if self.profile_dir is not None:
             self.profile_dir.mkdir(parents=True, exist_ok=True)
         with profile_context as profile_dir:
@@ -287,25 +296,26 @@ class ZendriverSentinelBundleProvider:
                         ]
                     )
                 )
-                session_expiry = _session_expiry_timestamp(
-                    getattr(getattr(client, "auth", None), "expires", None)
-                )
-                cookie_params = [
-                    cdp.network.CookieParam(
-                        name=str(name),
-                        value=str(value),
-                        url=CHAT_URL,
-                        secure=True,
-                        expires=(
-                            cdp.network.TimeSinceEpoch(session_expiry)
-                            if session_expiry is not None
-                            else None
-                        ),
+                if self.seeds_client_cookies:
+                    session_expiry = _session_expiry_timestamp(
+                        getattr(getattr(client, "auth", None), "expires", None)
                     )
-                    for name, value in cookies.items()
-                    if name is not None and value is not None
-                ]
-                await active_page.send(cdp.network.set_cookies(cookie_params))
+                    cookie_params = [
+                        cdp.network.CookieParam(
+                            name=str(name),
+                            value=str(value),
+                            url=CHAT_URL,
+                            secure=True,
+                            expires=(
+                                cdp.network.TimeSinceEpoch(session_expiry)
+                                if session_expiry is not None
+                                else None
+                            ),
+                        )
+                        for name, value in cookies.items()
+                        if name is not None and value is not None
+                    ]
+                    await active_page.send(cdp.network.set_cookies(cookie_params))
                 await active_page.get(CHAT_URL)
 
                 # The page normally prefetches on its own. A reversible input
@@ -362,4 +372,4 @@ class ZendriverSentinelBundleProvider:
                     request_stage="sentinel_bundle_provider",
                 ) from error
             finally:
-                await browser.stop()
+                await _graceful_browser_stop(browser, zendriver)

--- a/src/chatgpt_web_adapter/browser_sentinel.py
+++ b/src/chatgpt_web_adapter/browser_sentinel.py
@@ -135,7 +135,6 @@ class ZendriverSentinelBundleProvider:
         loop = asyncio.get_running_loop()
         captured: asyncio.Future[FinalizedSentinelBundle] = loop.create_future()
         finalize_requests: dict[Any, dict[str, Any]] = {}
-        finalize_statuses: dict[Any, int] = {}
         page: Any = None
 
         def on_request(event: Any, page: Any = None) -> None:
@@ -154,36 +153,46 @@ class ZendriverSentinelBundleProvider:
             if isinstance(payload, dict):
                 finalize_requests[event.request_id] = payload
 
-        def on_response(event: Any, page: Any = None) -> None:
-            response = getattr(event, "response", None)
-            if response is None or getattr(response, "url", "") != (
-                f"{CHAT_URL.rstrip('/')}{SENTINEL_FINALIZE_PATH}"
-            ):
+        async def read_finalize_response(request_id: Any, response_status: int) -> None:
+            if captured.done():
                 return
-            finalize_statuses[event.request_id] = int(getattr(response, "status", 0))
-
-        async def read_loading_finished(event: Any) -> None:
-            if captured.done() or event.request_id not in finalize_statuses:
-                return
-            request_payload = finalize_requests.get(event.request_id)
+            request_payload = finalize_requests.get(request_id)
             if request_payload is None:
                 try:
                     post_data = await active_page.send(
-                        cdp.network.get_request_post_data(event.request_id)
+                        cdp.network.get_request_post_data(request_id)
                     )
                     request_payload = json.loads(post_data)
                 except Exception:
                     return
+            body_response: tuple[str, bool] | None = None
+            for _attempt in range(100):
+                try:
+                    body_response = await active_page.send(
+                        cdp.network.get_response_body(request_id)
+                    )
+                    break
+                except Exception:
+                    await asyncio.sleep(0.05)
+            if body_response is None:
+                if not captured.done():
+                    captured.set_exception(
+                        RequestError(
+                            "SENTINEL_BROWSER_CAPTURE_BODY: finalize response body "
+                            "was not available from CDP",
+                            endpoint=SENTINEL_FINALIZE_PATH,
+                            request_stage="sentinel_browser_capture",
+                        )
+                    )
+                return
             try:
-                body, is_base64 = await active_page.send(
-                    cdp.network.get_response_body(event.request_id)
-                )
+                body, is_base64 = body_response
                 if is_base64:
                     body = base64.b64decode(body).decode("utf-8")
                 response_payload = json.loads(body)
                 bundle = _bundle_from_finalize_capture(
                     request_payload,
-                    finalize_statuses[event.request_id],
+                    response_status,
                     response_payload,
                 )
             except Exception as error:
@@ -193,11 +202,18 @@ class ZendriverSentinelBundleProvider:
             if not captured.done():
                 captured.set_result(bundle)
 
-        def on_loading_finished(event: Any, page: Any = None) -> None:
-            # zendriver 0.15.3 documents coroutine handlers but its connection
-            # dispatcher invokes them synchronously. Schedule the actual body
-            # explicitly so response-body reads are awaited by our event loop.
-            loop.create_task(read_loading_finished(event))
+        def on_response(event: Any, page: Any = None) -> None:
+            response = getattr(event, "response", None)
+            if response is None or getattr(response, "url", "") != (
+                f"{CHAT_URL.rstrip('/')}{SENTINEL_FINALIZE_PATH}"
+            ):
+                return
+            loop.create_task(
+                read_finalize_response(
+                    event.request_id,
+                    int(getattr(response, "status", 0)),
+                )
+            )
 
         cookies = getattr(getattr(client, "auth", None), "cookies", None)
         if not isinstance(cookies, dict) or not cookies:
@@ -217,7 +233,6 @@ class ZendriverSentinelBundleProvider:
                 active_page = await browser.get("about:blank")
                 active_page.add_handler(cdp.network.RequestWillBeSent, on_request)
                 active_page.add_handler(cdp.network.ResponseReceived, on_response)
-                active_page.add_handler(cdp.network.LoadingFinished, on_loading_finished)
                 await active_page.send(cdp.network.enable())
                 cookie_params = [
                     cdp.network.CookieParam(
@@ -234,32 +249,29 @@ class ZendriverSentinelBundleProvider:
 
                 # The page normally prefetches on its own. A reversible input
                 # event nudges lazy clients without clicking the submit button.
+                # Keep the probe in the editor until finalize completes: current
+                # clients cancel the Sentinel transaction when input is cleared
+                # immediately after the event.
                 await asyncio.sleep(3.0)
+                probe_input = None
                 if not captured.done():
-                    await active_page.evaluate(
-                        """
-                        (() => {
-                          const input = document.querySelector(
-                            '#prompt-textarea, [contenteditable="true"]'
-                          );
-                          if (!input) return false;
-                          input.focus();
-                          input.textContent = '.';
-                          input.dispatchEvent(new InputEvent('input', {
-                            bubbles: true, inputType: 'insertText', data: '.'
-                          }));
-                          setTimeout(() => {
-                            input.textContent = '';
-                            input.dispatchEvent(new InputEvent('input', {
-                              bubbles: true, inputType: 'deleteContentBackward'
-                            }));
-                          }, 75);
-                          return true;
-                        })()
-                        """,
-                        return_by_value=True,
-                    )
+                    try:
+                        probe_input = await active_page.select(
+                            '#prompt-textarea, [contenteditable="true"]',
+                            timeout=min(10.0, self.timeout),
+                        )
+                        # Zendriver/CDP emits trusted keyboard events. A synthetic
+                        # InputEvent can start finalize without ever receiving a
+                        # response on current ChatGPT clients.
+                        await probe_input.send_keys(".")
+                    except Exception:
+                        probe_input = None
                 bundle = await asyncio.wait_for(captured, timeout=self.timeout)
+                if probe_input is not None:
+                    try:
+                        await probe_input.clear_input_by_deleting()
+                    except Exception:
+                        pass
                 browser_cookies = await active_page.send(cdp.network.get_all_cookies())
                 _sync_chatgpt_cookies(client, browser_cookies)
                 return bundle

--- a/src/chatgpt_web_adapter/browser_sentinel.py
+++ b/src/chatgpt_web_adapter/browser_sentinel.py
@@ -12,6 +12,12 @@ from typing import Any
 from .auth import CHAT_URL
 from .auth_browser import _graceful_browser_stop, _session_expiry_timestamp
 from .auth_store import persist_auth_data
+from .browser_cookies import (
+    browser_cookie_params,
+    flatten_browser_cookies,
+    serialize_browser_cookies,
+)
+from .browser_profile_lock import BrowserProfileLock
 from .exceptions import RequestError
 from .sentinel_requirements import SENTINEL_FINALIZE_PATH
 from .sentinel_transaction import (
@@ -68,20 +74,14 @@ def _bundle_from_finalize_capture(
 
 
 def _sync_chatgpt_cookies(client: Any, browser_cookies: Any) -> None:
-    target = getattr(getattr(client, "auth", None), "cookies", None)
+    auth = getattr(client, "auth", None)
+    target = getattr(auth, "cookies", None)
     if not isinstance(target, dict) or not isinstance(browser_cookies, list):
         return
-    for cookie in browser_cookies:
-        domain = getattr(cookie, "domain", "")
-        name = getattr(cookie, "name", None)
-        value = getattr(cookie, "value", None)
-        if (
-            isinstance(domain, str)
-            and domain.lstrip(".").lower().endswith("chatgpt.com")
-            and isinstance(name, str)
-            and isinstance(value, str)
-        ):
-            target[name] = value
+    records = serialize_browser_cookies(browser_cookies)
+    target.update(flatten_browser_cookies(records))
+    if hasattr(auth, "browserCookies"):
+        auth.browserCookies = records
     _sync_device_header(client)
 
 
@@ -103,13 +103,26 @@ class ZendriverSentinelBundleProvider:
         headless: bool = False,
         browser_executable_path: str | Path | None = None,
         profile_dir: str | Path | None = None,
+        max_attempts: int = 2,
+        retry_delay: float = 1.0,
+        profile_lock_timeout: float = 30.0,
     ) -> None:
         if timeout <= 0:
             raise ValueError("timeout must be positive")
+        if int(max_attempts) <= 0:
+            raise ValueError("max_attempts must be positive")
+        if retry_delay < 0:
+            raise ValueError("retry_delay must be non-negative")
+        if profile_lock_timeout <= 0:
+            raise ValueError("profile_lock_timeout must be positive")
         self.timeout = float(timeout)
         self.headless = bool(headless)
         self.browser_executable_path = browser_executable_path
         self.profile_dir = Path(profile_dir) if profile_dir is not None else None
+        self.max_attempts = int(max_attempts)
+        self.retry_delay = float(retry_delay)
+        self.profile_lock_timeout = float(profile_lock_timeout)
+        self.last_diagnostics: dict[str, Any] = {}
 
     def __call__(self, client: Any) -> FinalizedSentinelBundle:
         try:
@@ -143,19 +156,76 @@ class ZendriverSentinelBundleProvider:
         return zendriver
 
     async def _acquire(self, client: Any) -> FinalizedSentinelBundle:
+        profile_lock = (
+            BrowserProfileLock(self.profile_dir, timeout=self.profile_lock_timeout)
+            if self.profile_dir is not None
+            else None
+        )
+        if profile_lock is not None:
+            try:
+                await asyncio.to_thread(profile_lock.acquire)
+            except TimeoutError as error:
+                raise RequestError(
+                    f"SENTINEL_BROWSER_PROFILE_BUSY: {error}",
+                    endpoint=SENTINEL_FINALIZE_PATH,
+                    request_stage="sentinel_browser_profile_lock",
+                ) from error
+        try:
+            last_error: RequestError | None = None
+            for attempt in range(1, self.max_attempts + 1):
+                try:
+                    return await self._acquire_once(client, attempt=attempt)
+                except RequestError as error:
+                    last_error = error
+                    retryable = getattr(error, "request_stage", None) in {
+                        "sentinel_bundle_provider",
+                        "sentinel_browser_capture",
+                    }
+                    if not retryable or attempt >= self.max_attempts:
+                        raise
+                    if self.retry_delay:
+                        await asyncio.sleep(self.retry_delay * attempt)
+            raise last_error or RequestError(
+                "SENTINEL_BROWSER_PROVIDER_FAILED",
+                request_stage="sentinel_bundle_provider",
+            )
+        finally:
+            if profile_lock is not None:
+                await asyncio.to_thread(profile_lock.release)
+
+    async def _acquire_once(
+        self,
+        client: Any,
+        *,
+        attempt: int,
+    ) -> FinalizedSentinelBundle:
         zendriver = self._import_zendriver()
         cdp = zendriver.cdp
         loop = asyncio.get_running_loop()
         captured: asyncio.Future[FinalizedSentinelBundle] = loop.create_future()
         finalize_requests: dict[Any, dict[str, Any]] = {}
         page: Any = None
+        diagnostics: dict[str, Any] = {
+            "attempt": attempt,
+            "page_loaded": False,
+            "editor_found": False,
+            "submit_clicked": False,
+            "prepare_seen": False,
+            "finalize_request_seen": False,
+            "finalize_response_seen": False,
+        }
+        self.last_diagnostics = diagnostics
 
         def on_request(event: Any, page: Any = None) -> None:
             request = getattr(event, "request", None)
-            if request is None or getattr(request, "url", "") != (
+            url = getattr(request, "url", "") if request is not None else ""
+            if url.endswith("/sentinel/chat-requirements/prepare"):
+                diagnostics["prepare_seen"] = True
+            if request is None or url != (
                 f"{CHAT_URL.rstrip('/')}{SENTINEL_FINALIZE_PATH}"
             ):
                 return
+            diagnostics["finalize_request_seen"] = True
             post_data = getattr(request, "post_data", None)
             if not isinstance(post_data, str):
                 return
@@ -221,6 +291,7 @@ class ZendriverSentinelBundleProvider:
                 f"{CHAT_URL.rstrip('/')}{SENTINEL_FINALIZE_PATH}"
             ):
                 return
+            diagnostics["finalize_response_seen"] = True
             loop.create_task(
                 read_finalize_response(
                     event.request_id,
@@ -300,23 +371,15 @@ class ZendriverSentinelBundleProvider:
                     session_expiry = _session_expiry_timestamp(
                         getattr(getattr(client, "auth", None), "expires", None)
                     )
-                    cookie_params = [
-                        cdp.network.CookieParam(
-                            name=str(name),
-                            value=str(value),
-                            url=CHAT_URL,
-                            secure=True,
-                            expires=(
-                                cdp.network.TimeSinceEpoch(session_expiry)
-                                if session_expiry is not None
-                                else None
-                            ),
-                        )
-                        for name, value in cookies.items()
-                        if name is not None and value is not None
-                    ]
+                    cookie_params = browser_cookie_params(
+                        cdp,
+                        getattr(getattr(client, "auth", None), "browserCookies", []),
+                        cookies,
+                        fallback_expires=session_expiry,
+                    )
                     await active_page.send(cdp.network.set_cookies(cookie_params))
                 await active_page.get(CHAT_URL)
+                diagnostics["page_loaded"] = True
 
                 # The page normally prefetches on its own. A reversible input
                 # event nudges lazy clients without clicking the submit button.
@@ -332,6 +395,7 @@ class ZendriverSentinelBundleProvider:
                             'textarea[placeholder]',
                             timeout=min(10.0, self.timeout),
                         )
+                        diagnostics["editor_found"] = True
                         # Zendriver/CDP emits trusted keyboard events. A synthetic
                         # InputEvent can start finalize without ever receiving a
                         # response on some ChatGPT clients.
@@ -349,6 +413,7 @@ class ZendriverSentinelBundleProvider:
                         # Fetch interception above aborts the actual conversation
                         # POST, leaving the captured bundle unused for the SDK.
                         await submit.click()
+                        diagnostics["submit_clicked"] = True
                     except Exception:
                         pass
                 bundle = await asyncio.wait_for(captured, timeout=self.timeout)
@@ -365,9 +430,13 @@ class ZendriverSentinelBundleProvider:
                         persist_auth_data(client.auth, auth_file)
                 return bundle
             except asyncio.TimeoutError as error:
+                detail = ", ".join(
+                    f"{key}={str(value).lower()}"
+                    for key, value in diagnostics.items()
+                )
                 raise RequestError(
                     "SENTINEL_BROWSER_PROVIDER_TIMEOUT: official ChatGPT page did "
-                    "not produce a finalized bundle before the timeout",
+                    f"not produce a finalized bundle before the timeout ({detail})",
                     endpoint=SENTINEL_FINALIZE_PATH,
                     request_stage="sentinel_bundle_provider",
                 ) from error

--- a/src/chatgpt_web_adapter/cli.py
+++ b/src/chatgpt_web_adapter/cli.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from .auth import DEFAULT_AUTH_FILE, load_auth_data
+from .auth_browser import browser_login
+from .auth_refresh import refresh_auth_session
+from .auth_status import get_auth_status
+from .client import ChatGPTWebClient
+from .exceptions import WebChatAdapterError
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="chatgpt-web-adapter")
+    commands = parser.add_subparsers(dest="command", required=True)
+    auth = commands.add_parser("auth", help="manage reusable ChatGPT web authorization")
+    auth_commands = auth.add_subparsers(dest="auth_command", required=True)
+
+    def add_auth_file(command: argparse.ArgumentParser) -> None:
+        command.add_argument("--auth-file", type=Path, default=DEFAULT_AUTH_FILE)
+
+    login = auth_commands.add_parser("login", help="open a browser and save authorization")
+    add_auth_file(login)
+    login.add_argument("--profile-dir", type=Path)
+    login.add_argument("--timeout", type=float, default=300.0)
+    login.add_argument("--browser-executable-path", type=Path)
+
+    status = auth_commands.add_parser("status", help="show authorization health")
+    add_auth_file(status)
+
+    refresh = auth_commands.add_parser("refresh", help="refresh tokens without browser login")
+    add_auth_file(refresh)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.auth_command == "login":
+            result = browser_login(
+                args.auth_file,
+                profile_dir=args.profile_dir,
+                timeout=args.timeout,
+                browser_executable_path=args.browser_executable_path,
+            )
+            print(f"Authorization saved to {result.auth_file}")
+            print(f"Persistent browser profile: {result.profile_dir}")
+            return 0
+        if args.auth_command == "status":
+            status = get_auth_status(args.auth_file)
+            print(
+                json.dumps(
+                    {
+                        "auth_file": str(status.auth_file),
+                        "file_exists": status.file_exists,
+                        "access_token_present": status.access_token_present,
+                        "access_token_expires_at": (
+                            status.access_token_expires_at.isoformat()
+                            if status.access_token_expires_at is not None
+                            else None
+                        ),
+                        "access_token_needs_refresh": status.access_token_needs_refresh,
+                        "session_cookie_present": status.session_cookie_present,
+                        "session_expires_at": status.session_expires_at,
+                    },
+                    indent=2,
+                )
+            )
+            return 0 if status.file_exists else 1
+        if args.auth_command == "refresh":
+            auth = load_auth_data(args.auth_file, allow_expired_session_refresh=True)
+            client = ChatGPTWebClient(
+                auth=auth,
+                auth_file=args.auth_file,
+                auto_refresh_auth=False,
+            )
+            result = refresh_auth_session(client, auth_file=args.auth_file)
+            print(
+                json.dumps(
+                    {
+                        "status_code": result.status_code,
+                        "session_token_rotated": result.session_token_rotated,
+                        "persisted": result.persisted,
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+    except (WebChatAdapterError, OSError, ValueError) as error:
+        print(f"error: {error}")
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/chatgpt_web_adapter/cli.py
+++ b/src/chatgpt_web_adapter/cli.py
@@ -35,6 +35,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     status = auth_commands.add_parser("status", help="show authorization health")
     add_auth_file(status)
+    status.add_argument("--profile-dir", type=Path)
 
     refresh = auth_commands.add_parser("refresh", help="refresh tokens without browser login")
     add_auth_file(refresh)
@@ -56,7 +57,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"Persistent browser profile: {result.profile_dir}")
             return 0
         if args.auth_command == "status":
-            status = get_auth_status(args.auth_file)
+            status = get_auth_status(args.auth_file, profile_dir=args.profile_dir)
             print(
                 json.dumps(
                     {
@@ -71,6 +72,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                         "access_token_needs_refresh": status.access_token_needs_refresh,
                         "session_cookie_present": status.session_cookie_present,
                         "session_expires_at": status.session_expires_at,
+                        "browser_cookie_count": status.browser_cookie_count,
+                        "browser_profile_dir": str(status.browser_profile_dir),
+                        "browser_profile_exists": status.browser_profile_exists,
                     },
                     indent=2,
                 )

--- a/src/chatgpt_web_adapter/cli.py
+++ b/src/chatgpt_web_adapter/cli.py
@@ -27,6 +27,11 @@ def _build_parser() -> argparse.ArgumentParser:
     login.add_argument("--profile-dir", type=Path)
     login.add_argument("--timeout", type=float, default=300.0)
     login.add_argument("--browser-executable-path", type=Path)
+    login.add_argument(
+        "--force",
+        action="store_true",
+        help="ignore saved auth and require a fresh interactive browser login",
+    )
 
     status = auth_commands.add_parser("status", help="show authorization health")
     add_auth_file(status)
@@ -45,6 +50,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 profile_dir=args.profile_dir,
                 timeout=args.timeout,
                 browser_executable_path=args.browser_executable_path,
+                reuse_existing_auth=not args.force,
             )
             print(f"Authorization saved to {result.auth_file}")
             print(f"Persistent browser profile: {result.profile_dir}")

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Sequence
 from urllib.parse import urlparse
 
 from .auth import CHAT_URL, DEFAULT_AUTH_FILE, build_base_headers, load_auth_data
-from .exceptions import MediaError, RequestError
+from .exceptions import AuthError, MediaError, RequestError
 from .model_detection import (
     detect_model_from_conversation_payload,
     detect_reasoning_effort_from_conversation_payload,
@@ -335,12 +335,26 @@ class ChatGPTWebClient:
         debug_trace_sanitize: bool = True,
         auto_refresh_auth: bool = True,
         persist_refreshed_auth: bool = True,
+        auto_login: bool = False,
+        browser_profile_dir: str | Path | None = None,
+        browser_login_timeout: float = 300.0,
     ) -> None:
         self.auth_file = Path(auth_file)
-        self.auth = auth or load_auth_data(
-            self.auth_file,
-            allow_expired_session_refresh=bool(auto_refresh_auth),
-        )
+        try:
+            self.auth = auth or load_auth_data(
+                self.auth_file,
+                allow_expired_session_refresh=bool(auto_refresh_auth),
+            )
+        except AuthError:
+            if not auto_login or auth is not None:
+                raise
+            from .auth_browser import browser_login
+
+            self.auth = browser_login(
+                self.auth_file,
+                profile_dir=browser_profile_dir,
+                timeout=browser_login_timeout,
+            ).auth
         self.timeout = max(10, int(timeout))
         self.base_headers = build_base_headers(self.auth)
         self.curl_bin = curl_bin or shutil.which("curl.exe") or shutil.which("curl")
@@ -355,15 +369,28 @@ class ChatGPTWebClient:
         self.debug_trace_dir = Path(debug_trace_dir) if debug_trace_dir is not None else None
         self.debug_trace_sanitize = bool(debug_trace_sanitize)
         self._debug_trace_counter = 0
+        self.persist_browser_auth = bool(persist_refreshed_auth and auth is None)
         if auto_refresh_auth:
             from .auth_refresh import auth_needs_refresh, refresh_auth_session
 
             if auth_needs_refresh(self.auth.accessToken):
-                refresh_auth_session(
-                    self,
-                    persist=bool(persist_refreshed_auth and auth is None),
-                    auth_file=self.auth_file,
-                )
+                try:
+                    refresh_auth_session(
+                        self,
+                        persist=bool(persist_refreshed_auth and auth is None),
+                        auth_file=self.auth_file,
+                    )
+                except AuthError:
+                    if not auto_login or auth is not None:
+                        raise
+                    from .auth_browser import browser_login
+
+                    self.auth = browser_login(
+                        self.auth_file,
+                        profile_dir=browser_profile_dir,
+                        timeout=browser_login_timeout,
+                    ).auth
+                    self.base_headers = build_base_headers(self.auth)
 
     def _build_headers(self, extra: dict[str, str | None] | None = None) -> dict[str, str]:
         headers = dict(self.base_headers)

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -333,8 +333,14 @@ class ChatGPTWebClient:
         curl_bin: str | None = None,
         debug_trace_dir: str | Path | None = None,
         debug_trace_sanitize: bool = True,
+        auto_refresh_auth: bool = True,
+        persist_refreshed_auth: bool = True,
     ) -> None:
-        self.auth = auth or load_auth_data(auth_file)
+        self.auth_file = Path(auth_file)
+        self.auth = auth or load_auth_data(
+            self.auth_file,
+            allow_expired_session_refresh=bool(auto_refresh_auth),
+        )
         self.timeout = max(10, int(timeout))
         self.base_headers = build_base_headers(self.auth)
         self.curl_bin = curl_bin or shutil.which("curl.exe") or shutil.which("curl")
@@ -349,6 +355,15 @@ class ChatGPTWebClient:
         self.debug_trace_dir = Path(debug_trace_dir) if debug_trace_dir is not None else None
         self.debug_trace_sanitize = bool(debug_trace_sanitize)
         self._debug_trace_counter = 0
+        if auto_refresh_auth:
+            from .auth_refresh import auth_needs_refresh, refresh_auth_session
+
+            if auth_needs_refresh(self.auth.accessToken):
+                refresh_auth_session(
+                    self,
+                    persist=bool(persist_refreshed_auth and auth is None),
+                    auth_file=self.auth_file,
+                )
 
     def _build_headers(self, extra: dict[str, str | None] | None = None) -> dict[str, str]:
         headers = dict(self.base_headers)
@@ -2298,17 +2313,16 @@ class ChatGPTWebClient:
     ) -> ChatResponse:
         normalized_effort = self._normalize_reasoning_effort(reasoning_effort)
         resolved_model = self._resolve_model(model, reasoning_effort)
+        from .sentinel_bundle import prepared_send_active
+
+        use_prepared_sentinel = prepared_send_active()
 
         normalized_media = self._normalize_media_items(media)
         image_requests = self._upload_media_files(normalized_media) if normalized_media else None
-        requirements, proof_header = self._get_ready_requirements()
-        chat_token = requirements.get("token")
-        if not isinstance(chat_token, str) or not chat_token:
-            raise RequestError("chat-requirements token is missing")
 
         conversation_dict = self._conversation_to_dict(conversation)
         conversation_id = None
-        parent_message_id = str(uuid.uuid4())
+        parent_message_id = "client-created-root" if use_prepared_sentinel else str(uuid.uuid4())
         user_id = None
         if isinstance(conversation_dict, dict):
             conversation_id = conversation_dict.get("conversation_id") or None
@@ -2319,6 +2333,67 @@ class ChatGPTWebClient:
             )
             user_id = conversation_dict.get("user_id")
 
+        messages = self._create_messages(
+            prompt,
+            None if conversation_id else system,
+            image_requests=image_requests,
+            system_hints=["search"] if web_search else None,
+        )
+        user_message = messages[-1] if messages else None
+        user_message_id = user_message.get("id") if isinstance(user_message, dict) else None
+        if not isinstance(user_message_id, str) or not user_message_id.strip():
+            raise RequestError(
+                "conversation prepare could not resolve user message id",
+                request_stage="conversation_prepare",
+            )
+
+        prepare_result = None
+        if use_prepared_sentinel:
+            from .conversation_prepare import prepare_text_turn
+
+            prepare_conversation = dict(conversation_dict or {})
+            prepare_conversation["parent_message_id"] = parent_message_id
+            prepare_result, _prepare_payload = prepare_text_turn(
+                self,
+                prompt,
+                model=resolved_model,
+                conversation=prepare_conversation,
+                reasoning_effort=normalized_effort,
+                web_search=web_search,
+                temporary=temporary,
+                partial_query_message_id=user_message_id,
+                include_partial_query=bool(conversation_id and not normalized_media),
+                client_prepare_state="none",
+                client_prepare_dispatch="immediate" if conversation_id else "debounced",
+                client_prepare_source="context_change" if conversation_id else "window_focus",
+                initial_conduit_token="no-token" if conversation_id else None,
+            )
+            if not prepare_result.status_ok:
+                raise RequestError(
+                    f"conversation prepare rejected: status={prepare_result.status_code}",
+                    status_code=prepare_result.status_code,
+                    endpoint=CHAT_CONVERSATION_PREPARE_URL,
+                    request_stage="conversation_prepare",
+                )
+            if not prepare_result.conduit_token_present or not prepare_result.conduit_token:
+                raise RequestError(
+                    "conversation prepare response missing conduit token",
+                    status_code=prepare_result.status_code,
+                    endpoint=CHAT_CONVERSATION_PREPARE_URL,
+                    request_stage="conversation_prepare",
+                )
+            self._emit_event(
+                on_event,
+                "conversation_prepare_succeeded",
+                status_code=prepare_result.status_code,
+                conduit_token_present=True,
+            )
+
+        requirements, proof_header = self._get_ready_requirements()
+        chat_token = requirements.get("token")
+        if not isinstance(chat_token, str) or not chat_token:
+            raise RequestError("chat-requirements token is missing")
+
         payload: dict[str, Any] = {
             "action": "next",
             "parent_message_id": parent_message_id,
@@ -2327,19 +2402,18 @@ class ChatGPTWebClient:
             "enable_message_followups": False,
             "supports_buffering": True,
             "supported_encodings": ["v1"],
-            "messages": self._create_messages(
-                prompt,
-                None if conversation_id else system,
-                image_requests=image_requests,
-                system_hints=["search"] if web_search else None,
-            ),
+            "messages": messages,
         }
+        if use_prepared_sentinel:
+            payload["client_prepare_state"] = "success"
+            payload["client_contextual_info"] = {"app_name": "chatgpt.com"}
+            payload["system_hints"] = ["search"] if web_search else []
+        elif web_search:
+            payload["system_hints"] = ["search"]
         if temporary:
             payload["history_and_training_disabled"] = True
         if conversation_id:
             payload["conversation_id"] = conversation_id
-        if web_search:
-            payload["system_hints"] = ["search"]
         if normalized_effort is not None:
             payload["thinking_effort"] = normalized_effort
         self._emit_event(
@@ -2348,8 +2422,7 @@ class ChatGPTWebClient:
             payload=json.loads(json.dumps(payload, ensure_ascii=False)),
         )
 
-        headers = self._build_headers(
-            {
+        header_overrides: dict[str, str | None] = {
                 "accept": "text/event-stream",
                 "content-type": "application/json",
                 "openai-sentinel-chat-requirements-token": chat_token,
@@ -2357,8 +2430,26 @@ class ChatGPTWebClient:
                 "openai-sentinel-turnstile-token": self.auth.turnstile_token
                 if (requirements.get("turnstile") or {}).get("required")
                 else None,
-            }
-        )
+        }
+        if use_prepared_sentinel and prepare_result is not None:
+            header_overrides.update(
+                {
+                    "origin": CHAT_URL.rstrip("/"),
+                    "referer": (
+                        f"{CHAT_URL.rstrip('/')}/c/{conversation_id}"
+                        if conversation_id
+                        else CHAT_URL
+                    ),
+                    "x-openai-target-path": "/backend-api/f/conversation",
+                    "x-openai-target-route": "/backend-api/f/conversation",
+                    "x-conduit-token": prepare_result.conduit_token,
+                }
+            )
+        headers = self._build_headers(header_overrides)
+        if use_prepared_sentinel:
+            refill = getattr(self, "start_sentinel_bundle_refill", None)
+            if callable(refill):
+                refill(on_event=on_event)
         state = {
             "recipient": "all",
             "conversation_id": conversation_id,

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -338,6 +338,10 @@ class ChatGPTWebClient:
         auto_login: bool = False,
         browser_profile_dir: str | Path | None = None,
         browser_login_timeout: float = 300.0,
+        auto_sentinel: bool = False,
+        sentinel_timeout: float = 60.0,
+        sentinel_max_attempts: int = 2,
+        sentinel_headless: bool = False,
     ) -> None:
         self.auth_file = Path(auth_file)
         try:
@@ -370,6 +374,21 @@ class ChatGPTWebClient:
         self.debug_trace_sanitize = bool(debug_trace_sanitize)
         self._debug_trace_counter = 0
         self.persist_browser_auth = bool(persist_refreshed_auth and auth is None)
+        if auto_sentinel:
+            from .auth_browser import default_browser_profile_dir
+            from .browser_sentinel import ZendriverSentinelBundleProvider
+
+            profile = (
+                Path(browser_profile_dir)
+                if browser_profile_dir is not None
+                else default_browser_profile_dir()
+            )
+            self._sentinel_bundle_provider = ZendriverSentinelBundleProvider(
+                timeout=sentinel_timeout,
+                headless=sentinel_headless,
+                profile_dir=profile,
+                max_attempts=sentinel_max_attempts,
+            )
         if auto_refresh_auth:
             from .auth_refresh import auth_needs_refresh, refresh_auth_session
 

--- a/src/chatgpt_web_adapter/conversation_prepare.py
+++ b/src/chatgpt_web_adapter/conversation_prepare.py
@@ -56,6 +56,10 @@ def build_text_prepare_payload(
     timezone: str | None = None,
     timezone_offset_min: int | None = None,
     partial_query_message_id: str | None = None,
+    include_partial_query: bool = True,
+    client_prepare_state: str = "success",
+    client_prepare_dispatch: str | None = None,
+    client_prepare_source: str | None = None,
 ) -> dict[str, Any]:
     """Build the observed ordinary-text ``conversation/prepare`` payload shape."""
 
@@ -70,14 +74,22 @@ def build_text_prepare_payload(
         "fork_from_shared_post": False,
         "parent_message_id": parent_message_id,
         "model": str(model),
-        "client_prepare_state": "success",
+        "client_prepare_state": client_prepare_state,
         "conversation_mode": {"kind": "primary_assistant"},
         "system_hints": ["search"] if web_search else [],
-        "partial_query": _partial_query(prompt, message_id=partial_query_message_id),
         "supports_buffering": True,
         "supported_encodings": ["v1"],
         "client_contextual_info": {"app_name": "chatgpt.com"},
     }
+    if include_partial_query:
+        payload["partial_query"] = _partial_query(
+            prompt,
+            message_id=partial_query_message_id,
+        )
+    if client_prepare_dispatch is not None:
+        payload["client_prepare_dispatch"] = client_prepare_dispatch
+    if client_prepare_source is not None:
+        payload["client_prepare_source"] = client_prepare_source
     conversation_id = conversation_dict.get("conversation_id")
     if isinstance(conversation_id, str) and conversation_id:
         payload["conversation_id"] = conversation_id
@@ -92,7 +104,12 @@ def build_text_prepare_payload(
     return payload
 
 
-def build_prepare_headers(client: Any, *, conversation_id: str | None = None) -> dict[str, str]:
+def build_prepare_headers(
+    client: Any,
+    *,
+    conversation_id: str | None = None,
+    initial_conduit_token: str | None = "no-token",
+) -> dict[str, str]:
     referer = CHAT_URL
     if conversation_id:
         referer = f"{CHAT_URL.rstrip('/')}/c/{conversation_id}"
@@ -102,7 +119,7 @@ def build_prepare_headers(client: Any, *, conversation_id: str | None = None) ->
             "content-type": "application/json",
             "origin": CHAT_URL.rstrip("/"),
             "referer": referer,
-            "x-conduit-token": "no-token",
+            "x-conduit-token": initial_conduit_token,
             "x-openai-target-path": PREPARE_PATH,
             "x-openai-target-route": PREPARE_PATH,
         }
@@ -165,6 +182,11 @@ def prepare_text_turn(
     timezone: str | None = None,
     timezone_offset_min: int | None = None,
     partial_query_message_id: str | None = None,
+    include_partial_query: bool = True,
+    client_prepare_state: str = "success",
+    client_prepare_dispatch: str | None = None,
+    client_prepare_source: str | None = None,
+    initial_conduit_token: str | None = "no-token",
 ) -> tuple[PrepareResult, dict[str, Any]]:
     """Issue only the prepare request and return structural evidence plus payload.
 
@@ -182,11 +204,16 @@ def prepare_text_turn(
         timezone=timezone,
         timezone_offset_min=timezone_offset_min,
         partial_query_message_id=partial_query_message_id,
+        include_partial_query=include_partial_query,
+        client_prepare_state=client_prepare_state,
+        client_prepare_dispatch=client_prepare_dispatch,
+        client_prepare_source=client_prepare_source,
     )
     conversation_id = payload.get("conversation_id")
     headers = build_prepare_headers(
         client,
         conversation_id=conversation_id if isinstance(conversation_id, str) else None,
+        initial_conduit_token=initial_conduit_token,
     )
     status, data = _prepare_json_request(client, payload, headers)
     response = data if isinstance(data, dict) else {}

--- a/src/chatgpt_web_adapter/sentinel_bundle.py
+++ b/src/chatgpt_web_adapter/sentinel_bundle.py
@@ -383,11 +383,24 @@ def redact_ephemeral_write_headers(
     return sanitize_header_value
 
 
-def gate_prepared_text_send(original_send: Callable[..., Any]) -> Callable[..., Any]:
+def prepared_send_active() -> bool:
+    return _PREPARED_SEND_ACTIVE.get()
+
+
+def gate_prepared_text_send(
+    original_send: Callable[..., Any],
+    *,
+    require_provider: bool = True,
+) -> Callable[..., Any]:
     """Establish an execution-local prepared-turn transaction context."""
 
     @wraps(original_send)
     def send(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if not require_provider:
+            challenge_provider = getattr(self, "_sentinel_challenge_provider", None)
+            bundle_provider = getattr(self, "_sentinel_bundle_provider", None)
+            if not callable(challenge_provider) and not callable(bundle_provider):
+                return original_send(self, *args, **kwargs)
         if getattr(self, "auth", None) is not None:
             _sync_device_header(self)
         on_event = kwargs.get("on_event")

--- a/src/chatgpt_web_adapter/types.py
+++ b/src/chatgpt_web_adapter/types.py
@@ -68,6 +68,7 @@ class AuthData:
     accessToken: str | None = None
     accessTokenSource: str | None = None
     cookies: dict[str, str] = field(default_factory=dict)
+    browserCookies: list[dict[str, Any]] = field(default_factory=list)
     headers: dict[str, str] = field(default_factory=dict)
     expires: Any = None
     proof_token: Any = None
@@ -78,6 +79,7 @@ class AuthData:
         accessToken: str | None = None,
         accessTokenSource: str | None = None,
         cookies: dict[str, str] | None = None,
+        browserCookies: list[dict[str, Any]] | None = None,
         headers: dict[str, str] | None = None,
         expires: Any = None,
         proof_token: Any = None,
@@ -85,6 +87,7 @@ class AuthData:
         *,
         access_token: str | None = None,
         access_token_source: str | None = None,
+        browser_cookies: list[dict[str, Any]] | None = None,
         api_key: str | None = None,
         api_key_source: str | None = None,
     ) -> None:
@@ -101,6 +104,12 @@ class AuthData:
         self.accessToken = token
         self.accessTokenSource = token_source
         self.cookies = dict(cookies or {})
+        cookie_records = (
+            browserCookies if browserCookies is not None else browser_cookies
+        )
+        self.browserCookies = [
+            dict(item) for item in (cookie_records or []) if isinstance(item, dict)
+        ]
         self.headers = dict(headers or {})
         self.expires = expires
         self.proof_token = proof_token
@@ -138,6 +147,16 @@ class AuthData:
     def api_key_source(self, value: str | None) -> None:
         self.accessTokenSource = value
 
+    @property
+    def browser_cookies(self) -> list[dict[str, Any]]:
+        return self.browserCookies
+
+    @browser_cookies.setter
+    def browser_cookies(self, value: list[dict[str, Any]] | None) -> None:
+        self.browserCookies = [
+            dict(item) for item in (value or []) if isinstance(item, dict)
+        ]
+
     @classmethod
     def from_json(cls, path: str | Path) -> "AuthData":
         import json
@@ -154,6 +173,11 @@ class AuthData:
         return cls(
             accessToken=access_token,
             cookies=payload.get("cookies") or {},
+            browserCookies=(
+                payload.get("browserCookies")
+                or payload.get("browser_cookies")
+                or []
+            ),
             headers=payload.get("headers") or {},
             expires=payload.get("expires"),
             proof_token=payload.get("proof_token"),

--- a/src/chatgpt_web_adapter/types.py
+++ b/src/chatgpt_web_adapter/types.py
@@ -69,7 +69,7 @@ class AuthData:
     accessTokenSource: str | None = None
     cookies: dict[str, str] = field(default_factory=dict)
     headers: dict[str, str] = field(default_factory=dict)
-    expires: int | None = None
+    expires: Any = None
     proof_token: Any = None
     turnstile_token: str | None = None
 
@@ -79,7 +79,7 @@ class AuthData:
         accessTokenSource: str | None = None,
         cookies: dict[str, str] | None = None,
         headers: dict[str, str] | None = None,
-        expires: int | None = None,
+        expires: Any = None,
         proof_token: Any = None,
         turnstile_token: str | None = None,
         *,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -127,6 +127,30 @@ def test_explicit_chunked_browser_session_cookies_win_over_session_token(tmp_pat
     assert auth.cookies["__Secure-next-auth.session-token.1"] == "chunk-one"
 
 
+def test_chunked_session_cookies_remove_conflicting_nonchunked_cookie(tmp_path) -> None:
+    auth_file = tmp_path / "auth_data.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "accessToken": "not.a.jwt",
+                "sessionToken": "json-fallback",
+                "cookies": {
+                    "__Secure-next-auth.session-token": "conflicting-fallback",
+                    "__Secure-next-auth.session-token.0": "chunk-zero",
+                    "__Secure-next-auth.session-token.1": "chunk-one",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    auth = adapter.load_auth_data(auth_file)
+
+    assert "__Secure-next-auth.session-token" not in auth.cookies
+    assert auth.cookies["__Secure-next-auth.session-token.0"] == "chunk-zero"
+    assert auth.cookies["__Secure-next-auth.session-token.1"] == "chunk-one"
+
+
 def test_oai_did_cookie_seeds_device_header() -> None:
     auth = adapter.AuthData(
         accessToken="token",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import base64
 import json
 
 import chatgpt_web_adapter as adapter
 import pytest
 
 from chatgpt_web_adapter.auth import build_base_headers
+
+
+def _expired_access_token() -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').decode("ascii").rstrip("=")
+    payload = base64.urlsafe_b64encode(b'{"exp":1}').decode("ascii").rstrip("=")
+    return f"{header}.{payload}.signature"
 
 
 def test_load_auth_data_uses_env_token_when_auth_file_is_missing(
@@ -129,3 +136,28 @@ def test_oai_did_cookie_seeds_device_header() -> None:
     headers = build_base_headers(auth)
 
     assert headers["oai-device-id"] == "device-id"
+
+
+def test_expired_access_token_can_be_loaded_only_for_session_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("accessToken", raising=False)
+    auth_file = tmp_path / "auth_data.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "accessToken": _expired_access_token(),
+                "sessionToken": "refreshable-session",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(adapter.AuthError, match="expired"):
+        adapter.load_auth_data(auth_file)
+
+    auth = adapter.load_auth_data(auth_file, allow_expired_session_refresh=True)
+    assert auth.accessToken is None
+    assert auth.cookies["__Secure-next-auth.session-token"] == "refreshable-session"

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from chatgpt_web_adapter import auth_browser
+from chatgpt_web_adapter.auth import CHATGPT_SESSION_COOKIE
+from chatgpt_web_adapter.exceptions import AuthError
+
+
+class FakePage:
+    async def get(self, url):
+        assert url in {"https://chatgpt.com/", "about:blank"}
+        return self
+
+    async def evaluate(self, expression, **kwargs):
+        if "api/auth/session" in expression:
+            return {
+                "status": 200,
+                "body": {
+                    "accessToken": "browser-access",
+                    "sessionToken": "browser-session-json",
+                    "expires": "2030-01-01T00:00:00.000Z",
+                },
+            }
+        return "Browser Test Agent"
+
+    async def send(self, command):
+        return [
+            SimpleNamespace(
+                domain=".chatgpt.com",
+                name=CHATGPT_SESSION_COOKIE,
+                value="browser-session-cookie",
+            ),
+            SimpleNamespace(domain=".chatgpt.com", name="oai-did", value="device-1"),
+            SimpleNamespace(domain="example.com", name="ignored", value="outside"),
+        ]
+
+
+class FakeBrowser:
+    def __init__(self):
+        self.page = FakePage()
+        self.stopped = False
+
+    async def get(self, url):
+        assert url == "https://chatgpt.com/"
+        return self.page
+
+    async def stop(self):
+        self.stopped = True
+
+
+def test_browser_login_captures_and_persists_reusable_session(tmp_path, monkeypatch) -> None:
+    browser = FakeBrowser()
+
+    async def start(**kwargs):
+        assert kwargs["user_data_dir"] == str(tmp_path / "profile")
+        assert kwargs["headless"] is False
+        return browser
+
+    fake_zendriver = SimpleNamespace(
+        start=start,
+        cdp=SimpleNamespace(
+            network=SimpleNamespace(
+                get_all_cookies=lambda: "get-all-cookies",
+                CookieParam=lambda **kwargs: kwargs,
+                set_cookies=lambda cookies: ("set-cookies", cookies),
+                TimeSinceEpoch=float,
+            )
+        ),
+    )
+    monkeypatch.setattr(auth_browser, "_import_zendriver", lambda: fake_zendriver)
+
+    result = auth_browser.browser_login(
+        tmp_path / "auth.json",
+        profile_dir=tmp_path / "profile",
+        timeout=1,
+    )
+
+    saved = json.loads((tmp_path / "auth.json").read_text(encoding="utf-8"))
+    assert browser.stopped is True
+    assert result.auth.accessToken == "browser-access"
+    assert result.auth.cookies[CHATGPT_SESSION_COOKIE] == "browser-session-cookie"
+    assert result.auth.cookies["oai-did"] == "device-1"
+    assert "ignored" not in result.auth.cookies
+    assert saved["sessionToken"] == "browser-session-json"
+    assert saved["sessionExpiresAt"] == "2030-01-01T00:00:00.000Z"
+    assert saved["headers"]["user-agent"] == "Browser Test Agent"
+    assert "proof_token" not in saved
+    assert "turnstile_token" not in saved
+
+
+def test_browser_login_seeds_existing_session_into_persistent_profile(
+    tmp_path, monkeypatch
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "accessToken": "not.a.jwt",
+                "sessionToken": "existing-session",
+            }
+        ),
+        encoding="utf-8",
+    )
+    browser = FakeBrowser()
+    started_urls = []
+    commands = []
+
+    async def start(**kwargs):
+        return browser
+
+    async def browser_get(url):
+        started_urls.append(url)
+        return browser.page
+
+    async def page_send(command):
+        commands.append(command)
+        if command == "get-all-cookies":
+            return [
+                SimpleNamespace(
+                    domain=".chatgpt.com",
+                    name=CHATGPT_SESSION_COOKIE,
+                    value="browser-session-cookie",
+                )
+            ]
+        return None
+
+    browser.get = browser_get
+    browser.page.send = page_send
+    fake_network = SimpleNamespace(
+        CookieParam=lambda **kwargs: kwargs,
+        set_cookies=lambda cookies: ("set-cookies", cookies),
+        delete_cookies=lambda name, **kwargs: ("delete-cookie", name),
+        get_all_cookies=lambda: "get-all-cookies",
+        TimeSinceEpoch=float,
+    )
+    monkeypatch.setattr(
+        auth_browser,
+        "_import_zendriver",
+        lambda: SimpleNamespace(
+            start=start,
+            cdp=SimpleNamespace(network=fake_network),
+        ),
+    )
+
+    auth_browser.browser_login(
+        auth_file,
+        profile_dir=tmp_path / "profile",
+        timeout=1,
+    )
+
+    assert started_urls == ["about:blank"]
+    seed_command = next(command for command in commands if command[0] == "set-cookies")
+    assert seed_command[1][0]["value"] == "existing-session"
+
+
+def test_browser_login_rejects_active_event_loop() -> None:
+    async def run() -> None:
+        with pytest.raises(AuthError, match="active asyncio event loop"):
+            auth_browser.browser_login(timeout=1)
+
+    import asyncio
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, {}, {"status": 401, "body": {}}, {"status": 200, "body": {}}],
+)
+def test_valid_session_payload_rejects_incomplete_auth(payload) -> None:
+    assert auth_browser._valid_session_payload(payload) is None
+
+
+def test_session_expiry_timestamp_parses_chatgpt_iso_value() -> None:
+    assert auth_browser._session_expiry_timestamp("2030-01-01T00:00:00.000Z") == 1893456000

--- a/tests/test_auth_browser.py
+++ b/tests/test_auth_browser.py
@@ -88,6 +88,7 @@ def test_browser_login_captures_and_persists_reusable_session(tmp_path, monkeypa
     assert saved["sessionToken"] == "browser-session-json"
     assert saved["sessionExpiresAt"] == "2030-01-01T00:00:00.000Z"
     assert saved["headers"]["user-agent"] == "Browser Test Agent"
+    assert saved["browserCookies"][0]["domain"] == ".chatgpt.com"
     assert "proof_token" not in saved
     assert "turnstile_token" not in saved
 

--- a/tests/test_auth_refresh.py
+++ b/tests/test_auth_refresh.py
@@ -62,11 +62,11 @@ def test_refresh_auth_rotates_and_atomically_persists_session(tmp_path) -> None:
     assert result.session_token_rotated is True
     assert result.persisted is True
     assert client.auth.accessToken == "new-access"
-    assert client.auth.cookies[CHATGPT_SESSION_COOKIE] == "new-session"
+    assert client.auth.cookies[CHATGPT_SESSION_COOKIE] == "old-session"
     assert saved["accessToken"] == "new-access"
     assert saved["sessionToken"] == "new-session"
     assert saved["account"] == {"id": "preserve-me"}
-    assert saved["cookies"][CHATGPT_SESSION_COOKIE] == "new-session"
+    assert saved["cookies"][CHATGPT_SESSION_COOKIE] == "old-session"
     assert "proof_token" not in saved
     assert "turnstile_token" not in saved
     assert not list(tmp_path.glob("*.tmp"))

--- a/tests/test_auth_refresh.py
+++ b/tests/test_auth_refresh.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from chatgpt_web_adapter.auth import CHATGPT_SESSION_COOKIE
+from chatgpt_web_adapter.auth_refresh import refresh_auth_session
+
+
+class RefreshClient:
+    def __init__(self, auth_file) -> None:
+        self.auth_file = auth_file
+        self.auth = SimpleNamespace(
+            accessToken="old-access",
+            accessTokenSource="file",
+            expires=None,
+            cookies={CHATGPT_SESSION_COOKIE: "old-session", "oai-did": "device"},
+            headers={"user-agent": "pytest"},
+        )
+        self.base_headers = {}
+
+    def _build_headers(self, extra):
+        headers = {
+            "authorization": f"Bearer {self.auth.accessToken}",
+            "cookie": "; ".join(f"{key}={value}" for key, value in self.auth.cookies.items()),
+        }
+        headers.update({key: value for key, value in extra.items() if value is not None})
+        return headers
+
+    def _json_request(self, method, url, payload, headers):
+        assert method == "GET"
+        assert url.endswith("/api/auth/session")
+        assert payload is None
+        assert "old-session" in headers["cookie"]
+        return 200, {
+            "accessToken": "new-access",
+            "sessionToken": "new-session",
+            "expires": "2030-01-01T00:00:00.000Z",
+            "user": {"id": "preserved-server-field"},
+        }
+
+
+def test_refresh_auth_rotates_and_atomically_persists_session(tmp_path) -> None:
+    auth_file = tmp_path / "auth_data.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "accessToken": "old-access",
+                "sessionToken": "old-session",
+                "account": {"id": "preserve-me"},
+                "proof_token": ["must", "disappear"],
+                "turnstile_token": "must-disappear",
+            }
+        ),
+        encoding="utf-8",
+    )
+    client = RefreshClient(auth_file)
+
+    result = refresh_auth_session(client)
+
+    saved = json.loads(auth_file.read_text(encoding="utf-8"))
+    assert result.session_token_rotated is True
+    assert result.persisted is True
+    assert client.auth.accessToken == "new-access"
+    assert client.auth.cookies[CHATGPT_SESSION_COOKIE] == "new-session"
+    assert saved["accessToken"] == "new-access"
+    assert saved["sessionToken"] == "new-session"
+    assert saved["account"] == {"id": "preserve-me"}
+    assert saved["cookies"][CHATGPT_SESSION_COOKIE] == "new-session"
+    assert "proof_token" not in saved
+    assert "turnstile_token" not in saved
+    assert not list(tmp_path.glob("*.tmp"))

--- a/tests/test_auth_status.py
+++ b/tests/test_auth_status.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+
+from chatgpt_web_adapter.auth import CHATGPT_SESSION_COOKIE
+from chatgpt_web_adapter.auth_status import get_auth_status
+
+
+def test_auth_status_reports_missing_file_without_secrets(tmp_path) -> None:
+    status = get_auth_status(tmp_path / "missing.json")
+    assert status.file_exists is False
+    assert status.access_token_needs_refresh is True
+    assert status.session_cookie_present is False
+
+
+def test_auth_status_reports_refreshable_session(tmp_path) -> None:
+    path = tmp_path / "auth.json"
+    path.write_text(
+        json.dumps(
+            {
+                "accessToken": "not.a.jwt",
+                "cookies": {CHATGPT_SESSION_COOKIE: "secret"},
+                "expires": "2030-01-01T00:00:00.000Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    status = get_auth_status(path)
+    assert status.file_exists is True
+    assert status.access_token_present is True
+    assert status.access_token_needs_refresh is False
+    assert status.session_cookie_present is True
+    assert status.session_expires_at == "2030-01-01T00:00:00.000Z"
+
+
+def test_auth_status_accepts_top_level_session_token(tmp_path) -> None:
+    path = tmp_path / "auth.json"
+    path.write_text(
+        json.dumps({"accessToken": "not.a.jwt", "sessionToken": "secret"}),
+        encoding="utf-8",
+    )
+    assert get_auth_status(path).session_cookie_present is True

--- a/tests/test_auth_status.py
+++ b/tests/test_auth_status.py
@@ -7,10 +7,14 @@ from chatgpt_web_adapter.auth_status import get_auth_status
 
 
 def test_auth_status_reports_missing_file_without_secrets(tmp_path) -> None:
-    status = get_auth_status(tmp_path / "missing.json")
+    status = get_auth_status(
+        tmp_path / "missing.json",
+        profile_dir=tmp_path / "profile",
+    )
     assert status.file_exists is False
     assert status.access_token_needs_refresh is True
     assert status.session_cookie_present is False
+    assert status.browser_profile_exists is False
 
 
 def test_auth_status_reports_refreshable_session(tmp_path) -> None:
@@ -20,17 +24,28 @@ def test_auth_status_reports_refreshable_session(tmp_path) -> None:
             {
                 "accessToken": "not.a.jwt",
                 "cookies": {CHATGPT_SESSION_COOKIE: "secret"},
+                "browserCookies": [
+                    {
+                        "name": CHATGPT_SESSION_COOKIE,
+                        "value": "secret",
+                        "domain": ".chatgpt.com",
+                    }
+                ],
                 "expires": "2030-01-01T00:00:00.000Z",
             }
         ),
         encoding="utf-8",
     )
-    status = get_auth_status(path)
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    status = get_auth_status(path, profile_dir=profile)
     assert status.file_exists is True
     assert status.access_token_present is True
     assert status.access_token_needs_refresh is False
     assert status.session_cookie_present is True
     assert status.session_expires_at == "2030-01-01T00:00:00.000Z"
+    assert status.browser_cookie_count == 1
+    assert status.browser_profile_exists is True
 
 
 def test_auth_status_accepts_top_level_session_token(tmp_path) -> None:

--- a/tests/test_auth_store.py
+++ b/tests/test_auth_store.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+
+from chatgpt_web_adapter.auth_store import persist_auth_data
+from chatgpt_web_adapter.types import AuthData
+
+
+def test_persist_auth_data_keeps_structured_browser_cookies(tmp_path) -> None:
+    path = tmp_path / "auth.json"
+    auth = AuthData(
+        accessToken="not.a.jwt",
+        cookies={"session.0": "chunk"},
+        browserCookies=[
+            {
+                "name": "session.0",
+                "value": "chunk",
+                "domain": ".chatgpt.com",
+                "path": "/",
+                "secure": True,
+            }
+        ],
+    )
+
+    persist_auth_data(auth, path)
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    loaded = AuthData.from_json(path)
+
+    assert saved["browserCookies"][0]["domain"] == ".chatgpt.com"
+    assert loaded.browserCookies == saved["browserCookies"]

--- a/tests/test_browser_cookies.py
+++ b/tests/test_browser_cookies.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from enum import Enum
+from types import SimpleNamespace
+
+from chatgpt_web_adapter.browser_cookies import (
+    browser_cookie_params,
+    flatten_browser_cookies,
+    serialize_browser_cookies,
+)
+
+
+def test_browser_cookie_round_trip_preserves_scope() -> None:
+    records = serialize_browser_cookies(
+        [
+            SimpleNamespace(
+                name="session.0",
+                value="chunk",
+                domain=".chatgpt.com",
+                path="/",
+                secure=True,
+                http_only=True,
+                same_site="Lax",
+                expires=1234.0,
+            ),
+            SimpleNamespace(
+                name="outside",
+                value="ignored",
+                domain="example.com",
+            ),
+        ]
+    )
+
+    assert records == [
+        {
+            "name": "session.0",
+            "value": "chunk",
+            "domain": ".chatgpt.com",
+            "path": "/",
+            "secure": True,
+            "http_only": True,
+            "same_site": "Lax",
+            "expires": 1234.0,
+        }
+    ]
+    assert flatten_browser_cookies(records) == {"session.0": "chunk"}
+
+
+def test_cookie_params_prefer_structured_records() -> None:
+    network = SimpleNamespace(
+        CookieParam=lambda **kwargs: kwargs,
+        TimeSinceEpoch=float,
+    )
+    cdp = SimpleNamespace(network=network)
+
+    params = browser_cookie_params(
+        cdp,
+        [
+            {
+                "name": "session.0",
+                "value": "chunk",
+                "domain": ".chatgpt.com",
+                "path": "/",
+                "secure": True,
+                "http_only": True,
+                "expires": 1234.0,
+            }
+        ],
+        {"session.0": "flat-fallback"},
+    )
+
+    assert params == [
+        {
+            "name": "session.0",
+            "value": "chunk",
+            "domain": ".chatgpt.com",
+            "path": "/",
+            "secure": True,
+            "http_only": True,
+            "expires": 1234.0,
+        }
+    ]
+
+
+def test_browser_cookie_serialization_prefers_domain_scoped_session_chunks() -> None:
+    records = serialize_browser_cookies(
+        [
+            SimpleNamespace(
+                name="__Secure-next-auth.session-token.0",
+                value="domain",
+                domain=".chatgpt.com",
+                path="/",
+            ),
+            SimpleNamespace(
+                name="__Secure-next-auth.session-token.0",
+                value="host-only-duplicate",
+                domain="chatgpt.com",
+                path="/",
+            ),
+        ]
+    )
+
+    assert len(records) == 1
+    assert records[0]["domain"] == ".chatgpt.com"
+    assert records[0]["value"] == "domain"
+
+
+def test_cookie_params_restore_enum_and_source_attributes() -> None:
+    class SameSite(Enum):
+        LAX = "Lax"
+
+    class Priority(Enum):
+        HIGH = "High"
+
+    class SourceScheme(Enum):
+        SECURE = "Secure"
+
+    network = SimpleNamespace(
+        CookieParam=lambda **kwargs: kwargs,
+        TimeSinceEpoch=float,
+        CookieSameSite=SameSite,
+        CookiePriority=Priority,
+        CookieSourceScheme=SourceScheme,
+    )
+
+    [param] = browser_cookie_params(
+        SimpleNamespace(network=network),
+        [
+            {
+                "name": "cookie",
+                "value": "value",
+                "domain": ".chatgpt.com",
+                "same_site": "Lax",
+                "priority": "High",
+                "source_scheme": "Secure",
+                "same_party": False,
+                "source_port": 443,
+            }
+        ],
+        {},
+    )
+
+    assert param["same_site"] is SameSite.LAX
+    assert param["priority"] is Priority.HIGH
+    assert param["source_scheme"] is SourceScheme.SECURE
+    assert param["same_party"] is False
+    assert param["source_port"] == 443

--- a/tests/test_browser_profile_lock.py
+++ b/tests/test_browser_profile_lock.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from chatgpt_web_adapter.browser_profile_lock import BrowserProfileLock
+
+
+def test_browser_profile_lock_rejects_concurrent_owner_then_recovers(tmp_path) -> None:
+    profile = tmp_path / "profile"
+    first = BrowserProfileLock(profile, timeout=1)
+    second = BrowserProfileLock(profile, timeout=0.05)
+
+    first.acquire()
+    try:
+        with pytest.raises(TimeoutError, match="Browser profile is busy"):
+            second.acquire()
+    finally:
+        first.release()
+
+    second.acquire()
+    second.release()

--- a/tests/test_browser_sentinel.py
+++ b/tests/test_browser_sentinel.py
@@ -67,6 +67,12 @@ def test_zendriver_provider_validates_timeout() -> None:
 def test_zendriver_provider_accepts_persistent_auth_profile(tmp_path) -> None:
     provider = ZendriverSentinelBundleProvider(profile_dir=tmp_path / "profile")
     assert provider.profile_dir == tmp_path / "profile"
+    assert provider.seeds_client_cookies is False
+
+
+def test_zendriver_provider_seeds_only_temporary_profile() -> None:
+    provider = ZendriverSentinelBundleProvider()
+    assert provider.seeds_client_cookies is True
 
 
 def test_sync_chatgpt_cookies_updates_device_binding_only_for_chatgpt() -> None:

--- a/tests/test_browser_sentinel.py
+++ b/tests/test_browser_sentinel.py
@@ -64,6 +64,11 @@ def test_zendriver_provider_validates_timeout() -> None:
         ZendriverSentinelBundleProvider(timeout=0)
 
 
+def test_zendriver_provider_accepts_persistent_auth_profile(tmp_path) -> None:
+    provider = ZendriverSentinelBundleProvider(profile_dir=tmp_path / "profile")
+    assert provider.profile_dir == tmp_path / "profile"
+
+
 def test_sync_chatgpt_cookies_updates_device_binding_only_for_chatgpt() -> None:
     from types import SimpleNamespace
 

--- a/tests/test_browser_sentinel.py
+++ b/tests/test_browser_sentinel.py
@@ -64,6 +64,48 @@ def test_zendriver_provider_validates_timeout() -> None:
         ZendriverSentinelBundleProvider(timeout=0)
 
 
+def test_zendriver_provider_validates_retry_options() -> None:
+    with pytest.raises(ValueError, match="max_attempts"):
+        ZendriverSentinelBundleProvider(max_attempts=0)
+    with pytest.raises(ValueError, match="retry_delay"):
+        ZendriverSentinelBundleProvider(retry_delay=-1)
+
+
+def test_zendriver_provider_retries_transient_capture_error(monkeypatch) -> None:
+    provider = ZendriverSentinelBundleProvider(max_attempts=3, retry_delay=0)
+    expected = _bundle_from_finalize_capture(
+        {
+            "prepare_token": "prepare",
+            "proofofwork": "proof",
+            "turnstile": "turnstile",
+        },
+        200,
+        {
+            "persona": "chatgpt-web",
+            "token": "requirements",
+            "expire_after": 60,
+            "expire_at": 1060,
+        },
+        acquired_monotonic=10,
+        acquired_wallclock=1000,
+    )
+    attempts = []
+
+    async def acquire_once(client, *, attempt):
+        attempts.append(attempt)
+        if attempt < 3:
+            raise RequestError(
+                "transient",
+                request_stage="sentinel_bundle_provider",
+            )
+        return expected
+
+    monkeypatch.setattr(provider, "_acquire_once", acquire_once)
+
+    assert provider(object()) is expected
+    assert attempts == [1, 2, 3]
+
+
 def test_zendriver_provider_accepts_persistent_auth_profile(tmp_path) -> None:
     provider = ZendriverSentinelBundleProvider(profile_dir=tmp_path / "profile")
     assert provider.profile_dir == tmp_path / "profile"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from chatgpt_web_adapter import cli
+from chatgpt_web_adapter.auth import CHATGPT_SESSION_COOKIE
+
+
+def test_auth_status_cli_reports_profile_and_structured_cookies(
+    tmp_path, capsys
+) -> None:
+    auth_file = tmp_path / "auth.json"
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    auth_file.write_text(
+        json.dumps(
+            {
+                "accessToken": "not.a.jwt",
+                "cookies": {CHATGPT_SESSION_COOKIE: "session"},
+                "browserCookies": [
+                    {
+                        "name": CHATGPT_SESSION_COOKIE,
+                        "value": "session",
+                        "domain": ".chatgpt.com",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = cli.main(
+        [
+            "auth",
+            "status",
+            "--auth-file",
+            str(auth_file),
+            "--profile-dir",
+            str(profile),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result == 0
+    assert payload["browser_cookie_count"] == 1
+    assert payload["browser_profile_exists"] is True
+
+
+def test_auth_login_force_disables_saved_auth_reuse(tmp_path, monkeypatch, capsys) -> None:
+    captured = {}
+
+    def login(path, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(auth_file=path, profile_dir=tmp_path / "profile")
+
+    monkeypatch.setattr(cli, "browser_login", login)
+
+    result = cli.main(
+        [
+            "auth",
+            "login",
+            "--auth-file",
+            str(tmp_path / "auth.json"),
+            "--force",
+        ]
+    )
+
+    assert result == 0
+    assert captured["reuse_existing_auth"] is False
+    assert "Authorization saved" in capsys.readouterr().out

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,7 @@ import base64
 import json
 import shutil
 import threading
+import time
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -294,6 +295,9 @@ def _make_chat_handler(
             if self.path == "/backend-api/f/conversation":
                 payload = json.loads(self._read_body().decode("utf-8"))
                 state["conversation_payloads"].append(payload)
+                state.setdefault("conversation_headers", []).append(
+                    {key.lower(): value for key, value in self.headers.items()}
+                )
                 if payload.get("messages"):
                     state.setdefault("approval_stream_payloads", []).append(payload)
                 if backend_status >= 400:
@@ -338,6 +342,9 @@ def _make_chat_handler(
             if self.path == "/backend-api/f/conversation/prepare":
                 payload = json.loads(self._read_body().decode("utf-8"))
                 state.setdefault("prepare_payloads", []).append(payload)
+                state.setdefault("prepare_headers", []).append(
+                    {key.lower(): value for key, value in self.headers.items()}
+                )
                 self._write_json(200, {"status": "ok", "conduit_token": "conduit-token"})
                 return
 
@@ -626,6 +633,101 @@ def test_send_with_warmup_media_and_flags_uses_prefetched_requirements(
     assert response.conversation.finish_reason == "stop"
     assert response.metrics.first_token is not None
     assert response.metrics.total is not None
+
+
+def _install_test_sentinel_bundle_provider(client: adapter.ChatGPTWebClient) -> None:
+    def provider(_client: adapter.ChatGPTWebClient) -> adapter.FinalizedSentinelBundle:
+        acquired = time.monotonic()
+        return adapter.FinalizedSentinelBundle(
+            "finalized-requirements",
+            "finalized-proof",
+            "finalized-turnstile",
+            acquired,
+            acquired + 60,
+        )
+
+    client.set_sentinel_bundle_provider(provider)
+
+
+def test_prepared_send_creates_new_chat_with_prepare_and_finalized_bundle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    _install_test_sentinel_bundle_provider(client)
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send("Create a new chat")
+
+    assert response.text == "Hello world"
+    assert response.conversation.conversation_id == "conv-123"
+    assert state["requirements_calls"] == 0
+    assert len(state["prepare_payloads"]) == 1
+    prepare_payload = state["prepare_payloads"][0]
+    assert prepare_payload["parent_message_id"] == "client-created-root"
+    assert prepare_payload["client_prepare_state"] == "none"
+    assert prepare_payload["client_prepare_dispatch"] == "debounced"
+    assert prepare_payload["client_prepare_source"] == "window_focus"
+    assert "conversation_id" not in prepare_payload
+    assert "partial_query" not in prepare_payload
+    assert "x-conduit-token" not in state["prepare_headers"][0]
+
+    payload = state["conversation_payloads"][0]
+    assert payload["parent_message_id"] == "client-created-root"
+    assert payload["client_prepare_state"] == "success"
+    assert "conversation_id" not in payload
+    headers = state["conversation_headers"][0]
+    assert headers["x-conduit-token"] == "conduit-token"
+    assert headers["openai-sentinel-chat-requirements-token"] == "finalized-requirements"
+    assert headers["openai-sentinel-proof-token"] == "finalized-proof"
+    assert headers["openai-sentinel-turnstile-token"] == "finalized-turnstile"
+
+
+def test_prepared_send_creates_new_chat_with_uploaded_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _build_client()
+    client.auth.accessToken = "test-token"
+    _install_test_sentinel_bundle_provider(client)
+    state = {
+        "requirements_calls": 0,
+        "file_create_payloads": [],
+        "conversation_payloads": [],
+        "uploaded_payloads": [],
+        "finalize_calls": 0,
+    }
+
+    with _serve(_make_chat_handler(state)) as base_url:
+        _patch_chat_endpoints(monkeypatch, base_url)
+        response = client.send(
+            "Inspect this image",
+            media=[(PNG_BYTES, "smoke.png")],
+        )
+
+    assert response.text == "Hello world"
+    assert state["requirements_calls"] == 0
+    assert state["file_create_payloads"] == [
+        {
+            "file_name": "smoke.png",
+            "file_size": len(PNG_BYTES),
+            "use_case": "multimodal",
+        }
+    ]
+    assert state["uploaded_payloads"] == [PNG_BYTES]
+    assert state["finalize_calls"] == 1
+    assert "partial_query" not in state["prepare_payloads"][0]
+    message = state["conversation_payloads"][0]["messages"][-1]
+    assert message["content"]["content_type"] == "multimodal_text"
+    assert message["metadata"]["attachments"][0]["name"] == "smoke.png"
+    assert state["conversation_headers"][0]["x-conduit-token"] == "conduit-token"
 
 
 def test_send_instant_mode_uses_minimal_payload_without_thinking_effort(

--- a/tests/test_client_auth_lifecycle.py
+++ b/tests/test_client_auth_lifecycle.py
@@ -58,3 +58,28 @@ def test_client_auto_login_recovers_failed_session_refresh(tmp_path, monkeypatch
     client = ChatGPTWebClient(auth_file=auth_file, auto_login=True, curl_bin="curl")
     assert client.auth is recovered
     assert client.base_headers["user-agent"]
+
+
+def test_client_can_configure_persistent_sentinel_automatically(tmp_path) -> None:
+    from chatgpt_web_adapter.browser_sentinel import ZendriverSentinelBundleProvider
+
+    client = ChatGPTWebClient(
+        auth=AuthData(
+            accessToken="not.a.jwt",
+            cookies={CHATGPT_SESSION_COOKIE: "session"},
+        ),
+        auto_refresh_auth=False,
+        auto_sentinel=True,
+        browser_profile_dir=tmp_path / "profile",
+        sentinel_timeout=12,
+        sentinel_max_attempts=3,
+        sentinel_headless=True,
+        curl_bin="curl",
+    )
+
+    provider = client._sentinel_bundle_provider
+    assert isinstance(provider, ZendriverSentinelBundleProvider)
+    assert provider.profile_dir == tmp_path / "profile"
+    assert provider.timeout == 12
+    assert provider.max_attempts == 3
+    assert provider.headless is True

--- a/tests/test_client_auth_lifecycle.py
+++ b/tests/test_client_auth_lifecycle.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+
+from chatgpt_web_adapter import AuthData, BrowserLoginResult, ChatGPTWebClient
+from chatgpt_web_adapter.auth import CHATGPT_SESSION_COOKIE
+from chatgpt_web_adapter.exceptions import AuthError
+
+
+def test_client_auto_login_bootstraps_missing_auth(tmp_path, monkeypatch) -> None:
+    auth_file = tmp_path / "missing.json"
+    captured = AuthData(
+        accessToken="captured-token",
+        cookies={CHATGPT_SESSION_COOKIE: "captured-session"},
+    )
+
+    def fake_login(path, **kwargs):
+        assert path == auth_file
+        return BrowserLoginResult(captured, auth_file, tmp_path / "profile", True)
+
+    monkeypatch.setattr("chatgpt_web_adapter.auth_browser.browser_login", fake_login)
+    client = ChatGPTWebClient(
+        auth_file=auth_file,
+        auto_login=True,
+        auto_refresh_auth=False,
+        curl_bin="curl",
+    )
+    assert client.auth is captured
+
+
+def test_client_auto_login_recovers_failed_session_refresh(tmp_path, monkeypatch) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps(
+            {
+                "accessToken": None,
+                "cookies": {CHATGPT_SESSION_COOKIE: "dead-session"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    recovered = AuthData(
+        accessToken="recovered-token",
+        cookies={CHATGPT_SESSION_COOKIE: "recovered-session"},
+    )
+
+    monkeypatch.setattr(
+        "chatgpt_web_adapter.auth_refresh.refresh_auth_session",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AuthError("session rejected")),
+    )
+    monkeypatch.setattr(
+        "chatgpt_web_adapter.auth_browser.browser_login",
+        lambda *args, **kwargs: BrowserLoginResult(
+            recovered, auth_file, tmp_path / "profile", True
+        ),
+    )
+
+    client = ChatGPTWebClient(auth_file=auth_file, auto_login=True, curl_bin="curl")
+    assert client.auth is recovered
+    assert client.base_headers["user-agent"]

--- a/tests/test_conversation_prepare.py
+++ b/tests/test_conversation_prepare.py
@@ -77,7 +77,35 @@ def test_prepare_text_turn_retains_token_only_in_memory() -> None:
     assert payload["partial_query"]["content"]["parts"] == ["secret prompt"]
 
 
-def test_normal_send_is_not_wired_to_prepare_boundary() -> None:
-    source = inspect.getsource(adapter.ChatGPTWebClient.send)
-    assert "prepare_text_turn" not in source
-    assert "CHAT_CONVERSATION_PREPARE_URL" not in source
+def test_normal_send_is_wired_to_prepare_boundary_when_provider_is_installed() -> None:
+    source = inspect.getsource(adapter._original_send)
+    assert "prepare_text_turn" in source
+    assert "CHAT_CONVERSATION_PREPARE_URL" in source
+
+
+def test_new_chat_prepare_omits_partial_query_and_initial_conduit() -> None:
+    class Client:
+        def _build_headers(self, extra):
+            return {key: value for key, value in extra.items() if value is not None}
+
+        def _json_request(self, method, url, payload, headers):
+            assert "partial_query" not in payload
+            assert payload["client_prepare_state"] == "none"
+            assert payload["client_prepare_dispatch"] == "debounced"
+            assert payload["client_prepare_source"] == "window_focus"
+            assert "x-conduit-token" not in headers
+            return 200, {"status": "ok", "conduit_token": "secret-conduit"}
+
+    result, payload = prepare_text_turn(
+        Client(),
+        "hello",
+        model="gpt-5-6-thinking",
+        include_partial_query=False,
+        client_prepare_state="none",
+        client_prepare_dispatch="debounced",
+        client_prepare_source="window_focus",
+        initial_conduit_token=None,
+    )
+
+    assert result.status_ok is True
+    assert "partial_query" not in payload


### PR DESCRIPTION
## Summary

- add persistent browser-based web auth with `login`, `login --force`, `status`, and `refresh` CLI flows
- refresh access/session metadata through `/api/auth/session` while preserving browser-issued scoped cookies
- protect new-chat, continuation, and multimodal writes with official-page Sentinel bundles
- persist structured `browserCookies`, serialize access to the Chromium profile, and retry transient Sentinel capture failures
- add `auto_sentinel=True`, headless post-login operation, Python 3.14 CI coverage, and prepare version 0.1.7

## Verification

- `657 passed`
- built wheel and sdist with `python -m build`
- `twine check` passed for both artifacts
- installed the wheel in a clean virtual environment
- installed the wheel with `[browser]` and completed a live headless request

## Live smoke

- first-turn system prompt
- new chat and continuation
- attach, message read, and completed status
- `/api/auth/session` refresh
- PNG, JPEG, GIF, and WebP uploads
- multiple images and image continuation
- headless Sentinel capture from the installed wheel

## Notes

- the initial login still requires an interactive Chromium window
- protected writes still require Chromium as the browser engine
- ChatGPT web endpoints and Sentinel behavior remain undocumented compatibility surfaces
- connector approval flows were not exercised live because they can cause external side effects