### PR TITLE
PR8.17 — Packaging / CI / Release Hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -45,10 +45,10 @@ jobs:
           python -m pip install -e .[test]
 
       - name: Run test suite
-        run: pytest -q
+        run: python -m pytest -q
 
   build:
-    name: Build package
+    name: Build release artifacts
     runs-on: ubuntu-latest
     needs:
       - tests
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -73,7 +73,46 @@ jobs:
       - name: Validate package metadata
         run: python -m twine check dist/*
 
-      - name: Smoke test built wheel
-        run: |
-          python -m pip install --force-reinstall dist/*.whl
-          python -c "from chatgpt_web_adapter import ChatGPTWebClient, __all__; assert 'ChatGPTWebClient' in __all__"
+      - name: Validate release artifact contract
+        run: python tools/release_gate.py --dist-dir dist
+
+      - name: Upload built distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: cwa-dist
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  installed-wheel-smoke:
+    name: Installed wheel (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        python-version:
+          - "3.10"
+          - "3.14"
+
+    steps:
+      - name: Check out release smoke tooling
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download exact built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: cwa-dist
+          path: dist
+
+      - name: Install and smoke-test exact wheel outside source imports
+        run: python tools/installed_wheel_smoke.py --wheel-dir dist --expected-version 0.2.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,18 +14,18 @@ concurrency:
 
 jobs:
   publish:
-    name: Build and publish package
+    name: Build, verify and publish package
     runs-on: ubuntu-latest
     environment: pypi
 
     steps:
-      - name: Checkout repository
+      - name: Checkout tagged release
         uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.13"
 
       - name: Install build tools
         run: python -m pip install --upgrade build twine
@@ -35,6 +35,18 @@ jobs:
 
       - name: Check distributions
         run: python -m twine check dist/*
+
+      - name: Verify tagged release contract
+        run: >-
+          python tools/release_gate.py
+          --dist-dir dist
+          --tag "${{ github.event.release.tag_name }}"
+
+      - name: Install and smoke-test exact wheel
+        run: >-
+          python tools/installed_wheel_smoke.py
+          --wheel-dir dist
+          --expected-version "${{ github.event.release.tag_name }}"
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -25,6 +25,50 @@ The historical `ChatGPTWebClient` API is still available for compatibility and f
 
 See [ROADMAP.md](ROADMAP.md) for the post-PR8 architecture plan and [docs/public_surface_pr8_6.md](docs/public_surface_pr8_6.md) for the support-tier and compatibility policy.
 
+## CWA 0.2 CLI Quick Start
+
+After installation and browser-owned runtime setup, the stable command surface is:
+
+```powershell
+cwa doctor --json
+cwa status --json
+cwa capabilities --json
+cwa send "Give me a short project summary." --profile HIGH
+cwa messages <conversation-id> --json
+cwa snapshot <conversation-id> --name project --output-dir ./artifacts --json
+cwa export <conversation-id> --format jsonl --name project --output-dir ./artifacts --json
+```
+
+The accepted public CLI model-profile names are:
+
+```text
+INSTANT <-> FAST
+MEDIUM  <-> BALANCED
+HIGH    <-> DEEP
+```
+
+Product-native names are preferred in CLI documentation. Direct Python runtime profile keys remain the semantic `FAST` / `BALANCED` / `DEEP` contract.
+
+Temporary Chat is available through the same public CLI surface:
+
+```powershell
+cwa send "Answer briefly." --temporary --profile INSTANT
+```
+
+CWA 0.2 intentionally freezes the proven text path first. Image upload, file attachment, multimodal continuation, web search/tools/connectors, and future browserless write transports remain later capability work rather than being implied by the current UI.
+
+## Release Integrity
+
+The 0.2 release candidate is validated as an exact wheel/sdist pair. CI verifies package metadata, console entry points, all packaged browser-extension `.json`/`.js` files, installed CLI help surfaces, and pre-setup `cwa doctor` behavior from a disposable environment rather than an editable checkout.
+
+A real tagged release additionally requires:
+
+```text
+GitHub tag version == pyproject package version == dated CHANGELOG release heading
+```
+
+See [docs/release_checklist.md](docs/release_checklist.md) for the complete release gate.
+
 ## What This Is
 
 `chatgpt-web-adapter` is a local adapter around an authenticated ChatGPT product session. It separates:
@@ -332,6 +376,7 @@ PR-specific feasibility probes may also live in `examples/`; they are not automa
 - [docs/troubleshooting.md](docs/troubleshooting.md)
 - [docs/raw_payload.md](docs/raw_payload.md)
 - [docs/rename_compatibility.md](docs/rename_compatibility.md)
+- [docs/release_checklist.md](docs/release_checklist.md)
 
 `USAGE.md` remains a detailed compatibility-client guide for the historical `ChatGPTWebClient` feature set. New ordinary text-turn integrations should start with this README and `examples/product_runtime.py` instead.
 

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,64 +1,186 @@
 # Release Checklist
 
-Use this checklist before cutting a release or publishing a new package version.
+Use this checklist before cutting a GitHub release or publishing a package version.
 
-## Tests
+PR8.17 separates two moments:
 
-- Run the full test suite:
-  - `pytest -q`
-- Build release artifacts:
-  - `python -m build`
-- Validate package metadata:
-  - `python -m twine check dist/*`
-- Smoke test the built wheel in a clean environment:
-  - `python -m pip install --force-reinstall dist/*.whl`
-  - `python -c "from chatgpt_web_adapter import ChatGPTWebClient"`
-- If public exports changed, recheck API-surface tests.
-- If transport/parsing changed, recheck client/status/message tests.
+```text
+release candidate ready
+        !=
+package published
+```
 
-## Documentation
+Merging release-hardening code never grants permission to publish. A tagged PyPI release is a separate action.
 
-- README reflects current stable vs experimental boundaries.
-- USAGE reflects current public exports and behavior.
-- [authentication.md](authentication.md) reflects login, refresh, profile, and
-  headless-write behavior.
-- [troubleshooting.md](troubleshooting.md) reflects current failure stages and
-  safe diagnostics.
-- Write examples use the supported Sentinel configuration; read-only examples
-  do not imply that Chromium is required.
-- Default model names and supported Python versions match package metadata.
-- New user-facing features or limitations are documented.
-- Experimental features are still clearly marked as experimental.
+## 1. Regression
 
-## Live Verification
+Run the focused release-hardening tests:
 
-- Run `chatgpt-web-adapter auth status --auth-file auth_data.json` without
-  printing any credential values.
-- Run the stable-core items from [live_smoke_checklist.md](./live_smoke_checklist.md)
-- Verify one protected write with `sentinel_headless=True` after the initial
-  interactive login.
-- Re-run experimental approval checks only if:
-  - approval code changed, or
-  - connector/web approval behavior appears to have changed
+```powershell
+python -m pytest tests/test_release_hardening_pr8_17.py -q
+```
 
-## Repository Hygiene
+Run the relevant packaging/CLI/doctor/artifact tests, then the full repository suite:
 
-- No secrets or traffic traces are staged.
-- `auth_data.json`, the persistent Chromium profile, HAR files, and local scan
-  artifacts remain untracked.
-- Commit history is clean and logically grouped.
+```powershell
+python -m pytest -q
+```
 
-## Versioning and Notes
+No release may proceed with a failing test.
 
-- Update changelog or release notes if applicable.
-- Call out compatibility-impacting changes explicitly.
-- Mention any known live-site caveats discovered during smoke testing.
+## 2. Build exact distributions
 
-## Exit Criteria
+Start from a clean `dist/` directory:
 
-- Tests pass.
-- Build artifacts pass `twine check`.
-- Built wheel installs and imports cleanly.
-- Stable-core live smoke passes.
-- Docs are in sync with behavior.
-- Experimental caveats are still explicit.
+```powershell
+Remove-Item -Recurse -Force .\dist -ErrorAction SilentlyContinue
+python -m pip install --upgrade build twine
+python -m build
+python -m twine check dist/*
+```
+
+The release candidate must produce exactly one wheel and one sdist.
+
+## 3. Candidate artifact contract
+
+Run:
+
+```powershell
+python tools/release_gate.py --dist-dir dist --json
+```
+
+The gate validates:
+
+- static package version from `pyproject.toml`;
+- exactly one wheel and one sdist;
+- canonical distribution filenames;
+- wheel `Name` / `Version` metadata;
+- `cwa`, `chatgpt-web-adapter`, and native-host console entry points;
+- required 0.2 modules;
+- all packaged browser-extension `.json` / `.js` files from the source package-data set;
+- required sdist source/package files.
+
+This candidate gate does not require a Git tag.
+
+## 4. Installed-wheel smoke
+
+Test the exact built wheel, not an editable checkout:
+
+```powershell
+python tools/installed_wheel_smoke.py `
+  --wheel-dir dist `
+  --expected-version 0.2.0 `
+  --json
+```
+
+The smoke installs the wheel through `pip --no-deps --force-reinstall` and verifies:
+
+- import resolves from `site-packages`, not the repository `src/` tree;
+- installed package metadata reports the expected version;
+- `cli_v02`, `doctor`, and artifact-manifest modules exist;
+- all three console scripts are installed with the frozen targets;
+- `cwa --help` and the stable 0.2 command help surfaces execute successfully;
+- the installed browser-extension directory contains the required package data;
+- `cwa doctor` can diagnose a deliberately unconfigured/missing-auth environment as structured unavailable (`exit 1`) rather than crashing;
+- static installed-package doctor checks remain `PASS`.
+
+CI runs this installed-wheel smoke on Linux and Windows with Python 3.10 and 3.14 after the full 3.10-3.14 source-test matrix.
+
+## 5. Live product verification
+
+For a release that contains product-runtime behavior changes, rerun the appropriate live evidence gates.
+
+For the CWA 0.2 release candidate after PR8.17, the already-proven baseline includes:
+
+```text
+cwa doctor                PASS
+cwa status                PASS
+cwa capabilities          PASS
+HIGH alias product write  PASS
+messages                  PASS
+snapshot/export manifests PASS
+doctor artifact verify    PASS
+Temporary / streaming / model-selection production gates preserved
+```
+
+PR8.17 itself must not add or modify a product write path.
+
+## 6. Version and changelog finalization
+
+Before creating `vX.Y.Z`:
+
+1. `pyproject.toml` must contain exactly `X.Y.Z`.
+2. `CHANGELOG.md` must contain a dated heading:
+
+   ```text
+   ## X.Y.Z - YYYY-MM-DD
+   ```
+
+3. The GitHub release tag must be exactly `vX.Y.Z` (the checker also accepts a raw `X.Y.Z` input for local verification).
+
+Validate the strict tagged contract locally before publishing:
+
+```powershell
+python tools/release_gate.py `
+  --dist-dir dist `
+  --tag v0.2.0 `
+  --json
+```
+
+A tag/version mismatch or missing dated changelog entry fails before upload.
+
+## 7. Repository hygiene
+
+Before tagging:
+
+- `git status` is clean;
+- no auth/session files are tracked;
+- no HAR/traffic traces, browser profiles, local artifacts, or private prompts were added;
+- release artifacts came from the intended commit;
+- CI is green for that exact commit;
+- the release notes describe user-visible changes and known limitations.
+
+## 8. Publishing
+
+PyPI publishing is triggered only by a published GitHub Release and uses Trusted Publishing.
+
+The publish workflow rebuilds the distributions and reruns, in order:
+
+```text
+python -m build
+python -m twine check dist/*
+strict tagged release gate
+installed exact-wheel smoke
+PyPI Trusted Publishing upload
+```
+
+If any pre-upload step fails, publishing stops.
+
+## 9. Post-publish verification
+
+After PyPI reports the version:
+
+1. create a new clean environment;
+2. install the public artifact from PyPI, not the repository;
+3. verify package version;
+4. run `cwa --help`;
+5. run `cwa doctor --json` before and after normal local setup;
+6. verify the packaged extension directory exists;
+7. perform one controlled product smoke if the release policy calls for it.
+
+Only then should downstream projects such as CMA pin the released CWA version.
+
+## Exit criteria
+
+```text
+focused release regression         PASS
+relevant regression                PASS
+full repository regression         PASS
+Linux/Windows Python 3.10-3.14 CI  PASS
+wheel + sdist build                PASS
+twine metadata check               PASS
+candidate release gate             PASS
+installed-wheel smoke              PASS
+tag/version/changelog contract     PASS before publication
+PyPI post-publish install          PASS after publication
+```

--- a/docs/release_hardening_pr8_17.md
+++ b/docs/release_hardening_pr8_17.md
@@ -1,0 +1,376 @@
+# PR8.17 — Packaging / CI / Release Hardening
+
+_Status: CLOSED / PASS — release candidate engineering gate complete_
+
+_Base: `main` after merged PR8.16 (`4d87993f0cce28842a2e645797228b4013c5dc65`)_
+
+## Purpose
+
+PR8.17 is the final engineering hardening step before the CWA 0.2 release gate.
+
+It does not add ChatGPT product capabilities. It makes the already-proven CWA 0.2 surface reproducibly buildable, installable, inspectable, and publishable.
+
+The target chain is:
+
+```text
+source checkout works
+        ↓
+full tests pass
+        ↓
+wheel + sdist build
+        ↓
+release artifact contract passes
+        ↓
+exact wheel installs into disposable clean venv
+        ↓
+installed CLI/package-data/doctor smoke passes
+        ↓
+strict tag/version/changelog gate passes
+        ↓
+Trusted Publishing may upload
+```
+
+## Scope boundary
+
+PR8.17 changes packaging/release surfaces only:
+
+- `pyproject.toml` version metadata;
+- CI build and installed-wheel smoke;
+- PyPI publish pre-upload gates;
+- repository-local release tools;
+- README/release checklist;
+- release-hardening regression tests.
+
+It must not change:
+
+```text
+ProductWriteTransport
+BrowserOwnedProductTransport
+Temporary Chat semantics
+streaming semantics
+model selector behavior
+canonical readback/finality
+Browser Authority lifecycle
+retry/fallback policy
+snapshot/export schema
+doctor classification semantics
+```
+
+## Version staging
+
+`pyproject.toml` is staged at:
+
+```text
+0.2.0
+```
+
+This does not publish the package.
+
+The release process deliberately separates:
+
+```text
+PR8.17 merged / release candidate ready
+        !=
+GitHub Release v0.2.0 published
+        !=
+PyPI upload verified
+```
+
+The current changelog may remain without a dated `0.2.0` heading while PR8.17 is only a candidate. The strict tagged release gate requires a final dated heading before a release can publish:
+
+```text
+## 0.2.0 - YYYY-MM-DD
+```
+
+## Candidate release gate
+
+Repository-local tool:
+
+```powershell
+python tools/release_gate.py --dist-dir dist --json
+```
+
+The candidate gate validates:
+
+- static package version from `[project]`;
+- exactly one wheel and one sdist;
+- canonical distribution filenames;
+- wheel distribution name/version metadata;
+- exact console-script mapping;
+- required 0.2 modules;
+- required browser-extension package data;
+- **all** source `browser_native_extension/*.json` and `*.js` files are present in the wheel;
+- required source/package files are present in the sdist.
+
+The release tool is repository-local and is not part of the installed SDK package.
+
+## Strict tagged release gate
+
+For a release tag:
+
+```powershell
+python tools/release_gate.py `
+  --dist-dir dist `
+  --tag v0.2.0 `
+  --json
+```
+
+The gate additionally requires:
+
+```text
+normalized tag == pyproject version
+CHANGELOG has exact version heading
+CHANGELOG heading has YYYY-MM-DD release date
+```
+
+Therefore a GitHub Release cannot accidentally publish a mismatched or unfinished version.
+
+## Exact installed-wheel smoke
+
+Repository-local tool:
+
+```powershell
+python tools/installed_wheel_smoke.py `
+  --wheel-dir dist `
+  --expected-version 0.2.0 `
+  --json
+```
+
+The tool:
+
+1. creates a disposable temporary virtual environment;
+2. installs the exact built wheel with `pip --no-deps --force-reinstall`;
+3. removes `PYTHONPATH` for the child smoke;
+4. executes installed checks from a temporary working directory rather than the repository;
+5. destroys the temporary environment after completion.
+
+This prevents an editable source checkout from masking a broken wheel and prevents the release smoke from mutating the developer's active virtual environment.
+
+### Installed assertions
+
+The smoke requires:
+
+```text
+installed metadata version matches expected version
+package import resolves from site-packages
+cli_v02.main exists
+doctor.run_doctor exists
+artifact manifest schema exists
+packaged extension manifest exists
+packaged service_worker.js exists
+installed extension contains JavaScript package data
+```
+
+It freezes the installed console targets:
+
+```text
+cwa                             -> chatgpt_web_adapter.cli_v02:main
+chatgpt-web-adapter             -> chatgpt_web_adapter.cli_v02:main
+chatgpt-web-adapter-native-host -> chatgpt_web_adapter.browser_native_host:main
+```
+
+It executes read-only help smoke for:
+
+```text
+cwa --help
+chatgpt-web-adapter --help
+cwa doctor --help
+cwa status --help
+cwa capabilities --help
+cwa messages --help
+cwa snapshot --help
+cwa export --help
+cwa send --help
+```
+
+Finally it runs installed `cwa doctor` with a deliberately missing auth path. The expected result is:
+
+```text
+exit = 1
+schema = 1
+command = doctor
+ok = false
+```
+
+while these installed-package checks must still be `PASS`:
+
+```text
+environment.python
+environment.package_metadata
+environment.extension_id_integrity
+install.extension_package
+```
+
+and `auth.file` must be classified `FAIL` rather than causing an exception.
+
+This proves that a new user can install the wheel and receive structured setup diagnostics before configuring CWA.
+
+## CI hardening
+
+Source regression remains a Linux/Windows matrix across Python:
+
+```text
+3.10
+3.11
+3.12
+3.13
+3.14
+```
+
+CI invokes the suite through:
+
+```text
+python -m pytest -q
+```
+
+so repository-local release tooling is imported under the same module-search contract used by the documented local release gate, without turning `tools/` into installed SDK package data.
+
+After all source tests pass, CI builds exactly one release artifact set and runs:
+
+```text
+python -m build
+python -m twine check dist/*
+python tools/release_gate.py --dist-dir dist
+```
+
+The exact built distributions are uploaded as one short-lived CI artifact.
+
+A downstream installed-wheel matrix downloads those exact bytes and runs the disposable installed-wheel smoke on:
+
+```text
+Ubuntu  + Python 3.10
+Ubuntu  + Python 3.14
+Windows + Python 3.10
+Windows + Python 3.14
+```
+
+The boundary versions are chosen for the cross-platform installed-artifact gate while the full source regression continues to cover every supported Python version.
+
+## Publish hardening
+
+PyPI publishing still uses GitHub Release + Trusted Publishing.
+
+Before `pypa/gh-action-pypi-publish` is allowed to run, the publish workflow performs:
+
+```text
+build wheel + sdist
+twine check
+strict tagged release gate
+exact installed-wheel smoke
+```
+
+The upload step is last. Any mismatch or installed-wheel failure stops publishing before credentials are used for upload.
+
+## README / user-facing boundary
+
+The README preserves the existing proven public-surface tiers, compatibility/research discoverability, examples, raw-payload docs, and browser-native setup while adding the stable 0.2 `cwa` path:
+
+```text
+cwa doctor
+cwa status
+cwa capabilities
+cwa send
+cwa messages
+cwa snapshot
+cwa export
+```
+
+The README also explicitly preserves:
+
+```text
+INSTANT <-> FAST
+MEDIUM  <-> BALANCED
+HIGH    <-> DEEP
+```
+
+and states that image/file upload, multimodal continuation, tools/connectors, and future browserless write transports are later capability work rather than implied 0.2 support.
+
+## Final evidence
+
+Local regression:
+
+```text
+focused release hardening             13 passed in 0.28s
+relevant 0.2 CLI/artifact/doctor      50 passed in 0.50s
+README/docs compatibility repair      26 passed in 0.17s
+full repository suite               1286 passed in 23.02s
+```
+
+Local distribution build:
+
+```text
+chatgpt_web_adapter-0.2.0.tar.gz                 BUILT
+chatgpt_web_adapter-0.2.0-py3-none-any.whl       BUILT
+twine check wheel                                 PASS
+twine check sdist                                 PASS
+```
+
+Candidate release gate:
+
+```text
+schema                   = 1
+ok                       = true
+project                  = chatgpt-web-adapter
+version                  = 0.2.0
+tag                      = null
+changelog_release_date   = null
+wheel extension files    = 50
+console entry points     = 3
+```
+
+The null tag/date are intentional at candidate stage; strict tagged publication remains fail-closed until release finalization.
+
+Local disposable installed-wheel smoke:
+
+```text
+schema                  = 1
+ok                      = true
+version                 = 0.2.0
+entry points            = 3
+help commands           = 9
+package provenance      = disposable venv site-packages
+extension provenance    = installed wheel site-packages
+pre-setup doctor exit   = 1
+```
+
+GitHub Actions run `195` on the corrected PR head proved:
+
+```text
+Ubuntu  Python 3.10  PASS
+Ubuntu  Python 3.11  PASS
+Ubuntu  Python 3.12  PASS
+Ubuntu  Python 3.13  PASS
+Ubuntu  Python 3.14  PASS
+Windows Python 3.10  PASS
+Windows Python 3.11  PASS
+Windows Python 3.12  PASS
+Windows Python 3.13  PASS
+Windows Python 3.14  PASS
+build / twine / candidate artifact gate / upload artifact  PASS
+cross-platform exact installed-wheel stage                 PASS
+workflow conclusion                                        success
+```
+
+An earlier Actions attempt exposed that calling the `pytest` console script did not put repository-local `tools/` on the import path. The CI runner was intentionally aligned with the documented/local `python -m pytest -q` invocation; no SDK package-data expansion was used to hide the issue.
+
+No live ChatGPT product write was required or performed by PR8.17.
+
+## Closure condition
+
+PR8.17 closes with:
+
+```text
+focused release regression             PASS
+relevant 0.2 CLI/artifact/doctor gate  PASS
+full repository suite                  PASS
+wheel build                             PASS
+sdist build                             PASS
+twine check                             PASS
+candidate release gate                 PASS
+local disposable installed-wheel smoke PASS
+CI source matrix                        PASS
+CI cross-platform installed-wheel gate PASS
+no product-runtime behavioral diff     CONFIRMED
+```
+
+After merge, CWA 0.2 still requires a separate explicit release decision, changelog finalization, strict tagged gate, GitHub Release, PyPI post-publish install verification, and then downstream version pinning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chatgpt-web-adapter"
-version = "0.1.7"
+version = "0.2.0"
 description = "Python SDK for using an existing ChatGPT web session from Python and terminal tools."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_release_hardening_pr8_17.py
+++ b/tests/test_release_hardening_pr8_17.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from tools import installed_wheel_smoke, release_gate
+
+
+VERSION = "0.2.0"
+
+
+def _root(tmp_path: Path, *, changelog: str = "# Changelog\n\n## Unreleased\n") -> Path:
+    root = tmp_path / "repo"
+    extension = root / "src" / "chatgpt_web_adapter" / "browser_native_extension"
+    extension.mkdir(parents=True)
+    (extension / "manifest.json").write_text("{}\n", encoding="utf-8")
+    (extension / "service_worker.js").write_text("// worker\n", encoding="utf-8")
+    (extension / "extra.js").write_text("// extra\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        "[project]\nname = \"chatgpt-web-adapter\"\nversion = \"0.2.0\"\n",
+        encoding="utf-8",
+    )
+    (root / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+    return root
+
+
+def _entry_points_text(*, broken: bool = False) -> str:
+    target = "chatgpt_web_adapter.cli:main" if broken else "chatgpt_web_adapter.cli_v02:main"
+    return (
+        "[console_scripts]\n"
+        f"cwa = {target}\n"
+        f"chatgpt-web-adapter = {target}\n"
+        "chatgpt-web-adapter-native-host = chatgpt_web_adapter.browser_native_host:main\n"
+    )
+
+
+def _write_dist(root: Path, *, broken_entry_points: bool = False, omit_extra_js: bool = False) -> Path:
+    dist = root / "dist"
+    dist.mkdir()
+    wheel = dist / f"chatgpt_web_adapter-{VERSION}-py3-none-any.whl"
+    dist_info = f"chatgpt_web_adapter-{VERSION}.dist-info"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(f"{dist_info}/METADATA", f"Name: chatgpt-web-adapter\nVersion: {VERSION}\n")
+        archive.writestr(f"{dist_info}/entry_points.txt", _entry_points_text(broken=broken_entry_points))
+        for required in release_gate.REQUIRED_WHEEL_FILES:
+            archive.writestr(required, "x\n")
+        if not omit_extra_js:
+            archive.writestr("chatgpt_web_adapter/browser_native_extension/extra.js", "x\n")
+    sdist = dist / f"chatgpt_web_adapter-{VERSION}.tar.gz"
+    root_name = f"chatgpt_web_adapter-{VERSION}"
+    with tarfile.open(sdist, "w:gz") as archive:
+        for suffix in release_gate.REQUIRED_SDIST_SUFFIXES:
+            info = tarfile.TarInfo(root_name + suffix)
+            payload = b"x\n"
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return dist
+
+
+def test_repository_package_version_is_staged_for_0_2() -> None:
+    repo = Path(__file__).resolve().parents[1]
+    assert release_gate.project_version(repo / "pyproject.toml") == VERSION
+
+
+def test_candidate_gate_allows_changelog_finalization_to_remain_separate(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    report = release_gate.run_release_gate(root=root)
+    assert report["ok"] is True
+    assert report["version"] == VERSION
+    assert report["tag"] is None
+    assert report["changelog_release_date"] is None
+
+
+def test_tagged_gate_requires_dated_changelog(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    with pytest.raises(release_gate.ReleaseGateError, match="CHANGELOG"):
+        release_gate.run_release_gate(root=root, tag="v0.2.0")
+
+
+def test_tagged_gate_requires_exact_version_match(tmp_path: Path) -> None:
+    root = _root(tmp_path, changelog="# Changelog\n\n## 0.2.0 - 2026-08-22\n")
+    with pytest.raises(release_gate.ReleaseGateError, match="tag/version mismatch"):
+        release_gate.run_release_gate(root=root, tag="v0.2.1")
+    report = release_gate.run_release_gate(root=root, tag="refs/tags/v0.2.0")
+    assert report["tag"] == VERSION
+    assert report["changelog_release_date"] == "2026-08-22"
+
+
+def test_installed_smoke_normalizes_release_tag_versions() -> None:
+    assert installed_wheel_smoke.normalize_expected_version("0.2.0") == VERSION
+    assert installed_wheel_smoke.normalize_expected_version("v0.2.0") == VERSION
+    assert installed_wheel_smoke.normalize_expected_version("refs/tags/v0.2.0") == VERSION
+
+
+def test_release_gate_accepts_complete_wheel_and_sdist(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    dist = _write_dist(root)
+    report = release_gate.run_release_gate(root=root, dist_dir=dist)
+    assert report["artifacts"]["wheel"]["filename"].endswith(".whl")
+    assert report["artifacts"]["wheel"]["extension_files"] == 3
+    assert report["artifacts"]["sdist"]["filename"].endswith(".tar.gz")
+
+
+def test_release_gate_rejects_omitted_extension_package_data(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    dist = _write_dist(root, omit_extra_js=True)
+    with pytest.raises(release_gate.ReleaseGateError, match="omitted packaged browser extension"):
+        release_gate.run_release_gate(root=root, dist_dir=dist)
+
+
+def test_release_gate_rejects_console_entrypoint_drift(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    dist = _write_dist(root, broken_entry_points=True)
+    with pytest.raises(release_gate.ReleaseGateError, match="console entry points mismatch"):
+        release_gate.run_release_gate(root=root, dist_dir=dist)
+
+
+def test_release_gate_rejects_ambiguous_distribution_set(tmp_path: Path) -> None:
+    root = _root(tmp_path)
+    dist = _write_dist(root)
+    (dist / "extra.whl").write_bytes(b"not-a-wheel")
+    with pytest.raises(release_gate.ReleaseGateError, match="exactly one wheel"):
+        release_gate.run_release_gate(root=root, dist_dir=dist)
+
+
+def test_pyproject_freezes_console_scripts_and_extension_package_data() -> None:
+    text = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "0.2.0"' in text
+    assert 'cwa = "chatgpt_web_adapter.cli_v02:main"' in text
+    assert 'chatgpt-web-adapter = "chatgpt_web_adapter.cli_v02:main"' in text
+    assert 'chatgpt-web-adapter-native-host = "chatgpt_web_adapter.browser_native_host:main"' in text
+    assert '"browser_native_extension/*.json"' in text
+    assert '"browser_native_extension/*.js"' in text
+
+
+def test_ci_builds_once_then_smokes_exact_wheel_on_linux_and_windows() -> None:
+    text = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    assert "python tools/release_gate.py --dist-dir dist" in text
+    assert "actions/upload-artifact@v4" in text
+    assert "actions/download-artifact@v4" in text
+    assert "installed-wheel-smoke:" in text
+    assert "ubuntu-latest" in text and "windows-latest" in text
+    assert '"3.10"' in text and '"3.14"' in text
+    assert "python tools/installed_wheel_smoke.py --wheel-dir dist --expected-version 0.2.0" in text
+
+
+def test_publish_workflow_gates_tag_and_exact_wheel_before_upload() -> None:
+    text = (Path(__file__).resolve().parents[1] / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+    tag_gate = text.index("python tools/release_gate.py")
+    wheel_smoke = text.index("python tools/installed_wheel_smoke.py")
+    publish = text.index("pypa/gh-action-pypi-publish@release/v1")
+    assert "github.event.release.tag_name" in text
+    assert tag_gate < wheel_smoke < publish
+
+
+def test_readme_and_release_checklist_present_0_2_user_and_release_contracts() -> None:
+    root = Path(__file__).resolve().parents[1]
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    checklist = (root / "docs" / "release_checklist.md").read_text(encoding="utf-8")
+    for command in ("cwa doctor", "cwa status", "cwa capabilities", "cwa send", "cwa messages", "cwa snapshot", "cwa export"):
+        assert command in readme
+    assert "GitHub tag version == pyproject package version == dated CHANGELOG release heading" in readme
+    assert "installed-wheel smoke" in checklist
+    assert "Post-publish verification" in checklist

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local release hardening tools; not part of the installed SDK package."""

--- a/tools/installed_wheel_smoke.py
+++ b/tools/installed_wheel_smoke.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import venv
+from pathlib import Path
+
+PROJECT_NAME = "chatgpt-web-adapter"
+EXPECTED_ENTRY_POINTS = {
+    "cwa": "chatgpt_web_adapter.cli_v02:main",
+    "chatgpt-web-adapter": "chatgpt_web_adapter.cli_v02:main",
+    "chatgpt-web-adapter-native-host": "chatgpt_web_adapter.browser_native_host:main",
+}
+HELP_COMMANDS = (
+    ("cwa", "--help"),
+    ("chatgpt-web-adapter", "--help"),
+    ("cwa", "doctor", "--help"),
+    ("cwa", "status", "--help"),
+    ("cwa", "capabilities", "--help"),
+    ("cwa", "messages", "--help"),
+    ("cwa", "snapshot", "--help"),
+    ("cwa", "export", "--help"),
+    ("cwa", "send", "--help"),
+)
+
+
+def normalize_expected_version(value: str) -> str:
+    normalized = value.strip()
+    if normalized.startswith("refs/tags/"):
+        normalized = normalized[len("refs/tags/") :]
+    if normalized.startswith("v"):
+        normalized = normalized[1:]
+    if not normalized:
+        raise RuntimeError("expected version is empty")
+    return normalized
+
+
+def _one_wheel(dist_dir: Path) -> Path:
+    wheels = sorted(dist_dir.resolve().glob("*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(f"expected exactly one wheel, found {len(wheels)}")
+    return wheels[0]
+
+
+def _venv_python(env_dir: Path) -> Path:
+    return env_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _venv_bin(env_dir: Path) -> Path:
+    return env_dir / ("Scripts" if os.name == "nt" else "bin")
+
+
+def _console_scripts() -> dict[str, str]:
+    result: dict[str, str] = {}
+    for entry in importlib.metadata.entry_points(group="console_scripts"):
+        if entry.name in EXPECTED_ENTRY_POINTS:
+            result[entry.name] = entry.value
+    return result
+
+
+def _run_help(command: tuple[str, ...], *, cwd: Path) -> None:
+    executable = shutil.which(command[0])
+    if executable is None:
+        raise RuntimeError(f"console executable not found: {command[0]}")
+    completed = subprocess.run(
+        [executable, *command[1:]],
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"help command failed ({' '.join(command)}): rc={completed.returncode} stderr={completed.stderr}"
+        )
+
+
+def _installed_checks(*, expected_version: str) -> dict[str, object]:
+    expected_version = normalize_expected_version(expected_version)
+    version = importlib.metadata.version(PROJECT_NAME)
+    if version != expected_version:
+        raise RuntimeError(f"installed version mismatch: {version!r} != {expected_version!r}")
+
+    package = importlib.import_module("chatgpt_web_adapter")
+    package_path = Path(package.__file__).resolve()
+    if "site-packages" not in str(package_path).lower().replace("\\", "/"):
+        raise RuntimeError(f"smoke did not import installed wheel from site-packages: {package_path}")
+
+    cli_v02 = importlib.import_module("chatgpt_web_adapter.cli_v02")
+    doctor = importlib.import_module("chatgpt_web_adapter.doctor")
+    artifact_manifest = importlib.import_module("chatgpt_web_adapter.artifact_manifest")
+    if not callable(getattr(cli_v02, "main", None)):
+        raise RuntimeError("installed cli_v02.main is missing")
+    if not callable(getattr(doctor, "run_doctor", None)):
+        raise RuntimeError("installed doctor.run_doctor is missing")
+    if not hasattr(artifact_manifest, "ARTIFACT_MANIFEST_SCHEMA"):
+        raise RuntimeError("installed artifact manifest contract is missing")
+
+    from chatgpt_web_adapter.browser_native_install import browser_native_extension_dir
+
+    extension_dir = browser_native_extension_dir().resolve()
+    required_extension_files = [extension_dir / "manifest.json", extension_dir / "service_worker.js"]
+    if not all(path.is_file() for path in required_extension_files):
+        raise RuntimeError(f"installed browser extension package data is incomplete: {extension_dir}")
+    if not list(extension_dir.glob("*.js")):
+        raise RuntimeError("installed browser extension contains no JavaScript files")
+
+    entry_points = _console_scripts()
+    if entry_points != EXPECTED_ENTRY_POINTS:
+        raise RuntimeError(f"installed console entry points mismatch: {entry_points!r}")
+
+    cwd = Path.cwd()
+    for command in HELP_COMMANDS:
+        _run_help(command, cwd=cwd)
+
+    missing_auth = cwd / "missing-auth.json"
+    cwa = shutil.which("cwa")
+    if cwa is None:
+        raise RuntimeError("cwa executable not found")
+    completed = subprocess.run(
+        [cwa, "doctor", "--auth-file", str(missing_auth), "--json"],
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 1:
+        raise RuntimeError(
+            f"pre-setup doctor should classify unavailable state with exit 1; got {completed.returncode}: {completed.stderr}"
+        )
+    payload = json.loads(completed.stdout)
+    if payload.get("schema") != 1 or payload.get("command") != "doctor" or payload.get("ok") is not False:
+        raise RuntimeError(f"unexpected pre-setup doctor payload: {payload!r}")
+    checks = {item.get("id"): item for item in payload.get("checks", []) if isinstance(item, dict)}
+    for check_id in (
+        "environment.python",
+        "environment.package_metadata",
+        "environment.extension_id_integrity",
+        "install.extension_package",
+    ):
+        if checks.get(check_id, {}).get("status") != "PASS":
+            raise RuntimeError(f"installed static doctor check did not pass: {check_id}")
+    if checks.get("auth.file", {}).get("status") != "FAIL":
+        raise RuntimeError("pre-setup doctor did not classify missing auth as FAIL")
+
+    return {
+        "schema": 1,
+        "ok": True,
+        "version": version,
+        "package_path": str(package_path),
+        "extension_dir": str(extension_dir),
+        "entry_points": sorted(entry_points),
+        "help_commands": len(HELP_COMMANDS),
+        "pre_setup_doctor_exit": 1,
+    }
+
+
+def run_smoke(*, wheel: Path, expected_version: str) -> dict[str, object]:
+    expected_version = normalize_expected_version(expected_version)
+    wheel = wheel.resolve()
+    script = Path(__file__).resolve()
+    with tempfile.TemporaryDirectory(prefix="cwa-wheel-venv-") as tmp:
+        tmp_path = Path(tmp)
+        env_dir = tmp_path / "venv"
+        venv.EnvBuilder(with_pip=True, clear=True).create(env_dir)
+        python = _venv_python(env_dir)
+        if not python.is_file():
+            raise RuntimeError(f"isolated venv python was not created: {python}")
+        subprocess.run(
+            [str(python), "-m", "pip", "install", "--no-deps", "--force-reinstall", str(wheel)],
+            cwd=tmp_path,
+            check=True,
+        )
+        env = dict(os.environ)
+        env.pop("PYTHONPATH", None)
+        env["PATH"] = str(_venv_bin(env_dir)) + os.pathsep + env.get("PATH", "")
+        completed = subprocess.run(
+            [
+                str(python),
+                str(script),
+                "--inside-installed-venv",
+                "--expected-version",
+                expected_version,
+                "--json",
+            ],
+            cwd=tmp_path,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"isolated installed-wheel checks failed: rc={completed.returncode} stdout={completed.stdout} stderr={completed.stderr}"
+            )
+        return json.loads(completed.stdout)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Install and smoke-test a built CWA wheel")
+    parser.add_argument("--wheel-dir", type=Path)
+    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--inside-installed-venv", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.inside_installed_venv:
+            report = _installed_checks(expected_version=args.expected_version)
+        else:
+            if args.wheel_dir is None:
+                raise RuntimeError("--wheel-dir is required")
+            report = run_smoke(
+                wheel=_one_wheel(args.wheel_dir),
+                expected_version=args.expected_version,
+            )
+    except Exception as error:
+        if args.json:
+            print(json.dumps({"schema": 1, "ok": False, "error": str(error)}, indent=2))
+        else:
+            print(f"installed-wheel smoke: FAIL: {error}")
+        return 1
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"installed-wheel smoke: PASS ({report['version']})")
+        print(f"package: {report['package_path']}")
+        print(f"extension: {report['extension_dir']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_gate.py
+++ b/tools/release_gate.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tarfile
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+from typing import Any
+
+PROJECT_NAME = "chatgpt-web-adapter"
+DIST_BASENAME = "chatgpt_web_adapter"
+EXPECTED_ENTRY_POINTS = {
+    "cwa": "chatgpt_web_adapter.cli_v02:main",
+    "chatgpt-web-adapter": "chatgpt_web_adapter.cli_v02:main",
+    "chatgpt-web-adapter-native-host": "chatgpt_web_adapter.browser_native_host:main",
+}
+REQUIRED_WHEEL_FILES = {
+    "chatgpt_web_adapter/cli_v02.py",
+    "chatgpt_web_adapter/doctor.py",
+    "chatgpt_web_adapter/artifact_manifest.py",
+    "chatgpt_web_adapter/conversation_snapshot.py",
+    "chatgpt_web_adapter/export.py",
+    "chatgpt_web_adapter/browser_native_extension/manifest.json",
+    "chatgpt_web_adapter/browser_native_extension/service_worker.js",
+}
+REQUIRED_SDIST_SUFFIXES = {
+    "/pyproject.toml",
+    "/README.md",
+    "/LICENSE",
+    "/src/chatgpt_web_adapter/browser_native_extension/manifest.json",
+    "/src/chatgpt_web_adapter/browser_native_extension/service_worker.js",
+}
+_VERSION_RE = re.compile(r'^version\s*=\s*["\']([^"\']+)["\']\s*$', re.MULTILINE)
+_PROJECT_RE = re.compile(r"^\[project\]\s*$([\s\S]*?)(?=^\[[^\n]+\]\s*$|\Z)", re.MULTILINE)
+_RELEASE_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+class ReleaseGateError(RuntimeError):
+    pass
+
+
+def project_version(pyproject: Path) -> str:
+    text = pyproject.read_text(encoding="utf-8")
+    section = _PROJECT_RE.search(text)
+    if section is None:
+        raise ReleaseGateError("pyproject.toml is missing [project]")
+    match = _VERSION_RE.search(section.group(1))
+    if match is None:
+        raise ReleaseGateError("[project] must contain a static version")
+    return match.group(1).strip()
+
+
+def changelog_release_date(changelog: Path, version: str) -> str | None:
+    text = changelog.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"^##\s+{re.escape(version)}(?:\s+-\s+([^\n]+))?\s*$",
+        re.MULTILINE,
+    )
+    match = pattern.search(text)
+    if match is None:
+        raise ReleaseGateError(f"CHANGELOG.md has no {version} release heading")
+    suffix = match.group(1)
+    return suffix.strip() if suffix is not None else None
+
+
+def normalize_release_tag(value: str) -> str:
+    normalized = value.strip()
+    if normalized.startswith("refs/tags/"):
+        normalized = normalized[len("refs/tags/") :]
+    if normalized.startswith("v"):
+        normalized = normalized[1:]
+    if not normalized:
+        raise ReleaseGateError("release tag is empty")
+    return normalized
+
+
+def _entry_points(text: str) -> dict[str, str]:
+    section = None
+    result: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip()
+            continue
+        if section == "console_scripts" and "=" in line:
+            name, target = line.split("=", 1)
+            result[name.strip()] = target.strip()
+    return result
+
+
+def _source_extension_files(root: Path) -> set[str]:
+    extension_dir = root / "src" / "chatgpt_web_adapter" / "browser_native_extension"
+    files = {
+        path.name
+        for pattern in ("*.json", "*.js")
+        for path in extension_dir.glob(pattern)
+        if path.is_file()
+    }
+    if not files:
+        raise ReleaseGateError("source browser extension package-data set is empty")
+    return files
+
+
+def verify_wheel(wheel: Path, *, root: Path, version: str) -> dict[str, Any]:
+    expected_name = f"{DIST_BASENAME}-{version}-py3-none-any.whl"
+    if wheel.name != expected_name:
+        raise ReleaseGateError(f"unexpected wheel filename: {wheel.name}; expected {expected_name}")
+    with zipfile.ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+        dist_info = f"{DIST_BASENAME}-{version}.dist-info"
+        metadata_name = f"{dist_info}/METADATA"
+        entry_points_name = f"{dist_info}/entry_points.txt"
+        if metadata_name not in names:
+            raise ReleaseGateError("wheel is missing METADATA")
+        metadata = Parser().parsestr(archive.read(metadata_name).decode("utf-8"))
+        if metadata.get("Name") != PROJECT_NAME:
+            raise ReleaseGateError(f"wheel metadata Name mismatch: {metadata.get('Name')!r}")
+        if metadata.get("Version") != version:
+            raise ReleaseGateError(f"wheel metadata Version mismatch: {metadata.get('Version')!r}")
+        missing_required = sorted(REQUIRED_WHEEL_FILES - names)
+        if missing_required:
+            raise ReleaseGateError(f"wheel is missing required files: {missing_required}")
+        source_extension_files = _source_extension_files(root)
+        wheel_extension_files = {
+            Path(name).name
+            for name in names
+            if name.startswith("chatgpt_web_adapter/browser_native_extension/")
+            and (name.endswith(".js") or name.endswith(".json"))
+        }
+        missing_extension = sorted(source_extension_files - wheel_extension_files)
+        if missing_extension:
+            raise ReleaseGateError(
+                f"wheel omitted packaged browser extension files: {missing_extension}"
+            )
+        if entry_points_name not in names:
+            raise ReleaseGateError("wheel is missing console entry-point metadata")
+        actual_entry_points = _entry_points(archive.read(entry_points_name).decode("utf-8"))
+        if actual_entry_points != EXPECTED_ENTRY_POINTS:
+            raise ReleaseGateError(f"console entry points mismatch: {actual_entry_points!r}")
+    return {
+        "path": str(wheel),
+        "filename": wheel.name,
+        "extension_files": len(source_extension_files),
+        "entry_points": sorted(EXPECTED_ENTRY_POINTS),
+    }
+
+
+def verify_sdist(sdist: Path, *, version: str) -> dict[str, Any]:
+    expected_name = f"{DIST_BASENAME}-{version}.tar.gz"
+    if sdist.name != expected_name:
+        raise ReleaseGateError(f"unexpected sdist filename: {sdist.name}; expected {expected_name}")
+    with tarfile.open(sdist, "r:gz") as archive:
+        names = set(archive.getnames())
+    missing = [
+        suffix
+        for suffix in sorted(REQUIRED_SDIST_SUFFIXES)
+        if not any(name.endswith(suffix) for name in names)
+    ]
+    if missing:
+        raise ReleaseGateError(f"sdist is missing required files: {missing}")
+    return {"path": str(sdist), "filename": sdist.name}
+
+
+def verify_dist(root: Path, dist_dir: Path, version: str) -> dict[str, Any]:
+    wheels = sorted(dist_dir.glob("*.whl"))
+    sdists = sorted(dist_dir.glob("*.tar.gz"))
+    if len(wheels) != 1:
+        raise ReleaseGateError(f"expected exactly one wheel, found {len(wheels)}")
+    if len(sdists) != 1:
+        raise ReleaseGateError(f"expected exactly one sdist, found {len(sdists)}")
+    return {
+        "wheel": verify_wheel(wheels[0], root=root, version=version),
+        "sdist": verify_sdist(sdists[0], version=version),
+    }
+
+
+def run_release_gate(
+    *,
+    root: Path,
+    dist_dir: Path | None = None,
+    tag: str | None = None,
+) -> dict[str, Any]:
+    root = root.resolve()
+    version = project_version(root / "pyproject.toml")
+    normalized_tag = normalize_release_tag(tag) if tag is not None else None
+    try:
+        release_date = changelog_release_date(root / "CHANGELOG.md", version)
+    except ReleaseGateError:
+        if normalized_tag is not None:
+            raise
+        release_date = None
+
+    if normalized_tag is not None:
+        if normalized_tag != version:
+            raise ReleaseGateError(
+                f"release tag/version mismatch: tag={normalized_tag!r} package={version!r}"
+            )
+        if release_date is None or not _RELEASE_DATE_RE.fullmatch(release_date):
+            raise ReleaseGateError(
+                "tagged release requires CHANGELOG heading with YYYY-MM-DD release date"
+            )
+
+    artifacts = None
+    if dist_dir is not None:
+        artifacts = verify_dist(root, dist_dir.resolve(), version)
+    return {
+        "schema": 1,
+        "ok": True,
+        "project": PROJECT_NAME,
+        "version": version,
+        "changelog_release_date": release_date,
+        "tag": normalized_tag,
+        "artifacts": artifacts,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate the CWA release candidate contract")
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--dist-dir", type=Path)
+    parser.add_argument("--tag")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    try:
+        report = run_release_gate(root=args.root, dist_dir=args.dist_dir, tag=args.tag)
+    except (OSError, ValueError, ReleaseGateError, zipfile.BadZipFile, tarfile.TarError) as error:
+        if args.json:
+            print(json.dumps({"schema": 1, "ok": False, "error": str(error)}, indent=2))
+        else:
+            print(f"release gate: FAIL: {error}")
+        return 1
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"release gate: PASS ({report['project']} {report['version']})")
+        if report["tag"] is not None:
+            print(f"tag: {report['tag']}")
+        if report["artifacts"] is not None:
+            print(f"wheel: {report['artifacts']['wheel']['filename']}")
+            print(f"sdist: {report['artifacts']['sdist']['filename']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Final engineering hardening before the separate CWA 0.2 release gate.

This PR does **not** add or modify ChatGPT product capabilities. It hardens packaging, CI, exact installed-wheel verification, and the pre-PyPI release contract.

### Package/version

- stage package metadata at `0.2.0`
- no automatic publication
- candidate validation remains separate from strict tagged-release validation
- strict publish gate requires `tag == pyproject version == dated CHANGELOG heading`

### Release tooling

Repository-local tools (not SDK public surface):

```text
tools/release_gate.py
tools/installed_wheel_smoke.py
```

Candidate release gate validates exact wheel/sdist count, canonical filenames, metadata, frozen console entry points, required 0.2 modules, all browser-extension package data, and required sdist files.

Installed-wheel smoke creates a disposable temporary venv, installs the exact wheel, removes `PYTHONPATH`, runs outside the source checkout, verifies `site-packages` import provenance, all stable CLI help entry points, packaged extension files, and structured pre-setup `cwa doctor` behavior. It does not mutate the developer's active venv.

### CI / publish hardening

- source test matrix: Ubuntu/Windows × Python 3.10–3.14
- source suite invoked as `python -m pytest -q`
- build once after source tests
- `python -m build`
- `twine check`
- candidate release artifact gate
- upload exact built distributions
- downstream exact-wheel smoke on Ubuntu/Windows × Python 3.10/3.14
- Trusted Publishing upload remains last after strict tag/version/changelog gate + exact-wheel smoke

### Docs

README preserves the existing proven public-surface tiers, compatibility/research discoverability, examples, raw-payload docs, and browser-native setup while adding the stable 0.2 `cwa` entry path. Images/files/multimodal/tools/future browserless transports remain later capability work.

## Final evidence

```text
focused release hardening             13 passed in 0.28s
relevant 0.2 CLI/artifact/doctor      50 passed in 0.50s
README/docs compatibility repair      26 passed in 0.17s
full repository suite               1286 passed in 23.02s
```

Local distribution gate:

```text
wheel build                            PASS
sdist build                            PASS
twine wheel/sdist                      PASS
candidate release gate                 PASS
version                                0.2.0
wheel extension files                  50
console entry points                   3
local disposable installed-wheel smoke PASS
installed help commands                9
pre-setup doctor exit                  1 (expected unavailable)
```

Final GitHub Actions run `199` on exact head `755e6c81e0a5a4c01ee34aff35b8aca926153167`:

```text
Ubuntu  Python 3.10  PASS
Ubuntu  Python 3.11  PASS
Ubuntu  Python 3.12  PASS
Ubuntu  Python 3.13  PASS
Ubuntu  Python 3.14  PASS
Windows Python 3.10  PASS
Windows Python 3.11  PASS
Windows Python 3.12  PASS
Windows Python 3.13  PASS
Windows Python 3.14  PASS
build / twine / candidate artifact gate / artifact upload  PASS
installed wheel Ubuntu 3.10 / 3.14                       PASS
installed wheel Windows 3.10 / 3.14                      PASS
workflow conclusion                                       success
```

## Final branch shape

```text
base       4d87993f0cce28842a2e645797228b4013c5dc65
head       755e6c81e0a5a4c01ee34aff35b8aca926153167
ahead_by   1
behind_by  0
commits    1
files      10
```

No product-runtime/transport/Temporary/streaming/model-selection/canonical-finality/Browser-Authority/retry-fallback/artifact-schema/doctor-runtime/extension-JS behavior changed.

## Status

**CLOSED / PASS — ready for review.**

## Release policy

Merging PR8.17 does not publish CWA 0.2. A separate explicit release decision, changelog finalization, strict tagged gate, GitHub Release, PyPI post-publish install verification, and downstream pinning are still required.

Do not merge without explicit authorization.