### PR TITLE
PR8.14 — Stable Product Inspection CLI, Product-Native Model Profile Aliases and Exit-Code Contract

### DIFF
--- a/docs/stable_product_inspection_cli_pr8_14.md
+++ b/docs/stable_product_inspection_cli_pr8_14.md
@@ -1,0 +1,163 @@
+# PR8.14 — Stable Product Inspection CLI, Product-Native Model Profile Aliases and Exit-Code Contract
+
+_Status: CLOSED / PASS_
+
+_Date: 2026-08-21_
+
+_Base: `main` after integration PR #48 (`421e0b4bc4a92b7b23bfb28202907a6d5d10f1f9`)_
+
+## Scope
+
+PR8.14 starts CWA 0.2 stabilization. It adds a stable public CLI front controller without changing the proven product transport, browser write path, canonical read path, retry policy, or fallback policy.
+
+Both console entry points route through `chatgpt_web_adapter.cli_v02:main`. The older `chatgpt_web_adapter.cli` remains the compatibility runner underneath it.
+
+## Stable inspection commands
+
+```powershell
+cwa status
+cwa status --conversation <id-or-url>
+cwa capabilities
+cwa messages <id-or-url>
+```
+
+All three commands are read-only and support `--json`.
+
+`status` reports the existing `ProductRuntimeHealth`. A valid inspection that observes an unhealthy runtime returns exit `1`; it is not treated as an operational exception.
+
+`capabilities` reports the existing evidence-backed `ProductCapabilities` plus the public model-profile naming contract.
+
+`messages` uses `ChatGPTProductRuntime.get_messages()` and returns normalized `ChatMessage.to_dict()` items from the canonical current branch. It supports `--limit`, repeated `--role`, and `--include-empty`.
+
+The artifact boundary is explicit:
+
+```text
+messages = inspect canonical product state now
+snapshot = create a deterministic ConversationSnapshot artifact on disk
+export   = broader/raw archival representation
+
+messages != snapshot != export
+```
+
+## Product-native model profile aliases
+
+The already-proven mapping is accepted directly by the public CLI:
+
+```text
+FAST     <-> INSTANT
+BALANCED <-> MEDIUM
+DEEP     <-> HIGH
+```
+
+Product-native names are first-class input:
+
+```powershell
+cwa send "..." --profile INSTANT
+cwa send "..." --profile MEDIUM
+cwa send "..." --profile HIGH
+```
+
+Existing semantic names remain compatible. Input normalizes before the existing selector:
+
+```text
+INSTANT -> FAST     -> product INSTANT
+MEDIUM  -> BALANCED -> product MEDIUM
+HIGH    -> DEEP     -> product HIGH
+```
+
+The public default is `HIGH`; the existing internal semantic key remains `DEEP`. No selector, slider-index, Browser Authority, prewrite selection, or provenance semantics change. `MAX` remains unmapped because no fourth product state is proven.
+
+## Machine-readable schema
+
+Successful inspection commands use `schema = 1`, `command`, and `ok`.
+
+`status` adds `transport` and `health`; `capabilities` adds `transport`, `product`, and `model_profiles`; `messages` adds `conversation_id`, `count`, and `messages`.
+
+For `--json`, post-parse failures use the same schema with `ok=false` and an `error` object. Bounded structured exception fields are included when available. Argparse syntax failures remain normal argparse stderr failures because no parsed command payload exists yet.
+
+## Exit-code contract
+
+```text
+0 = success
+1 = valid inspection observed unhealthy/unavailable state
+2 = CLI usage or input validation failure
+3 = product/runtime operational failure
+4 = ambiguous write outcome requiring reconciliation
+```
+
+Exit `4` is selected only when structured exception state reports `reconciliation_required == true`; message text is not used to infer ambiguity.
+
+## Compatibility and safety
+
+Existing `auth`, `snapshot`, `send`, `browser-native`, and `runtime` commands continue through the compatibility runner. Nested `runtime status` remains supported, while the new top-level inspection commands are the intended 0.2-facing surface.
+
+The new commands do not call `send_text()` or `send_text_observed()` and introduce no automatic write retry or fallback.
+
+## Regression evidence
+
+User-reported on 2026-08-21:
+
+```text
+focused PR8.14                10 passed in 0.21s
+relevant CLI/runtime          27 passed in 0.25s
+full repository suite       1246 passed in 23.31s
+```
+
+## Production CLI smoke evidence
+
+`cwa capabilities --json` passed with:
+
+```text
+ok = true
+schema = 1
+default profile = HIGH
+accepted = INSTANT, MEDIUM, HIGH, FAST, BALANCED, DEEP
+HIGH -> DEEP
+MEDIUM -> BALANCED
+INSTANT -> FAST
+max_mapped = false
+```
+
+`cwa status --json` passed with:
+
+```text
+ok = true
+health.ready = true
+reason = READY_FOR_BROWSER_OWNED_WRITE
+bridge_available = true
+extension_connected = true
+automatic_write_retry = false
+fallback_transport = null
+```
+
+A controlled public alias write passed:
+
+```text
+cwa send "Reply with exactly: CWA_PR8_14_HIGH_ALIAS_OK" --profile HIGH --json
+```
+
+Observed result:
+
+```text
+ok = true
+text = CWA_PR8_14_HIGH_ALIAS_OK
+backend_status = 200
+completion.source = CANONICAL_READBACK
+canonical_completion_proven = true
+write_event_observed = true
+conversation_mode = NORMAL
+```
+
+This smoke proves that the public CLI accepts `HIGH` and dispatches successfully through the existing profile-selection path. The generic send JSON does not itself expose `selected_mode_after=HIGH`; browser-side HIGH selection remains covered by the previously frozen PR8.10 live evidence. PR8.14 does not alter that selector.
+
+A direct read-only production smoke also passed for the same conversation:
+
+```powershell
+cwa messages 6a8863ef-a89c-83eb-afd5-02389d6fc849 --json
+```
+
+The returned schema, conversation id, normalized user message, assistant response `CWA_PR8_14_HIGH_ALIAS_OK`, and message count matched the PR8.14 contract. No product write was performed by this inspection command.
+
+## Closure
+
+PR8.14 is closed as PASS. The stable public surface now includes read-only `status`, `capabilities`, and `messages`; product-native profile names are first-class aliases; and CLI exit classes are frozen for the 0.2 stabilization line.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ test = ["pytest>=8"]
 browser = ["zendriver==0.15.3"]
 
 [project.scripts]
-chatgpt-web-adapter = "chatgpt_web_adapter.cli:main"
-cwa = "chatgpt_web_adapter.cli:main"
+chatgpt-web-adapter = "chatgpt_web_adapter.cli_v02:main"
+cwa = "chatgpt_web_adapter.cli_v02:main"
 chatgpt-web-adapter-native-host = "chatgpt_web_adapter.browser_native_host:main"
 
 [tool.setuptools]

--- a/src/chatgpt_web_adapter/cli_v02.py
+++ b/src/chatgpt_web_adapter/cli_v02.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any, Sequence
+
+from . import cli as legacy_cli
+from .auth import DEFAULT_AUTH_FILE
+from .product_runtime import (
+    DEFAULT_PRODUCT_TRANSPORT,
+    SUPPORTED_PRODUCT_TRANSPORTS,
+    assemble_product_runtime,
+)
+from .types import ConversationRef
+
+CLI_CONTRACT_SCHEMA = 1
+EXIT_OK = 0
+EXIT_UNAVAILABLE = 1
+EXIT_USAGE = 2
+EXIT_OPERATION_FAILED = 3
+EXIT_RECONCILIATION_REQUIRED = 4
+
+PRODUCT_NATIVE_MODEL_PROFILES: tuple[str, ...] = ("INSTANT", "MEDIUM", "HIGH")
+SEMANTIC_MODEL_PROFILES: tuple[str, ...] = ("FAST", "BALANCED", "DEEP")
+PUBLIC_MODEL_PROFILES: tuple[str, ...] = (
+    *PRODUCT_NATIVE_MODEL_PROFILES,
+    *SEMANTIC_MODEL_PROFILES,
+)
+PRODUCT_NATIVE_TO_SEMANTIC: dict[str, str] = {
+    "INSTANT": "FAST",
+    "MEDIUM": "BALANCED",
+    "HIGH": "DEEP",
+}
+SEMANTIC_TO_PRODUCT_NATIVE: dict[str, str] = {
+    semantic: product
+    for product, semantic in PRODUCT_NATIVE_TO_SEMANTIC.items()
+}
+DEFAULT_PUBLIC_MODEL_PROFILE = "HIGH"
+
+
+def normalize_public_model_profile(value: str) -> str:
+    """Normalize product-native or semantic profile names to CWA's proven semantic key."""
+
+    if not isinstance(value, str):
+        raise TypeError("profile must be a string")
+    normalized = value.strip().upper()
+    if normalized in PRODUCT_NATIVE_TO_SEMANTIC:
+        return PRODUCT_NATIVE_TO_SEMANTIC[normalized]
+    if normalized in SEMANTIC_MODEL_PROFILES:
+        return normalized
+    supported = ", ".join(PUBLIC_MODEL_PROFILES)
+    raise ValueError(f"unsupported profile {value!r}; expected one of: {supported}")
+
+
+def product_native_model_profile(value: str) -> str:
+    semantic = normalize_public_model_profile(value)
+    return SEMANTIC_TO_PRODUCT_NATIVE[semantic]
+
+
+def _argparse_model_profile(value: str) -> str:
+    try:
+        return normalize_public_model_profile(value)
+    except (TypeError, ValueError) as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def model_profile_contract() -> dict[str, Any]:
+    return {
+        "default": DEFAULT_PUBLIC_MODEL_PROFILE,
+        "product_native": list(PRODUCT_NATIVE_MODEL_PROFILES),
+        "semantic_aliases": dict(SEMANTIC_TO_PRODUCT_NATIVE),
+        "accepted": list(PUBLIC_MODEL_PROFILES),
+        "normalization": dict(PRODUCT_NATIVE_TO_SEMANTIC),
+        "max_mapped": False,
+    }
+
+
+def _root_subparsers(parser: argparse.ArgumentParser) -> argparse._SubParsersAction:
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    raise RuntimeError("PR8_14_ROOT_SUBPARSERS_MISSING")
+
+
+def _configure_send_profile(parser: argparse.ArgumentParser) -> None:
+    root = _root_subparsers(parser)
+    send = root.choices.get("send")
+    if send is None:
+        raise RuntimeError("PR8_14_SEND_COMMAND_MISSING")
+    for action in send._actions:
+        if action.dest != "profile":
+            continue
+        action.type = _argparse_model_profile
+        action.choices = None
+        action.metavar = "{INSTANT,MEDIUM,HIGH,FAST,BALANCED,DEEP}"
+        action.help = (
+            "product model profile; default HIGH. Semantic aliases remain supported: "
+            "FAST=INSTANT, BALANCED=MEDIUM, DEEP=HIGH"
+        )
+        return
+    raise RuntimeError("PR8_14_SEND_PROFILE_ARGUMENT_MISSING")
+
+
+def _add_inspection_common(command: argparse.ArgumentParser) -> None:
+    command.add_argument("--auth-file", type=Path, default=DEFAULT_AUTH_FILE)
+    command.add_argument(
+        "--transport",
+        choices=SUPPORTED_PRODUCT_TRANSPORTS,
+        default=DEFAULT_PRODUCT_TRANSPORT,
+        help="product transport to inspect; no automatic fallback is performed",
+    )
+    command.add_argument(
+        "--json",
+        action="store_true",
+        help="print the stable PR8.14 machine-readable schema",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = legacy_cli._build_parser()
+    parser.prog = "cwa"
+    _configure_send_profile(parser)
+    root = _root_subparsers(parser)
+
+    status = root.add_parser(
+        "status",
+        help="inspect product-runtime readiness without performing a write",
+    )
+    _add_inspection_common(status)
+    status.add_argument(
+        "--conversation",
+        help="optional raw conversation id or ChatGPT conversation URL to check canonically",
+    )
+
+    capabilities = root.add_parser(
+        "capabilities",
+        help="inspect evidence-backed product capabilities without performing a write",
+    )
+    _add_inspection_common(capabilities)
+
+    messages = root.add_parser(
+        "messages",
+        help="read normalized messages from the canonical current conversation branch",
+    )
+    _add_inspection_common(messages)
+    messages.add_argument("conversation", help="raw conversation id or ChatGPT conversation URL")
+    messages.add_argument("--limit", type=int)
+    messages.add_argument(
+        "--role",
+        action="append",
+        dest="roles",
+        help="include only this role; repeat to select multiple roles",
+    )
+    messages.add_argument(
+        "--include-empty",
+        action="store_true",
+        help="include messages whose normalized text is empty",
+    )
+
+    return parser
+
+
+def _json_print(payload: dict[str, Any], *, stream=None) -> None:
+    print(
+        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True),
+        file=stream if stream is not None else sys.stdout,
+    )
+
+
+def _runtime_for(args: argparse.Namespace):
+    return assemble_product_runtime(
+        transport=args.transport,
+        auth_file=args.auth_file,
+    )
+
+
+def _run_status(args: argparse.Namespace) -> int:
+    runtime = _runtime_for(args)
+    health = runtime.health(args.conversation)
+    payload = {
+        "schema": CLI_CONTRACT_SCHEMA,
+        "command": "status",
+        "ok": bool(health.ready),
+        "transport": runtime.transport,
+        "health": health.to_dict(),
+    }
+    if args.json:
+        _json_print(payload)
+    else:
+        print(f"ready: {str(bool(health.ready)).lower()}")
+        print(f"transport: {runtime.transport}")
+        print(f"reason: {health.reason}")
+        if health.conversation_id is not None:
+            print(f"conversation_id: {health.conversation_id}")
+        if health.canonical_status is not None:
+            print(f"canonical_status: {health.canonical_status}")
+        if health.extension_connected is not None:
+            print(f"extension_connected: {str(bool(health.extension_connected)).lower()}")
+    return EXIT_OK if health.ready else EXIT_UNAVAILABLE
+
+
+def _run_capabilities(args: argparse.Namespace) -> int:
+    runtime = _runtime_for(args)
+    capabilities = runtime.capabilities().to_dict()
+    payload = {
+        "schema": CLI_CONTRACT_SCHEMA,
+        "command": "capabilities",
+        "ok": True,
+        "transport": runtime.transport,
+        "product": capabilities,
+        "model_profiles": model_profile_contract(),
+    }
+    if args.json:
+        _json_print(payload)
+    else:
+        print(f"transport: {runtime.transport}")
+        entries = capabilities.get("capabilities", {})
+        for name in sorted(entries):
+            entry = entries[name]
+            state = entry.get("state", "UNKNOWN") if isinstance(entry, dict) else "UNKNOWN"
+            owner = entry.get("owner", "UNKNOWN") if isinstance(entry, dict) else "UNKNOWN"
+            print(f"{name}: {state} ({owner})")
+        print("model_profiles: INSTANT MEDIUM HIGH")
+        print("aliases: FAST=INSTANT BALANCED=MEDIUM DEEP=HIGH")
+    return EXIT_OK
+
+
+def _run_messages(args: argparse.Namespace) -> int:
+    if args.limit is not None and args.limit < 0:
+        raise ValueError("--limit must be greater than or equal to 0")
+    runtime = _runtime_for(args)
+    ref = ConversationRef.from_any(args.conversation)
+    messages = runtime.get_messages(
+        ref,
+        limit=args.limit,
+        roles=args.roles,
+        include_empty=args.include_empty,
+    )
+    payload = {
+        "schema": CLI_CONTRACT_SCHEMA,
+        "command": "messages",
+        "ok": True,
+        "conversation_id": ref.conversation_id,
+        "count": len(messages),
+        "messages": [message.to_dict() for message in messages],
+    }
+    if args.json:
+        _json_print(payload)
+    else:
+        for message in messages:
+            role = message.role or "unknown"
+            print(f"[{role}] {message.text}")
+    return EXIT_OK
+
+
+def _legacy_dispatch(args: argparse.Namespace) -> int:
+    if args.command == "auth":
+        return legacy_cli._run_auth(args)
+    if args.command == "snapshot":
+        return legacy_cli._run_snapshot(args)
+    if args.command == "send":
+        return legacy_cli._run_send(args)
+    if args.command == "browser-native":
+        return legacy_cli._run_browser_native(args)
+    if args.command == "runtime":
+        return legacy_cli._run_runtime(args)
+    raise ValueError(f"unsupported command: {args.command}")
+
+
+def _error_exit_code(error: BaseException) -> int:
+    if getattr(error, "reconciliation_required", False) is True:
+        return EXIT_RECONCILIATION_REQUIRED
+    if isinstance(error, (TypeError, ValueError)):
+        return EXIT_USAGE
+    return EXIT_OPERATION_FAILED
+
+
+def _error_payload(args: argparse.Namespace, error: BaseException, exit_code: int) -> dict[str, Any]:
+    detail: dict[str, Any] = {
+        "type": type(error).__name__,
+        "message": str(error),
+        "exit_code": exit_code,
+    }
+    for name in (
+        "request_stage",
+        "status_code",
+        "endpoint",
+        "write_may_have_been_submitted",
+        "reconciliation_required",
+    ):
+        if hasattr(error, name):
+            detail[name] = getattr(error, name)
+    return {
+        "schema": CLI_CONTRACT_SCHEMA,
+        "command": getattr(args, "command", None),
+        "ok": False,
+        "error": detail,
+    }
+
+
+def _emit_error(args: argparse.Namespace, error: BaseException, exit_code: int) -> None:
+    if getattr(args, "json", False):
+        _json_print(_error_payload(args, error, exit_code), stream=sys.stderr)
+    else:
+        print(f"error: {error}", file=sys.stderr)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "status":
+            return _run_status(args)
+        if args.command == "capabilities":
+            return _run_capabilities(args)
+        if args.command == "messages":
+            return _run_messages(args)
+        return _legacy_dispatch(args)
+    except Exception as error:
+        exit_code = _error_exit_code(error)
+        _emit_error(args, error, exit_code)
+        return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stable_product_inspection_cli_pr8_14.py
+++ b/tests/test_stable_product_inspection_cli_pr8_14.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import chatgpt_web_adapter.cli_v02 as cli
+
+
+class _Health:
+    def __init__(self, *, ready: bool = True) -> None:
+        self.ready = ready
+        self.reason = "ready" if ready else "bridge unavailable"
+        self.conversation_id = "conversation-1"
+        self.canonical_status = "completed" if ready else None
+        self.extension_connected = ready
+
+    def to_dict(self):
+        return {
+            "transport": "browser-owned",
+            "ready": self.ready,
+            "reason": self.reason,
+            "conversation_id": self.conversation_id,
+            "canonical_status": self.canonical_status,
+            "canonical_read_checked": True,
+            "read_plane": "BROWSERLESS_CANONICAL_HTTP",
+            "session_plane": "CANONICAL_SESSION",
+            "write_plane": "BROWSER_NATIVE_PAGE_OWNED_WRITE",
+            "automatic_write_retry": False,
+            "fallback_transport": None,
+            "bridge_available": self.ready,
+            "extension_connected": self.extension_connected,
+            "runtime_tab_id": 7 if self.ready else None,
+            "runtime_tab_preexisting": True if self.ready else None,
+        }
+
+
+class _CapabilitySet:
+    def to_dict(self):
+        return {
+            "transport": "browser-owned",
+            "product_semantics": "ordinary-chatgpt",
+            "capabilities": {
+                "streaming": {
+                    "state": "AVAILABLE",
+                    "owner": "TRANSPORT",
+                    "evidence": "test",
+                },
+                "temporary_chat": {
+                    "state": "AVAILABLE",
+                    "owner": "TRANSPORT",
+                    "evidence": "test",
+                },
+            },
+        }
+
+
+class _Message:
+    def __init__(self, role: str, text: str) -> None:
+        self.role = role
+        self.text = text
+
+    def to_dict(self):
+        return {
+            "node_id": f"node-{self.role}",
+            "message_id": f"message-{self.role}",
+            "role": self.role,
+            "text": self.text,
+            "create_time": 1.0,
+            "recipient": None,
+            "model": None,
+            "finish_reason": None,
+            "metadata_preview": {},
+        }
+
+
+class _Runtime:
+    transport = "browser-owned"
+
+    def __init__(self, *, ready: bool = True) -> None:
+        self.ready = ready
+        self.message_call = None
+        self.write_called = False
+
+    def health(self, conversation=None):
+        return _Health(ready=self.ready)
+
+    def capabilities(self):
+        return _CapabilitySet()
+
+    def get_messages(self, conversation, **kwargs):
+        self.message_call = (conversation, kwargs)
+        return [_Message("user", "hello"), _Message("assistant", "world")]
+
+    def send_text_observed(self, *args, **kwargs):
+        self.write_called = True
+        raise AssertionError("PR8.14 inspection commands must not write")
+
+
+def test_product_native_and_semantic_profile_names_normalize_to_proven_keys() -> None:
+    assert cli.normalize_public_model_profile("INSTANT") == "FAST"
+    assert cli.normalize_public_model_profile("fast") == "FAST"
+    assert cli.normalize_public_model_profile("MEDIUM") == "BALANCED"
+    assert cli.normalize_public_model_profile("balanced") == "BALANCED"
+    assert cli.normalize_public_model_profile("HIGH") == "DEEP"
+    assert cli.normalize_public_model_profile("deep") == "DEEP"
+    assert cli.product_native_model_profile("DEEP") == "HIGH"
+
+    with pytest.raises(ValueError, match="unsupported profile"):
+        cli.normalize_public_model_profile("MAX")
+
+
+def test_send_accepts_product_native_alias_and_delegates_canonical_profile(monkeypatch) -> None:
+    captured = {}
+
+    def fake_run_send(args):
+        captured["profile"] = args.profile
+        return 0
+
+    monkeypatch.setattr(cli.legacy_cli, "_run_send", fake_run_send)
+
+    assert cli.main(["send", "hello", "--profile", "HIGH"]) == 0
+    assert captured["profile"] == "DEEP"
+
+    assert cli.main(["send", "hello", "--profile", "medium"]) == 0
+    assert captured["profile"] == "BALANCED"
+
+    assert cli.main(["send", "hello", "--profile", "instant"]) == 0
+    assert captured["profile"] == "FAST"
+
+
+def test_profile_contract_exposes_product_names_first_and_keeps_semantic_aliases() -> None:
+    contract = cli.model_profile_contract()
+
+    assert contract["default"] == "HIGH"
+    assert contract["product_native"] == ["INSTANT", "MEDIUM", "HIGH"]
+    assert contract["semantic_aliases"] == {
+        "FAST": "INSTANT",
+        "BALANCED": "MEDIUM",
+        "DEEP": "HIGH",
+    }
+    assert contract["normalization"] == {
+        "INSTANT": "FAST",
+        "MEDIUM": "BALANCED",
+        "HIGH": "DEEP",
+    }
+    assert contract["max_mapped"] is False
+
+
+def test_status_is_read_only_and_unhealthy_state_uses_exit_one(monkeypatch, capsys) -> None:
+    runtime = _Runtime(ready=False)
+    monkeypatch.setattr(cli, "assemble_product_runtime", lambda **kwargs: runtime)
+
+    code = cli.main(["status", "--conversation", "conversation-1", "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == cli.EXIT_UNAVAILABLE
+    assert payload["schema"] == 1
+    assert payload["command"] == "status"
+    assert payload["ok"] is False
+    assert payload["health"]["ready"] is False
+    assert runtime.write_called is False
+
+
+def test_capabilities_is_read_only_and_exports_profile_alias_contract(monkeypatch, capsys) -> None:
+    runtime = _Runtime()
+    monkeypatch.setattr(cli, "assemble_product_runtime", lambda **kwargs: runtime)
+
+    code = cli.main(["capabilities", "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == cli.EXIT_OK
+    assert payload["schema"] == 1
+    assert payload["command"] == "capabilities"
+    assert payload["ok"] is True
+    assert payload["product"]["capabilities"]["temporary_chat"]["state"] == "AVAILABLE"
+    assert payload["model_profiles"]["default"] == "HIGH"
+    assert runtime.write_called is False
+
+
+def test_messages_reads_canonical_current_branch_without_creating_artifacts(
+    monkeypatch,
+    capsys,
+) -> None:
+    runtime = _Runtime()
+    monkeypatch.setattr(cli, "assemble_product_runtime", lambda **kwargs: runtime)
+
+    code = cli.main(
+        [
+            "messages",
+            "https://chatgpt.com/c/conversation-1",
+            "--limit",
+            "2",
+            "--role",
+            "user",
+            "--role",
+            "assistant",
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == cli.EXIT_OK
+    assert payload["schema"] == 1
+    assert payload["command"] == "messages"
+    assert payload["conversation_id"] == "conversation-1"
+    assert payload["count"] == 2
+    assert [item["role"] for item in payload["messages"]] == ["user", "assistant"]
+    conversation, kwargs = runtime.message_call
+    assert conversation.conversation_id == "conversation-1"
+    assert kwargs == {
+        "limit": 2,
+        "roles": ["user", "assistant"],
+        "include_empty": False,
+    }
+    assert runtime.write_called is False
+
+
+def test_negative_message_limit_is_usage_error_with_stable_json_envelope(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(cli, "assemble_product_runtime", lambda **kwargs: _Runtime())
+
+    code = cli.main(["messages", "conversation-1", "--limit", "-1", "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert captured.out == ""
+    assert code == cli.EXIT_USAGE
+    assert payload["schema"] == 1
+    assert payload["ok"] is False
+    assert payload["error"]["exit_code"] == cli.EXIT_USAGE
+    assert payload["error"]["type"] == "ValueError"
+
+
+def test_operational_failure_uses_exit_three(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        cli,
+        "assemble_product_runtime",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("transport failed")),
+    )
+
+    code = cli.main(["status", "--json"])
+
+    payload = json.loads(capsys.readouterr().err)
+    assert code == cli.EXIT_OPERATION_FAILED
+    assert payload["error"]["exit_code"] == cli.EXIT_OPERATION_FAILED
+    assert payload["error"]["message"] == "transport failed"
+
+
+def test_reconciliation_required_failure_uses_exit_four(monkeypatch, capsys) -> None:
+    class _Ambiguous(RuntimeError):
+        reconciliation_required = True
+        write_may_have_been_submitted = True
+        request_stage = "conversation_write"
+
+    monkeypatch.setattr(
+        cli.legacy_cli,
+        "_run_send",
+        lambda args: (_ for _ in ()).throw(_Ambiguous("write outcome ambiguous")),
+    )
+
+    code = cli.main(["send", "hello", "--json"])
+
+    payload = json.loads(capsys.readouterr().err)
+    assert code == cli.EXIT_RECONCILIATION_REQUIRED
+    assert payload["error"]["exit_code"] == cli.EXIT_RECONCILIATION_REQUIRED
+    assert payload["error"]["reconciliation_required"] is True
+    assert payload["error"]["write_may_have_been_submitted"] is True
+
+
+def test_public_console_scripts_route_through_stable_pr814_front_controller() -> None:
+    text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'chatgpt-web-adapter = "chatgpt_web_adapter.cli_v02:main"' in text
+    assert 'cwa = "chatgpt_web_adapter.cli_v02:main"' in text


### PR DESCRIPTION
## Summary

Begins CWA 0.2 stabilization with a stable public CLI front-controller layered above the existing proven runtime.

### New read-only public commands

- `cwa status [--conversation <id-or-url>]`
- `cwa capabilities`
- `cwa messages <id-or-url>`

All support `--json`. Inspection commands are read-only and do not call product write methods.

### Product-native model profile aliases

The public CLI accepts both product-native names and existing CWA semantic aliases:

```text
INSTANT <-> FAST
MEDIUM  <-> BALANCED
HIGH    <-> DEEP
```

Product-native names normalize to the already-proven semantic selector before dispatch. Selector, slider indices, Browser Authority, prewrite selection, and provenance semantics are unchanged. `MAX` remains unmapped.

### Stable exit classes

```text
0 success
1 valid inspection observed unhealthy/unavailable state
2 usage/input validation failure
3 product/runtime operational failure
4 reconciliation-required ambiguous write outcome
```

Exit `4` is derived only from structured `reconciliation_required == true` exception state.

### Compatibility

Both console scripts route through `chatgpt_web_adapter.cli_v02:main`. Existing `auth`, `snapshot`, `send`, `browser-native`, and `runtime` commands delegate to the previous compatibility runner.

The artifact boundary remains explicit:

```text
messages != snapshot != export
```

## Evidence

```text
focused PR8.14          10 passed in 0.21s
relevant CLI/runtime    27 passed in 0.25s
full repository suite 1246 passed in 23.31s
```

Production CLI smoke:

- `cwa capabilities --json` — PASS; schema 1, default `HIGH`, all six accepted aliases, `MAX` unmapped.
- `cwa status --json` — PASS; runtime ready, bridge/extension connected, no retry/fallback.
- `cwa send ... --profile HIGH --json` — PASS; response `CWA_PR8_14_HIGH_ALIAS_OK`, backend 200, canonical completion proven.
- `cwa messages <created-conversation> --json` — PASS; canonical read returned the expected normalized user/assistant messages and schema without a product write.

The HIGH smoke proves the public alias path into the existing selector. Browser-side HIGH selection itself remains covered by frozen PR8.10 live evidence; PR8.14 does not alter that selector.

## Final branch state

Single clean PR8.14 commit on top of `main`; 4 files changed; no browser extension or product write path changes.

## Status

**CLOSED / PASS — ready for review.**

## Merge policy

Do not merge without explicit authorization.