### PR TITLE
docs: define post-0.2 PR9 roadmap and resync CMA boundary

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -289,12 +289,19 @@ Historical compatibility/media paths may provide evidence and implementation mat
 
 Browser-owned production support and browserless experimental support are evaluated independently.
 
+Capability state and transport support tier are separate axes. Do not invent composite capability states to encode both.
+
 Example:
 
 ```text
 images:
-  browser-owned = AVAILABLE
-  browserless    = UNKNOWN / EXPERIMENTAL / AVAILABLE-experimental
+  browser-owned:
+    capability = AVAILABLE
+    support     = PRODUCTION
+
+  browserless:
+    capability = UNKNOWN or AVAILABLE
+    support     = EXPERIMENTAL
 ```
 
 Do not flatten transport-specific evidence into one false global claim.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,1125 +1,447 @@
 # chatgpt-web-adapter Roadmap
 
-_Last updated: 2026-08-15_
+_Last updated: 2026-08-22_
 
-This roadmap defines the canonical architectural direction for `chatgpt-web-adapter` after the PR8 browser-owned transport, production-runtime, capability/provenance, and public-surface work.
+This roadmap defines the canonical post-0.2 direction for `chatgpt-web-adapter` (CWA).
 
-The detailed daily-use architecture review is recorded in:
+CWA is a standalone SDK / CLI / local ChatGPT product bridge. It is not a support library for any single downstream project. HDE, `codexia-manual-agent` (CMA), terminal users, Python applications and future local tools are all consumers of the same public product-runtime contract.
 
-- [`docs/post_pr8_daily_use_product_bridge_direction.md`](docs/post_pr8_daily_use_product_bridge_direction.md)
-
-That document is the source of detail for Temporary Chat, browser-authority lifetime, revision-safe streaming, model selection, resource/debugger work, and HDE research automation boundaries. This roadmap keeps the repository-level sequence and invariants concise enough to remain navigable.
-
-The strategic goal is no longer merely to prove that ordinary ChatGPT product turns can be sent from Python.
-
-The goal is to evolve the proven transport into a **fast, capability-aware, low-overhead local ChatGPT product bridge** whose browser implementation remains replaceable and whose public contract is suitable for HDE and other local tools.
+The detailed historical PR8 daily-use design remains in [`docs/post_pr8_daily_use_product_bridge_direction.md`](docs/post_pr8_daily_use_product_bridge_direction.md). Cross-repository ownership and version coordination with CMA is maintained separately in [`docs/cwa_cma_coordination_roadmap.md`](docs/cwa_cma_coordination_roadmap.md).
 
 ---
 
-## 1. Current Proven Baseline
+## 1. Frozen baseline — CWA 0.2.0
 
-The PR8 series established a working ordinary-ChatGPT product transport with the following shape:
-
-```text
-HDE / terminal / Python caller
-        |
-        v
-ChatGPTProductRuntime
-        |
-        +-- READ / STATUS / SESSION
-        |      -> browserless canonical HTTP
-        |
-        `-- WRITE
-               -> ProductWriteTransport
-               -> BrowserOwnedProductTransport
-               -> Native Messaging
-               -> Chrome extension
-               -> ordinary ChatGPT page-owned product write
-               -> browserless canonical readback/finality
-```
-
-### Proven properties
-
-The current green PR8.6 baseline has evidence for:
-
-- ordinary ChatGPT product semantics rather than a separate API product;
-- explicit browser-owned write delegation;
-- browserless canonical conversation reads, status, and session lifecycle;
-- new-chat creation;
-- existing-conversation continuation;
-- canonical response readback;
-- exact conversation/message identity recovery for ordinary durable chats;
-- on-demand runtime-tab creation when absent;
-- stale stored-tab reconciliation;
-- same-tab reuse across turns;
-- successful warm inactive-tab reuse;
-- a cold/no-tab path where foreground activation was observed even though the runtime did not request it;
-- no automatic retry after an ambiguous delegated write;
-- no legacy/direct-write fallback from the production runtime;
-- explicit closed-set `browser-owned` transport selection through `ChatGPTProductRuntime`;
-- a stable canonical/write interface split;
-- capability states that distinguish `AVAILABLE`, `UNSUPPORTED`, `UNKNOWN`, and `UNIMPLEMENTED`;
-- structured product execution provenance;
-- nullable `finish_reason` without synthetic `stop` fabrication;
-- public-surface classification separating production, shared support, compatibility, experimental, and research/diagnostic APIs;
-- a green repository-wide regression suite after PR8.6 (`826 passed`, `0 failed` in the validating Windows checkout).
-
-### Important foreground-activation correction
-
-The correct invariant is:
+CWA 0.2.0 was released on 2026-08-22 and is the frozen baseline for the next generation.
 
 ```text
-runtime_tab_foreground_activation_requested = false
+release     v0.2.0
+commit      f1ebfd671c45153a3279163dc624e0af7c00e3f9
+main == tag at release boundary
 ```
 
-not:
+The 0.2 line establishes the first release-grade product-runtime surface:
 
-```text
-foreground activation can never happen
-```
+- `ChatGPTProductRuntime` as the forward-looking application boundary;
+- browser-owned ordinary ChatGPT product writes;
+- canonical browserless read/status/finality where supported;
+- no hidden fallback to legacy direct writes;
+- no automatic retry after ambiguous writes;
+- revision-safe streaming and final-only observation;
+- product-native model profiles `INSTANT`, `MEDIUM`, `HIGH` plus compatibility aliases `FAST`, `BALANCED`, `DEEP`;
+- production Temporary Chat text turns with session-local authority;
+- stable `cwa` CLI surfaces for send/status/capabilities/messages/snapshot/export/doctor;
+- deterministic conversation artifact manifests;
+- release-grade packaging, installed-wheel smoke and cross-platform CI.
 
-A warm path has been observed to stay inactive, while a cold/no-tab creation path has also been observed to foreground the newly created tab.
-
-Future lifecycle/resource work must measure both:
-
-```text
-cold-start foreground-disturbance risk
-warm-reuse foreground-disturbance risk
-```
-
-rather than encoding “never foregrounds” as a false guarantee.
-
-### PR8.2.5 non-tab boundary
-
-The supported Chrome surfaces reviewed in PR8.2.5 did **not** reveal a qualifying supported hidden/non-tab runtime that simultaneously preserves ordinary top-level ChatGPT product semantics.
-
-The current minimum proven write substrate therefore remains an ordinary ChatGPT page runtime owned by Chrome/extension machinery.
-
-This is a reopenable evidence boundary, not a metaphysical impossibility claim. Reopen it if a newly documented Chrome or OpenAI-supported surface materially changes the architecture.
+The 0.2 release intentionally does **not** graduate the new product-runtime surface for images, general files, multimodal continuation, web search/tools/connectors or a production browserless write transport.
 
 ---
 
-## 2. Current Product-Runtime Contract
+## 2. Product identity and ownership
 
-The intended public mental model after PR8.4–PR8.6 is:
+The project should be understood as:
+
+```text
+                     ChatGPT product
+                           |
+                           v
+                 chatgpt-web-adapter
+             standalone SDK / CLI / bridge
+                           |
+            +--------------+--------------+
+            |              |              |
+            v              v              v
+           CMA            HDE        other callers
+```
+
+CWA owns facts and mechanisms intrinsic to the ChatGPT product bridge:
+
+- transport and session mechanics;
+- canonical conversation observation;
+- product writes;
+- streaming/finality/reconciliation;
+- product capabilities and provenance;
+- model/product-mode selection;
+- Temporary Chat semantics;
+- browser authority lifecycle;
+- attachments and rich product features when graduated;
+- product-level diagnostics and artifacts.
+
+CWA does **not** own downstream project cognition or authority:
+
+- Director / Worker / Summarizer roles;
+- project state or project history meaning;
+- task orchestration;
+- workspace mutation policy;
+- Git authority;
+- autonomous project continuation policy.
+
+Those belong to CMA/HDE/other applications built on CWA.
+
+---
+
+## 3. Architectural invariants
+
+The PR9 line must preserve the following unless new evidence explicitly supersedes one.
+
+1. **CWA remains standalone.** Downstream integrations may stress-test the public contract but do not define the product roadmap.
+2. **Ordinary ChatGPT product semantics remain first-class.** Do not silently substitute another product/API surface while calling it equivalent.
+3. **Canonical observation and product mutation remain separate planes.**
+4. **Transport selection is explicit.** No silent browser-owned ↔ browserless ↔ legacy fallback.
+5. **Ambiguous writes are never automatically retried.** Reconciliation comes first.
+6. **Streaming is not finality.** Incremental observations never fabricate canonical completion.
+7. **Observed provenance is preserved rather than synthesized.**
+8. **Capabilities remain evidence-backed.** `AVAILABLE`, `UNSUPPORTED`, `UNKNOWN`, and `UNIMPLEMENTED` remain distinct.
+9. **Browser Authority Lease remains separate from Turn Lifecycle.**
+10. **Browser internals stay below the public runtime boundary.** Callers should not depend on tab ids, extension worker details, Native Messaging internals, debugger target ids or concrete transport classes.
+11. **The production transport remains replaceable.** New transports must fit the product-level contract rather than forcing downstream rewrites.
+12. **No challenge-bypass expansion.** Do not add Turnstile solving, proof-token generation, browser-protection emulation or replay-oriented protected-write reconstruction.
+13. **Browserless write work is experimental by default.** A working direct-request path does not become production merely because it passed today.
+14. **Dynamic web-product drift is an explicit risk.** Browserless behavior may change independently of CWA releases and must fail clearly rather than pretend permanence.
+
+---
+
+## 4. Development mode after 0.2 — fast and reliable
+
+PR8 used many small evidence and repair steps because the architecture and product contracts were still unknown. That mode should not become permanent process overhead.
+
+Post-0.2 development should prefer **large vertical milestones**.
+
+```text
+OLD RESEARCH MODE
+feature
+ -> probe
+ -> repair
+ -> hardening
+ -> replication
+ -> polish
+ -> another small contract PR
+
+POST-0.2 MODE
+one vertical milestone
+ -> implementation
+ -> deterministic regression/failure semantics
+ -> bounded live validation
+ -> docs/compatibility
+ -> full regression
+ -> DONE
+```
+
+The goal is not fewer checks. The goal is fewer administrative stops.
+
+A separate repair/hardening PR is justified when:
+
+- a real post-merge defect is found;
+- live evidence reveals a fundamentally new boundary;
+- the original milestone cannot safely contain the newly discovered work;
+- product drift invalidates an existing assumption.
+
+Do not create tiny PRs merely to repeat verification already covered by the milestone acceptance gate.
+
+---
+
+# PR9 — Post-0.2 Product Generation
+
+## 5. PR9.0 — Browser-Owned v1 Completion and Standalone SDK Architecture Freeze
+
+### Goal
+
+Finish the browser-owned generation as the mature production baseline and freeze the standalone SDK architecture that later transports must preserve.
+
+This is not another investigation into whether browser-owned writes work. They already do. PR9.0 should close the remaining browser-owned era as a product milestone.
+
+### Scope
+
+PR9.0 should include, in one vertical PR where practical:
+
+- final review of the public `ChatGPTProductRuntime` contract;
+- final transport/canonical boundary suitable for both current browser-owned and future browserless implementations;
+- browser authority lifecycle and resource behavior cleanup where evidence already supports it;
+- stable ordinary-text durable and Temporary behavior;
+- model profile and streaming behavior under the frozen public contract;
+- finality, reconciliation and ambiguous-write semantics;
+- diagnostics and product provenance consistency;
+- standalone Python SDK and CLI ergonomics;
+- downstream compatibility expectations without adding downstream-specific orchestration;
+- performance cleanup that materially improves real use;
+- removal or isolation of obvious obsolete internal paths where safe;
+- documentation updated from “research architecture” to “mature production browser-owned baseline”.
+
+### Acceptance principle
+
+```text
+BrowserOwnedProductTransport
+    = production implementation complete
+```
+
+“Complete” does not mean immutable. It means future work should primarily add capabilities or alternative transports rather than repeatedly reopen already-proven browser-owned foundations.
+
+### Downstream contract
+
+CMA is one important integration consumer. HDE and arbitrary third-party callers are equally valid consumers.
+
+PR9.0 should preserve the rule:
+
+```text
+CWA public product contract
+    stable above implementation details
+```
+
+rather than adding CMA-specific concepts to CWA.
+
+---
+
+## 6. PR9.1 — Experimental Browserless Request Transport
+
+### Goal
+
+Build the next transport generation using direct web requests where technically and ethically supportable, while keeping it explicitly experimental because ChatGPT Web is a dynamic undocumented product surface.
+
+Target architecture:
 
 ```text
                  ChatGPTProductRuntime
-                    /           \
-                   /             \
-                  v               v
-     CanonicalConversation    ProductWriteTransport
-           Client                    Protocol
-             |                          |
-             |                          `-- BrowserOwnedProductTransport
-             |                                  |
-             |                                  `-- current page-owned writer
-             |
-             `-- messages / status / session / attach / readback
+                         |
+          +--------------+--------------+
+          |                             |
+          v                             v
+BrowserOwnedProductTransport   BrowserlessRequestTransport
+PRODUCTION                     EXPERIMENTAL
 ```
 
-HDE should use the product-runtime contract rather than browser implementation details.
+### Principle
 
-Current HDE-facing primitives include:
+Browserless is not a requirement to eliminate the browser at any cost. It is an experimental direct-request path behind the same product-level runtime contract.
 
-```python
-runtime.health(...)
-runtime.capabilities()
-runtime.send(...)
-runtime.send_text_observed(...)
-runtime.get_status(...)
-runtime.get_messages(...)
-runtime.attach_conversation(...)
-runtime.governance()
-```
+The existing production browser-owned implementation remains available as the reliable baseline.
 
-HDE should **not** need to know:
+### Vertical scope
 
-- Chrome tab IDs;
-- extension worker names;
-- Native Messaging host details;
-- `chrome.debugger` target IDs;
-- Sentinel internals;
-- concrete browser-owned writer classes;
-- whether a future implementation becomes Python-centered, daemon-centered, or extension-centered.
+PR9.1 should investigate and implement the complete viable browserless text path in one milestone rather than one header or endpoint per PR:
 
----
+- session/auth use within existing legitimate session boundaries;
+- new conversation;
+- existing conversation continuation;
+- prepare/write sequencing where applicable;
+- response stream observation;
+- canonical finality and reconciliation;
+- product identity recovery;
+- model/reasoning selection where representable without fabricating equivalence;
+- Temporary semantics where representable;
+- explicit unsupported/unknown states where not representable;
+- drift/error classification;
+- no automatic retry after ambiguous writes;
+- no silent fallback to browser-owned writes unless the caller explicitly requests a policy that permits it.
 
-## 3. Architectural Invariants
+### Experimental status
 
-Future PRs must preserve these invariants unless later evidence explicitly supersedes one.
-
-1. **Ordinary product semantics are first-class.** Do not silently substitute another product/API surface while calling it equivalent.
-2. **Canonical observation and product mutation are separate planes.** Read/status/session logic must not be coupled to one particular write mechanism.
-3. **Transport selection is explicit.** No silent `browser-owned -> legacy direct write` fallback.
-4. **Ambiguous writes are never automatically retried.** Reconciliation precedes any retry decision.
-5. **Authoritative completion evidence is preserved.** Page submission alone is not enough to claim a completed product turn.
-6. **Incremental text observation is not canonical finality.** Partial text may be shown early without claiming completion.
-7. **Browser Authority Lease is not Turn Lifecycle Lease.** The logical turn may remain active after browser authority becomes unnecessary, if live evidence proves early release safe.
-8. **Browser authority stays browser-local where possible.** Browser state and page interaction should not be reconstructed externally without need.
-9. **HDE must not depend on browser implementation details.** It depends on the product-runtime contract.
-10. **Observed provenance is preserved instead of synthesized.** Missing metadata remains missing when other evidence proves completion.
-11. **Capability states remain distinct.** `UNSUPPORTED`, `UNKNOWN`, and `UNIMPLEMENTED` must not collapse into false/true.
-12. **Parameterized capabilities may add structured details without discarding the four-state model.**
-13. **Explicit product-mode selection is fail-closed unless the caller explicitly opts into best-effort fallback.**
-14. **Conversation/product mode must not leak silently across independent turns.** Sticky UI state requires explicit characterization and isolation.
-15. **Legacy research remains recoverable.** Sentinel/direct-write work is isolated before deletion.
-16. **No challenge-bypass expansion.** No Turnstile solving, proof-token generation, browser-protection emulation, protective-credential extraction/replay, or reconstructed protected private writes.
-17. **The current production transport is replaceable.** Future supported/native/desktop transports should be swappable without rewriting HDE.
-18. **Architecture work is evidence-labelled.** Distinguish `PROVEN`, `TARGET`, `HYPOTHESIS`, `DECISION`, and `DECISION_PENDING` when the distinction matters.
-
----
-
-## 4. Completed Foundation — PR8.3 through PR8.6
-
-### PR8.3 — Production Browser-Owned ChatGPT Transport Integration
-
-Status: **COMPLETE / LIVE-VALIDATED**
-
-Established:
-
-- `ChatGPTProductRuntime`;
-- production `browser-owned` transport selection;
-- CLI `runtime status` / `runtime send`;
-- browserless canonical/session plane plus page-owned write plane;
-- no legacy direct-write fallback;
-- canonical readback requirement;
-- no automatic ambiguous-write retry.
-
-### PR8.4 — Product Transport Protocol and Canonical/Write Plane Separation
-
-Status: **COMPLETE / REGRESSION-CLEAN**
-
-Established:
-
-- `ProductWriteTransport`;
-- `CanonicalConversationClient`;
-- implementation-independent `ChatGPTProductRuntime` dispatch;
-- `BrowserOwnedProductTransport` as the first concrete production transport;
-- explicit transport identity validation;
-- HDE-facing decoupling from the concrete browser writer.
-
-### PR8.5 — Product Capability Model and Provenance-Aware Response Governance
-
-Status: **COMPLETE / LIVE-VALIDATED**
-
-Established:
-
-- four-state capability model;
-- machine-readable browser-owned feature declaration;
-- product execution/completion/identity provenance;
-- canonical completion independent of nullable `finish_reason`;
-- no synthetic `stop`;
-- live capability/provenance compatibility gate.
-
-### PR8.6 — Legacy/Sentinel Isolation and Public Surface Reclassification
-
-Status: **COMPLETE / FULL SUITE GREEN**
-
-Established:
+Even a successful PR9.1 remains:
 
 ```text
-PRIMARY_PRODUCTION
-SHARED_SUPPORT
-COMPATIBILITY
-EXPERIMENTAL
-RESEARCH_DIAGNOSTIC
+BrowserlessRequestTransport = EXPERIMENTAL
 ```
 
-with:
+Reason:
 
-- `ChatGPTProductRuntime` as the forward-looking production surface;
-- `ChatGPTWebClient` retained as compatibility rather than silently redirected/deprecated;
-- Sentinel/direct browser-native surfaces classified as research/diagnostic;
-- README/examples/architecture repositioned around the product runtime;
-- no transport/runtime behavior rewrite.
+```text
+browser-owned:
+    the official frontend adapts to many product changes itself
+
+browserless:
+    CWA directly depends on current web protocol behavior
+```
+
+Therefore direct-request compatibility can break when the site changes independently of a CWA release.
+
+### Boundary rule
+
+If a protected product write cannot be represented legitimately without reconstructing challenge protections or replay-oriented credential machinery, record the limitation. Do not turn browserless research into challenge-bypass work.
 
 ---
 
-## 5. Daily-Use Phase — Why PR8.7 through PR8.11 Exist
-
-The next phase is not about proving that the transport works at all.
-
-It is about making the proven product-runtime boundary suitable for actual HDE daily use.
-
-The target experience is:
-
-```text
-request
-   |
-   v
-create/reuse minimal browser authority
-   |
-   v
-page-owned write
-   |
-   +--> useful text appears quickly
-   |
-   +--> browser authority released as soon as evidence permits
-   |
-   v
-authoritative finality/reconciliation
-```
-
-For internal HDE calls:
-
-```text
-Temporary product mode
-+ FAST semantic model intent
-+ revision-safe streaming
-+ TURN_SCOPED browser authority
-```
-
-should eventually provide a low-latency, non-cluttering inference primitive while HDE retains ownership of its reviewed context/memory policy.
-
-The detailed reviewed design is in [`docs/post_pr8_daily_use_product_bridge_direction.md`](docs/post_pr8_daily_use_product_bridge_direction.md).
-
----
-
-## 6. PR8.7 — Temporary Chat Product Semantics, Ephemeral Identity / Persistence Characterization and Fail-Closed Conversation-Mode Governance
+## 7. PR9.2 — Full Product Input Expansion: Images, Files and Multimodal
 
 ### Goal
 
-Make Temporary Chat a proven product-runtime capability suitable for ephemeral HDE calls without assuming durable-conversation identity/readback semantics.
+Move CWA beyond the 0.2 text-first product contract and make the standalone SDK useful for the ordinary rich-input workflows users expect from ChatGPT.
 
-### Required characterization
+### Scope
 
-At minimum:
+Prefer one integrated milestone covering:
 
-```text
-Temporary mode selection proven before write
-successful text turn
-no normal/durable fallback on selection failure
-history/persistence behavior
-conversation/turn identity behavior
-get_messages/get_status/attach behavior or explicit absence
-terminal/finality source
-cold/no-tab path
-warm/reused-tab path
-TEMP -> NORMAL isolation
-NORMAL -> TEMP isolation
-runtime-tab recreation behavior
-continuation semantics if any
-```
+- image upload;
+- multiple images;
+- image + text turns;
+- general file attachment;
+- PDF/document/code attachment paths;
+- multimodal continuation;
+- attachment identity and metadata in product responses/artifacts;
+- upload/submit partial-failure semantics;
+- streaming after rich input;
+- model-profile interaction;
+- durable versus Temporary behavior;
+- capability declarations per transport.
 
-### Primary API direction
+Historical compatibility/media paths may provide evidence and implementation material, but they do not count as product-runtime graduation by themselves.
 
-```python
-runtime.send(
-    prompt,
-    conversation_mode="temporary",
-)
-```
+### Transport rule
 
-A convenience `send_temporary()` may later delegate to the same mode contract.
+Browser-owned production support and browserless experimental support are evaluated independently.
 
-### Core invariant
+Example:
 
 ```text
-TEMPORARY requested
-    -> Temporary product mode proven before write
-or
-    -> fail before write
+images:
+  browser-owned = AVAILABLE
+  browserless    = UNKNOWN / EXPERIMENTAL / AVAILABLE-experimental
 ```
 
-No accidental durable conversation creation.
-
-### Capability rule
-
-`temporary_chat` moves from `UNKNOWN` to `AVAILABLE` only after the transition/identity/persistence matrix is live-characterized.
-
-### Architecture Invalidation Check
-
-If Temporary Chat cannot be represented safely through the current product-runtime/canonical boundaries without major special-case coupling, advance PR9.0 rather than forcing durable-chat semantics onto an ephemeral product mode.
+Do not flatten transport-specific evidence into one false global claim.
 
 ---
 
-## 7. PR8.8 — Browser Authority Lease, Turn Lifecycle Separation, Idle-TTL / Turn-Scoped Disposal and Cold/Warm Lifecycle Governance
-
-### Central distinction
-
-```text
-Browser Authority Lease != Turn Lifecycle Lease
-```
-
-### Turn Lifecycle Lease
-
-Covers the logical turn through authoritative finality/reconciliation.
-
-### Browser Authority Lease
-
-Covers only the time during which the browser page/context remains genuinely required.
-
-If evidence proves the page is required until finality, both leases end together.
-
-If evidence proves generation/canonical observation can continue after page-owned write handoff, browser authority may be released earlier while the logical turn remains active.
-
-### Lifecycle policies
-
-```text
-PERSISTENT
-IDLE_TTL
-TURN_SCOPED
-```
-
-Initial PR8.8 compatibility defaults:
-
-```text
-PERSISTENT = default
-IDLE_TTL = opt-in
-TURN_SCOPED = opt-in
-```
-
-Do not change the default until lifecycle/resource evidence justifies it.
-
-### TTL precedence
-
-```text
-per-turn explicit override
-        ↓
-runtime assembly default
-        ↓
-transport implementation default
-```
-
-### TTL rule
-
-TTL begins after **Browser Authority Lease release**, never merely after submit.
-
-`ttl=0` is permitted for any explicit `TURN_SCOPED` path whose authority-release point is proven safe; it is not Temporary-only.
-
-### Disposal decision
-
-```text
-CLOSE   = production v1
-DISCARD = benchmark/characterization candidate
-```
-
-### Minimum PR8.8 resource evidence
-
-```text
-cold-start latency
-warm-reuse latency
-idle CPU
-idle memory
-close -> next-turn latency
-foreground disturbance
-Browser Authority Lease duration
-```
-
-### Core invariant
-
-```text
-no tab disposal while browser authority is still required
-```
-
-### Architecture Invalidation Check
-
-If browser authority cannot meaningfully separate from the full logical turn lifecycle, record that as a hard PR9.0 boundary rather than hiding it behind timer policy.
-
----
-
-## 8. PR8.9 — Incremental Text Observation, Revision-Safe Streaming, First-Delta Latency and Canonical-Finality Reconciliation
+## 8. PR9.3 — Search, Tools and Rich Product Turn Surface
 
 ### Goal
 
-Surface useful response text as soon as safely observable rather than blocking on the current final-message polling loop.
+Expose more of the ChatGPT product turn as structured CWA observations without turning CWA into a project agent or authority system.
 
-### Central distinction
+### Candidate product observations
 
-```text
-Incremental Text Observation != Canonical Finality
-```
+- web-search activity;
+- search/source/citation observations;
+- tool invocation and tool completion activity where safely observable;
+- required-action states;
+- connector/product activity where appropriate;
+- richer assistant activity/event normalization;
+- final answer plus source/provenance relationships.
 
-### Primary abstraction
+### Ownership boundary
 
-Do not promise model-token boundaries unless the source actually exposes them.
-
-Prefer revision-safe text observations such as:
-
-```text
-AssistantTextSnapshot
-AssistantTextDelta
-AssistantTextRevision
-CanonicalTextFinalized
-```
-
-`on_token` may remain as compatibility/helper behavior where an append-only channel is proven.
-
-### Streaming source order
+CWA may report:
 
 ```text
-1. incremental canonical observation
-2. safe browser response observation
-3. rendered-page observation
+"ChatGPT performed/asked for product action X"
 ```
 
-Start with a focused live question:
-
-> Does the canonical read surface expose useful partial assistant content during generation?
-
-If clearly no, move to the next source rather than forcing the canonical path.
-
-### Reconciliation states
-
-A useful final stream/canonical relationship may include:
+CWA must not infer:
 
 ```text
-EXACT_MATCH
-CANONICAL_EXTENDS_STREAM
-STREAM_REVISED_BY_CANONICAL
-STREAM_INCOMPLETE
-UNAVAILABLE
+"therefore mutate this workspace or Git repository"
 ```
 
-### Metrics
+External/local authority remains the responsibility of the caller such as CMA or HDE.
 
-At minimum:
-
-```text
-TTFW
-TTFT
-stream_duration
-finality_lag
-return_lag
-browser_authority_release_lag
-```
-
-### Core invariant
-
-```text
-partial text may be shown early
-completion is not claimed until authoritative terminal semantics are proven
-no automatic resend after partial-stream failure
-```
-
-### Architecture Invalidation Check
-
-If useful low-latency streaming fundamentally requires a browser-ownership model incompatible with the current runtime seams, advance PR9.0 before building further features on an invalid boundary.
+Normalized product observations are evidence, not downstream authority.
 
 ---
 
-## 9. PR8.10 — Product Model / Reasoning Selection, Semantic Model Profiles, State-Scope Isolation and Selection Provenance
+## 9. PR9.4 — CWA 0.3 Stabilization and Release
 
 ### Goal
 
-Let HDE deliberately choose low-latency versus deep-reasoning product behavior.
+Cut the next release after the PR9 product generation reaches a coherent user-facing boundary.
 
-### HDE-facing semantic intent
-
-```text
-FAST
-BALANCED
-DEEP
-MAX
-```
-
-Semantic profiles belong at the `ChatGPTProductRuntime` layer.
-
-The transport exposes/applies product-specific selectors and returns observed selection evidence.
-
-### Exact selector
-
-An advanced exact product-model/mode selector may exist, but semantic intent should remain the stable HDE-facing abstraction.
-
-### Explicit selection is strict by default
+Target positioning:
 
 ```text
-no explicit intent
-    -> inherited/default behavior may be allowed
+CWA 0.2
+    production-grade text product bridge
 
-explicit model_profile/model_exact
-    -> select/prove before write
-       or fail before write
+CWA 0.3 target
+    mature standalone product SDK
+    + completed browser-owned baseline
+    + experimental browserless request transport
+    + rich input / multimodal product support
+    + richer search/tool/product observations where completed
 ```
 
-Best-effort fallback requires explicit caller opt-in and provenance must record the fallback.
+Not every experimental surface must be promoted to stable status to ship 0.3. Experimental features must be clearly labeled and must not weaken the stable browser-owned contract.
 
-### Required scope characterization
+Release acceptance should continue to require:
 
-Determine whether selection mutates:
-
-```text
-turn
-conversation
-runtime tab
-future new chats
-account/product default
-other manually open ChatGPT tabs
-```
-
-Transition tests must detect sticky-state leakage.
-
-### Structured capability details
-
-Keep the PR8.5 four-state model, but allow parameterized capabilities to expose structured details when needed.
-
-### Core invariant
-
-```text
-requested model intent is never silently represented as honored when evidence says otherwise
-```
-
-### Architecture Invalidation Check
-
-If reliable model/reasoning control requires fundamentally different page authority, carry that evidence to PR9.0 rather than hiding the limitation.
+- full deterministic regression suite;
+- bounded live product gate for changed product-facing behavior;
+- Linux/Windows package validation;
+- exact installed-wheel smoke;
+- release metadata/tag/version agreement;
+- explicit capability/support-tier documentation.
 
 ---
 
-## 10. PR8.11 — Browser Authority Cost Reduction, Debugger Attachment Minimization and Deep Resource Baseline
+## 10. CMA and other downstream consumers
 
-### Goal
+CMA remains strategically important because it is a demanding real consumer of CWA, but it does not own the CWA roadmap.
 
-Reduce browser overhead and visible browser authority without weakening product semantics.
-
-### Debugger policy
-
-Do **not** attempt to conceal or bypass Chrome security UX while still using debugger authority.
-
-Correct sequence:
+The relationship is:
 
 ```text
-measure current debugger attachment lifetime
-        ↓
-shorten attachment window where safe
-        ↓
-live reliability validation
-        ↓
-independently investigate debugger-free/lower-authority path
-```
-
-Possible lower-authority experiments include content scripts / `chrome.scripting`, but they must independently prove product-semantic equivalence.
-
-### Deep resource baseline
-
-Build on PR8.8 minimum lifecycle measurements and add:
-
-```text
-cold boot CPU time
-network bytes/request count
-JS heap if available
-DOM node count if useful
-GPU/compositor activity if measurable
-per-turn CPU/network cost
-navigation/reload cost
-debugger attach lifetime
-resource-class contribution
-```
-
-Resource blocking/removal should be performed one class at a time and must not approximate or break product semantics.
-
-### Architecture Invalidation Check
-
-If a clearly superior lower-authority mechanism requires a larger ownership rewrite, defer that rewrite and carry evidence into PR9.0.
-
----
-
-## 11. Architecture Invalidation Check
-
-Normal sequencing is:
-
-```text
-PR8.7 -> PR8.8 -> PR8.9 -> PR8.10 -> PR8.11 -> PR9.0
-```
-
-But every PR8.7–PR8.11 must explicitly ask:
-
-```text
-Did this PR reveal that the current product-runtime boundary cannot safely express the feature?
-Did it reveal unavoidable browser coupling that invalidates the current ownership model?
-Would a next-generation bridge materially change the implementation we are about to build next?
-```
-
-If yes:
-
-```text
-FUNDAMENTAL_BOUNDARY_DISCOVERED
+CWA releases stable product contracts
         |
         v
-advance PR9.0
+CMA explicitly pins/migrates to a version
 ```
 
-Do not mechanically finish the entire PR8.7–PR8.11 sequence on top of an architecture that evidence has already invalidated.
+CMA M3.0 may pin CWA 0.2.0 and migrate to `ChatGPTProductRuntime` without waiting for PR9.
+
+Future CMA adoption of 0.3/PR9 capabilities should be an explicit downstream migration rather than an implicit moving dependency.
+
+The same rule applies to HDE and other callers.
+
+Cross-repository ownership details belong in [`docs/cwa_cma_coordination_roadmap.md`](docs/cwa_cma_coordination_roadmap.md), not in feature-number ownership of this roadmap.
 
 ---
 
-## 12. HDE Integration During the Daily-Use Phase
+## 11. Long-term direction after PR9
 
-Do not wait for PR9.0 to begin HDE integration.
-
-HDE can use the current PR8.6 product runtime for ordinary text turns now, with capability checks around optional features.
-
-Conceptual HDE call classes may become:
-
-### User-visible durable conversation
+PR9 is not the end-state of CWA. It establishes two parallel transport realities:
 
 ```text
-mode: durable
-model: FAST/BALANCED by default when model control becomes AVAILABLE
-streaming: yes when AVAILABLE
-browser policy: moderate idle TTL after lifecycle evidence
+PRODUCTION
+browser-owned product authority
+
+EXPERIMENTAL
+browserless direct-request product transport
 ```
 
-### Internal short inference
+Future generations may improve either side, add supported native/product surfaces if they appear, or eventually promote a browserless mode only if long-term evidence justifies a stronger support claim.
+
+The stable abstraction should remain:
 
 ```text
-mode: temporary when AVAILABLE
-model: FAST when AVAILABLE
-streaming: optional/preferred
-browser policy: TURN_SCOPED, ttl=0 when authority release is proven safe
-```
-
-### Deep research step
-
-```text
-mode: durable research conversation
-model: DEEP/MAX when AVAILABLE
-streaming: yes
-browser policy: long enough to preserve warm active research session
-```
-
-### Planner/evaluator call
-
-```text
-mode: temporary
-model: FAST
-browser policy: TURN_SCOPED
-```
-
-HDE must continue to use `runtime.capabilities()` rather than importing browser-native internals to gain these features.
-
----
-
-## 13. Research Automation Boundary
-
-`chatgpt-web-adapter` should expose product/runtime primitives:
-
-```text
-send
-revision-safe text observation
-status/messages/attach
-Temporary Chat
-model/reasoning selection
-Browser Authority Lease / TTL
-completion/finality events
-provenance
-reconciliation
-```
-
-HDE should own cognition/workflow policy:
-
-```text
-research goals
-next-step generation
-planner/evaluator policy
-memory/context projection
-budget
-stop criteria
-human-review checkpoints
-tool/external-action policy
-```
-
-A strong future pattern is:
-
-```text
-MAIN DURABLE RESEARCH CHAT
-          |
-          v
-HDE Research Controller
-          |
-          +--> TEMPORARY FAST evaluator/planner
-          |
-          v
-validated next instruction
-          |
-          v
-MAIN DURABLE RESEARCH CHAT
-```
-
-Minimum automation lineage/guards should include:
-
-```text
-job_id
-step_id
-parent_step_id
-persistent journal
-request fingerprint
-max turns/runtime/failures
-no-progress budget
-duplicate detection
-DONE / ABSTAIN / NEEDS_REVIEW states
-no resend after ambiguous write
-human gate for external effects
-```
-
-The planner/evaluator is not automatically “independent evidence” merely because it is a second model turn.
-
----
-
-## 14. PR9.0 — Next-Generation Product Bridge Architecture Feasibility
-
-PR9.0 remains an architecture-decision PR, not a rewrite PR.
-
-Normal timing is after PR8.11, but the Architecture Invalidation Check may advance it.
-
-### Candidate A — Current Python-Centered Runtime
-
-```text
-Python / HDE
-  -> canonical HTTP
-  -> Native Messaging
-  -> extension
-  -> ordinary ChatGPT runtime tab
-```
-
-### Candidate B — Optimized Lightweight Inactive-Tab Runtime
-
-Evolve the current architecture with:
-
-- bounded Browser Authority Lease;
-- TTL/turn-scoped lifetime;
-- revision-safe streaming;
-- minimized debugger lifetime;
-- reduced page-resource cost where proven safe.
-
-### Candidate C — Extension-First Product Bridge
-
-Treat the extension as the primary owner of browser authority and product-page state, while preserving an efficient canonical/session plane outside the browser when advantageous.
-
-### Candidate D — Native Daemon + Extension
-
-Potential shape:
-
-```text
-               local product bridge
-                 /             \
-                /               \
-      canonical/session        extension
-            plane             browser plane
-                \               /
-                 \             /
-             ordinary ChatGPT product
-```
-
-The Python package could become a thin client to a language-independent local bridge.
-
-### Candidate E — Extension Offscreen / Embedded Experiments
-
-Only consider these if live evidence proves they preserve the required product semantics. Do not equate hidden/embedded contexts with an ordinary top-level product runtime without evidence.
-
-### Candidate F — Direct CDP / External Browser Control
-
-Compare as an architecture candidate, not as presumed simplification. External CDP may reduce extension components while worsening browser lifecycle/security ownership.
-
-### Candidate G — Newly Supported Product Surface
-
-If Chrome or OpenAI introduces a documented supported product/local execution surface that changes the PR8.2.5 boundary, reopen the lower-bound analysis.
-
----
-
-## 15. PR9.0 Comparison Criteria
-
-Every candidate should be compared against the same dimensions:
-
-- ordinary-product semantic fidelity;
-- browser ownership clarity;
-- Turn Lifecycle / Browser Authority separation;
-- canonical-read independence;
-- public API stability;
-- HDE integration complexity;
-- first-text latency;
-- canonical finality lag;
-- browser-authority release lag;
-- cold-start latency;
-- idle CPU/RAM;
-- network/page-init cost;
-- foreground-disturbance risk;
-- Temporary Chat fidelity;
-- streaming/revision fidelity;
-- model/reasoning control fidelity;
-- failure/process isolation;
-- language independence;
-- installation complexity;
-- upgrade/version-skew complexity;
-- security boundary;
-- local IPC exposure;
-- session continuity;
-- duplicate-write / unknown-outcome risk;
-- observability/reconciliation quality;
-- maintainability;
-- testability;
-- cross-platform portability;
-- migration cost from the proven PR8 baseline.
-
-PR9.0 should end with an explicit written verdict, for example:
-
-```text
-DECISION: EVOLVE_CURRENT_ARCHITECTURE
-```
-
-or:
-
-```text
-DECISION: PROTOTYPE_NATIVE_DAEMON_BRIDGE
-```
-
-with measurable reasons.
-
----
-
-## 16. Possible Post-PR9 Direction
-
-Two broad outcomes remain open.
-
-### Path 1 — Evolve the Current Architecture
-
-If the current model remains the best tradeoff:
-
-```text
+application
+    |
+    v
 ChatGPTProductRuntime
-  -> stable transport protocol
-  -> optimized BrowserOwnedProductTransport
-  -> bounded browser authority
+    |
+    v
+explicit product transport
 ```
 
-Continue improving it without a disruptive v2 rewrite.
+so transport evolution does not force users to rebuild their applications.
 
-### Path 2 — Build a Next-Generation Product Bridge
+---
 
-If daemon-centered or extension-first ownership is clearly superior:
+## 12. Canonical post-0.2 sequence
 
 ```text
-HDE / Python SDK / CLI / other local tools
-               |
-               v
-      local ChatGPT product bridge
-          /              \
- canonical plane       browser plane
-          \              /
-           ordinary ChatGPT
+v0.2.0 — frozen production text baseline
+   |
+   v
+PR9.0 — finish browser-owned generation + freeze mature standalone SDK architecture
+   |
+   v
+PR9.1 — experimental browserless direct-request transport
+   |
+   v
+PR9.2 — images / files / multimodal product-runtime graduation
+   |
+   v
+PR9.3 — search / tools / rich product observations
+   |
+   v
+PR9.4 — CWA 0.3 stabilization and release
 ```
 
-The current Python library can become a compatibility/client layer rather than being discarded.
-
----
-
-## 17. Multi-Provider Generalization Is Deliberately Deferred
-
-A future abstraction could eventually look like:
-
-```text
-ProductRuntime
-├─ ChatGPTProductRuntime
-├─ ClaudeProductRuntime
-├─ GeminiProductRuntime
-└─ LocalModelRuntime
-```
-
-Do **not** build this abstraction yet.
-
-One backend is not enough evidence to know which concepts are truly portable. Premature multi-provider design risks creating a lowest-common-denominator API based on ChatGPT-specific assumptions disguised as generic concepts.
-
-Revisit only after there is a concrete second product/runtime implementation and enough evidence to distinguish universal contracts from provider-specific behavior.
-
----
-
-## 18. Stress / Daily-Use Validation — Deferred, Not Cancelled
-
-Stress testing should resume after the architecture intended for daily use is stable enough that endurance evidence will validate the design we intend to keep.
-
-Future stress gates should include:
-
-- repeated production-runtime continuation turns;
-- new-chat + continuation mixes;
-- Temporary/durable mode transitions once Temporary becomes AVAILABLE;
-- model-profile transitions once model control becomes AVAILABLE;
-- runtime reconstruction between groups of turns;
-- process restart/reassembly;
-- no duplicate runtime tabs beyond policy;
-- no duplicate product turns;
-- measured foreground-disturbance rate rather than a false “never foregrounds” assumption;
-- authoritative completion/readback on every successful turn;
-- browserless session renewal during longer runs;
-- explicit reconciliation for ambiguous outcomes;
-- no automatic fallback to legacy write paths;
-- capability/provenance consistency across the run;
-- Browser Authority Lease / TTL correctness;
-- revision-safe stream/canonical reconciliation when streaming becomes AVAILABLE.
-
-Stress should validate the **post-daily-use architecture**, not freeze the earlier implementation merely by making endurance work the next center of gravity.
-
----
-
-## 19. Security and Product-Boundary Governance
-
-All future architecture work remains subject to these boundaries:
-
-- no Turnstile solving or bypass;
-- no proof-token synthesis;
-- no browser-fingerprint emulation;
-- no extraction/replay of protective browser credentials;
-- no reconstruction of protected private writes whose operation depends on bypassing product safeguards;
-- no silent credential copying between security contexts;
-- no attempt to conceal browser security UI while continuing to use the authority that triggers it;
-- no claim that embedded/offscreen contexts are equivalent to ordinary top-level ChatGPT without evidence;
-- no automatic resend when a delegated write may already have happened.
-
-Preferred direction:
-
-```text
-supported/session-safe canonical operations
-+ page-owned browser product write
-+ explicit capability/provenance evidence
-+ bounded browser authority
-+ fail-closed ambiguity handling
-```
-
----
-
-## 20. Decision Checkpoints
-
-### PR8.4 — COMPLETE
-
-Confirmed:
-
-- HDE can depend on the runtime without importing the concrete writer;
-- transport and canonical boundaries are explicit;
-- a future transport can fit behind the protocol.
-
-### PR8.5 — COMPLETE
-
-Confirmed:
-
-- capability states distinguish available/unsupported/unknown/unimplemented;
-- completion provenance does not invent nullable metadata;
-- HDE receives structured execution provenance.
-
-### PR8.6 — COMPLETE
-
-Confirmed:
-
-- the primary production surface is obvious;
-- compatibility/research surfaces remain recoverable;
-- README/examples/exports/architecture tell a consistent product-runtime-first story;
-- full regression suite is green.
-
-### After PR8.7
-
-Ask:
-
-- Are Temporary identity/persistence/finality semantics understood?
-- Can explicit Temporary requests fail closed before write?
-- Is TEMP↔NORMAL state isolation proven?
-- Did the work invalidate the current canonical/product boundary?
-
-### After PR8.8
-
-Ask:
-
-- Are Turn Lifecycle and Browser Authority lifetimes separately observable?
-- Can browser authority be safely released before canonical finality?
-- What cold/warm/resource tradeoff does TTL actually produce?
-- Did lifecycle evidence invalidate the current architecture?
-
-### After PR8.9
-
-Ask:
-
-- Can useful text be surfaced materially earlier than finality?
-- Is the stream revision-safe and reconciled with authoritative final state?
-- What source owns low-latency observation?
-- Does streaming require a different browser ownership architecture?
-
-### After PR8.10
-
-Ask:
-
-- Can HDE request FAST/DEEP intent without sticky state leakage?
-- Is selection scope understood?
-- Is explicit selection fail-closed and provenance-backed?
-
-### After PR8.11
-
-Ask:
-
-- What is the measured browser cost?
-- Can debugger attachment be materially shortened or removed?
-- Is a lower-authority browser path actually superior?
-
-### After PR9.0
-
-Ask:
-
-- Should the current Python-centered runtime remain primary?
-- Is extension-first ownership materially cleaner?
-- Is a local native daemon worth its lifecycle complexity?
-- Does any newly supported surface invalidate the current page-runtime lower bound?
-- Is a v2 product bridge justified by measurable gains?
-
----
-
-## 21. Planned Order
-
-| Phase | Work | Primary purpose |
-| --- | --- | --- |
-| Complete | PR8.2.x | Establish browser-owned write/read/session boundaries and non-tab feasibility boundary |
-| Complete | PR8.3 | Production `ChatGPTProductRuntime`, closed transport selection, CLI, live new/continuation turns |
-| Complete | PR8.4 | Product transport protocol + canonical/write plane separation |
-| Complete | PR8.5 | Capability states + feature declaration + execution provenance |
-| Complete | PR8.6 | Legacy/Sentinel isolation + public-surface/docs compatibility boundary |
-| Next | PR8.7 | Temporary Chat semantics + ephemeral identity/persistence characterization |
-| Then | PR8.8 | Browser Authority Lease + Turn Lifecycle separation + TTL/disposal |
-| Then | PR8.9 | Revision-safe streaming + first-text latency + canonical reconciliation |
-| Then | PR8.10 | Semantic model/reasoning selection + state-scope isolation |
-| Then | PR8.11 | Browser authority/resource cost + debugger minimization |
-| Decision | PR9.0 | Compare current/optimized/extension-first/daemon/offscreen/CDP/supported alternatives |
-| Later | Stress | Validate the chosen daily-use architecture under repeated use |
-| Deferred | Multi-provider runtime | Generalize only after a real second provider supplies evidence |
-
-Every PR8.7–PR8.11 includes an `ARCHITECTURE_INVALIDATION_CHECK`; PR9.0 may move earlier if a fundamental boundary is discovered.
-
----
-
-## 22. North Star
-
-The long-term objective is not merely:
-
-> “send a ChatGPT message from Python.”
-
-The objective is a small, explicit, local product-runtime boundary that lets higher-level systems such as HDE use ordinary ChatGPT product capabilities without coupling themselves to browser implementation details.
-
-The ideal result is:
-
-```text
-HDE / CLI / SDK / local tools
-          |
-          v
-stable product-runtime contract
-          |
-          +-- canonical observation
-          +-- revision-safe incremental text observation
-          +-- explicit capabilities + structured feature details
-          +-- provenance-aware completion
-          +-- Temporary / durable conversation intent
-          +-- semantic model/reasoning intent
-          +-- Browser Authority Lease / TTL
-          +-- replaceable product write transport
-          |
-          v
-ordinary ChatGPT product semantics
-```
-
-The current browser-owned runtime is the first proven authority mechanism behind that contract, not the definition of the contract itself.
-
-Three reviewed distinctions should remain visible throughout the next phase:
-
-```text
-Browser Authority Lease != Turn Lifecycle Lease
-
-Incremental Text Observation != Canonical Finality
-
-chatgpt-web-adapter owns product-runtime primitives
-HDE owns cognition, research policy, and workflow meaning
-```
-
-Those boundaries are the foundation for PR8.7–PR9.0.
+The sequence may be adjusted if live product evidence reveals a fundamental dependency, but avoid returning to tiny verification-only PR chains without a concrete reason.

--- a/docs/cwa_cma_coordination_roadmap.md
+++ b/docs/cwa_cma_coordination_roadmap.md
@@ -1,39 +1,76 @@
 # CWA ↔ CMA Coordination Roadmap
 
-_Last synchronized: 2026-08-20_
+_Last synchronized: 2026-08-22_
 
-This document is the cross-repository planning contract between `chatgpt-web-adapter` (CWA) and `codexia-manual-agent` (CMA). It is intentionally narrower than either repository's full roadmap. When an older roadmap paragraph uses broader language such as “HDE owns workflow meaning” or “CWA is transport only”, this document defines the current ownership boundary for CWA ↔ CMA work.
+This document is the cross-repository coordination contract between `chatgpt-web-adapter` (CWA) and `codexia-manual-agent` (CMA).
+
+It does **not** make CWA a CMA support project. CWA is a standalone SDK / CLI / local ChatGPT product bridge with its own roadmap, releases and users. CMA is one demanding downstream consumer of the public CWA contract.
+
+The purpose of this document is narrower:
+
+- preserve the ownership boundary;
+- record version/integration checkpoints;
+- prevent duplicate implementation across repositories;
+- keep CMA migrations explicit when CWA evolves.
+
+For CWA feature sequencing, [`../ROADMAP.md`](../ROADMAP.md) is authoritative.
+
+---
 
 ## 1. Architectural split
 
 ```text
 ChatGPT product
-      ↓
-CWA — product bridge
-      ↓
+      |
+      v
+CWA — standalone product bridge / SDK / CLI
+      |
+      v
 CMA provider/runtime
-      ↓
+      |
+      v
 CMA project/orchestration layer
-      ↓
+      |
+      v
 CMA local authority + workspace/Git execution
 ```
 
+CWA is also directly consumable by HDE, terminal users, Python applications and other local tools:
+
+```text
+                    CWA
+                     |
+        +------------+------------+
+        |            |            |
+        v            v            v
+       CMA          HDE      other callers
+```
+
+CMA must therefore consume CWA through the same public product contract available to other callers rather than through CMA-specific hooks.
+
+---
+
+## 2. Ownership boundary
+
 ### CWA owns product/runtime primitives
 
-CWA owns facts and mechanisms that are intrinsic to the ChatGPT product bridge:
+CWA owns facts and mechanisms intrinsic to the ChatGPT product bridge:
 
 - ordinary ChatGPT product transport;
 - canonical conversation reads, status, attach/session identity and finality;
 - browser-owned product writes and Browser Authority lifecycle;
+- explicit transport selection;
 - durable vs Temporary Chat product semantics;
 - semantic model/reasoning profiles and selection provenance;
 - revision-safe assistant text streaming;
-- normalized user-visible activity/tool/search streaming;
+- normalized user-visible product activity;
 - optional final-answer-only streaming;
 - product capabilities and execution provenance;
 - canonical reconciliation and ambiguous-write handling;
-- deterministic product-level `ConversationSnapshot` artifacts;
-- low-level CLI/SDK diagnostics such as status/messages/capabilities/doctor.
+- product `ConversationSnapshot` / export artifacts;
+- product-level CLI/SDK diagnostics such as status/messages/capabilities/doctor;
+- images/files/multimodal/search/tool observations when those capabilities graduate;
+- experimental browserless direct-request transport work under CWA support-tier rules.
 
 CWA must not own project cognition, project history meaning, task orchestration, local tool authority, workspace mutation policy or Git policy.
 
@@ -56,121 +93,106 @@ CMA owns semantics that exist because a project is being worked on rather than b
 - deterministic project resume/recovery;
 - bounded autonomous work policy.
 
-CMA must not depend on Chrome tab ids, service-worker internals, Native Messaging details or the concrete CWA browser writer.
+CMA must not depend on Chrome tab ids, service-worker internals, Native Messaging details, debugger target ids, private web protocol details or the concrete CWA transport implementation.
 
-## 2. Terminology boundary
+---
 
-Two names are deliberately kept distinct.
+## 3. Terminology boundary
+
+Two names remain deliberately distinct.
 
 ### CWA `ConversationSnapshot`
 
-A transport/product artifact describing what was actually present in a ChatGPT conversation. It may contain deterministic user/assistant context output and an optional raw product payload backup.
+A product/transport artifact describing what was present in a ChatGPT conversation. It may contain deterministic user/assistant context and optional product payload evidence according to the CWA artifact contract.
 
 ### CMA `ProjectContextCheckpoint`
 
-A semantic project artifact describing what the project should carry forward after one or more conversations. It is produced by CMA policy, not by CWA transport logic.
+A semantic project artifact describing what the project should carry forward after one or more conversations. It is produced by CMA policy, not CWA transport logic.
 
-The intended flow is:
+The intended flow remains:
 
 ```text
 CWA ConversationSnapshot
-        ↓ source/provenance
+        |
+        v
 CMA Summarizer
-        ↓
+        |
+        v
 HistoryDelta
-        ↓
+        |
+        v
 ProjectContextCheckpoint
 ```
 
-CMA should therefore not introduce another orchestration object called `ConversationSnapshot`.
+CMA should not introduce another orchestration object named `ConversationSnapshot`.
 
-Likewise, orchestration results use `WorkResult`, not `ResultReceipt`. The word `receipt` remains reserved for authority/security concepts such as authorization receipts and mutation receipts/observations.
+Likewise, orchestration results use `WorkResult`, not `ResultReceipt`. `receipt` remains reserved for authority/security/mutation evidence where appropriate.
 
-## 3. Synchronized execution order
+---
 
-CWA and CMA can advance in parallel because their next milestones are on different layers.
+## 4. Current synchronization checkpoint
 
 ### CWA
 
-1. **PR8.12 — normalized activity + final-only streaming**
-   - full user-visible turn stream is implemented and live-covered;
-   - presentation polish is complete;
-   - `--stream --final-only` is implemented as an optional quieter surface.
-2. **PR8.13 — Temporary Chat production graduation**
-   - production `conversation_mode="temporary"` path;
-   - pre-write Temporary proof;
-   - same-lifecycle continuation authority where supported;
-   - Temporary-specific finality/recovery semantics;
-   - no durable fallback.
-3. **Standalone/runtime stabilization for 0.2**
-   - README quick start for `cwa send` and `cwa snapshot`;
-   - `cwa status`, `cwa messages`, `cwa capabilities`;
-   - explicit snapshot vs export distinction;
-   - `cwa doctor`;
-   - stable artifact manifest/CLI contracts and exit codes;
-   - Windows/Linux CI, wheel/sdist smoke, changelog and release cleanup.
+CWA 0.2.0 is released and frozen as the current stable baseline:
 
-CWA should not add project summarization, history merge, Director/Worker state machines or project rollover as part of this sequence.
+```text
+version     0.2.0
+tag         v0.2.0
+commit      f1ebfd671c45153a3279163dc624e0af7c00e3f9
+release     2026-08-22
+```
+
+The release includes the stable product-runtime text contract required for CMA migration:
+
+- `ChatGPTProductRuntime`;
+- health/capability inspection;
+- durable text turns;
+- Temporary text turns;
+- model profile intent and provenance;
+- revision-safe/final-only streaming;
+- canonical status/messages/attach/readback;
+- finality/reconciliation semantics;
+- no automatic ambiguous-write retry;
+- product conversation artifacts;
+- stable CLI/diagnostic surfaces.
+
+CWA 0.2 intentionally leaves images/files/multimodal/search/tools and browserless production writes outside the stable product-runtime contract.
 
 ### CMA
 
-1. **M2.4.1 — exact patch proposal contract** — COMPLETE.
-2. **M2.4.2 — complete preimage/namespace revalidation + exact execution plan**
-   - revalidate the entire multi-file preimage set before authority consumption;
-   - bind an execution plan to accepted M2.3 create/replace primitives.
-3. **M2.4.3 — multi-file application and failure semantics**
-   - define the commit model;
-   - all-or-fail where supportable, otherwise explicit bounded partial-failure semantics;
-   - no silent best-effort mutation.
-4. **M2.4.4 — changed-file mutation observations/receipts**
-   - digest-bound per-file/set execution observations;
-   - exact changed-file/failure evidence.
-5. **M2.4.5 — rollback, crash and recovery semantics**
-   - recover from interrupted multi-file application according to the chosen commit model.
-6. **M2.4.6 — model patch request → bounded proposal → local human approval**
-   - the remote model may propose a bounded patch request;
-   - it still receives no direct write authority;
-   - execution remains under CMA local authority.
-7. **M2.5 — explicit Git mutation governance**
-   - commit and push remain distinct authorized actions;
-   - workspace mutation never implies Git authority.
-8. **M3.0 — CWA Product Runtime provider migration**
-   - move CMA off the old `ChatGPTWebClient.send()/send_to_conversation()` integration contract;
-   - consume stable `ChatGPTProductRuntime` capabilities/provenance/streaming surfaces;
-   - keep browser internals below the CWA boundary.
-9. **M3.1 — durable `ProjectState` + event journal**
-   - persistent exact chronology for project/runtime decisions, tool results, authority outcomes and conversation identities.
-10. **M3.2 — Summarizer + `HistoryDelta` + `ProjectContextCheckpoint` + rollover**
-    - project-semantic context compression and deterministic handoff;
-    - CWA snapshots are inputs/provenance, not the project memory format.
-11. **M3.3 — Director/Worker protocol**
-    - `WorkOrder` issuance;
-    - `WorkResult` return contract;
-    - conversation allocation and role boundaries.
-12. **M3.4 — project execution state machine**
+At the current synchronization point, CMA has completed M2.4.4 — exact changed-file mutation observations and digest-bound set receipts.
+
+The synchronized next sequence remains:
 
 ```text
-INIT
-→ DIRECTING
-→ WORK_READY
-→ EXECUTING
-→ VERIFYING
-→ REVIEW_READY
-→ DIRECTING
-
-terminal:
-COMPLETE / BLOCKED / FAILED / ESCALATED / BUDGET_EXHAUSTED
+M2.4.5
+rollback / crash / recovery semantics
+        |
+        v
+M2.4.6
+model patch request
+ -> bounded proposal
+ -> local human approval
+        |
+        v
+M2.5
+explicit Git mutation governance
+        |
+        v
+M3.0
+CWA Product Runtime provider migration
 ```
 
-13. **M3.5 — deterministic resume/recovery and multi-conversation lifecycle**
-    - interrupted Director/Worker work can be reconstructed from durable state;
-    - no duplicate side effect is inferred from conversational state alone.
-14. **M4 — Computational Lab** builds on the completed project runtime.
-15. **M5 — bounded automation** adds limited autonomous continuation with explicit budgets and stop policies.
+CMA may continue its local-authority work independently while CWA begins PR9.
 
-## 4. Integration contract
+---
 
-CMA should consume CWA through a provider boundary conceptually shaped like:
+## 5. CMA M3.0 — explicit CWA 0.2 migration gate
+
+CMA M3.0 should migrate off the old compatibility integration based on direct `ChatGPTWebClient.send()` / `send_to_conversation()` usage and consume the stable CWA product runtime instead.
+
+Conceptual provider boundary:
 
 ```text
 CWA ChatGPTProductRuntime
@@ -182,35 +204,181 @@ CWA ChatGPTProductRuntime
     answer/activity stream events
     execution provenance
     product ConversationSnapshot
-          ↓
+          |
+          v
 CMA provider adapter
-          ↓
+          |
+          v
 Director / Worker / Summarizer
-          ↓
+          |
+          v
 ProjectState + WorkOrder + WorkResult
 HistoryDelta + ProjectContextCheckpoint
-          ↓
+          |
+          v
 CMA local authority / workspace / Git governance
 ```
 
-CWA events are observations. They do not become CMA authority.
+### M3.0 pin
 
-CMA authority objects are local. They do not become CWA product-transport concerns.
+M3.0 should record an explicit dependency baseline:
 
-## 5. Explicit non-overlap rules
+```text
+CWA version  = 0.2.0
+CWA tag      = v0.2.0
+CWA commit   = f1ebfd671c45153a3279163dc624e0af7c00e3f9
+```
+
+and record the exact capability assumptions CMA relies on.
+
+CMA must not implicitly follow moving CWA `main`.
+
+---
+
+## 6. CWA PR9 proceeds independently
+
+CWA no longer needs to wait for CMA M3.0 before continuing its own product roadmap.
+
+The post-0.2 sequence is owned by CWA:
+
+```text
+PR9.0
+finish browser-owned generation
++ freeze mature standalone SDK architecture
+        |
+        v
+PR9.1
+experimental browserless direct-request transport
+        |
+        v
+PR9.2
+images / files / multimodal product-runtime graduation
+        |
+        v
+PR9.3
+search / tools / rich product observations
+        |
+        v
+PR9.4
+CWA 0.3 stabilization/release
+```
+
+CMA does not get CWA-specific milestone numbers in its own roadmap and CWA does not get CMA orchestration milestone numbers in its roadmap.
+
+The projects synchronize at explicit version boundaries instead.
+
+---
+
+## 7. Browser-owned and browserless coordination rule
+
+CMA M3.0 should rely on the stable 0.2 browser-owned product contract.
+
+Future CWA browserless work is explicitly experimental:
+
+```text
+BrowserOwnedProductTransport
+    production baseline
+
+BrowserlessRequestTransport
+    experimental direct-request path
+```
+
+CMA must not silently switch transports merely because a browserless experiment exists.
+
+Any future CMA use of browserless CWA should be an explicit dependency/configuration decision with capability checks and support-tier awareness.
+
+This keeps site-protocol drift inside CWA rather than leaking private request details into CMA.
+
+---
+
+## 8. Capability and version migration policy
+
+After M3.0, CMA should treat CWA as a versioned dependency.
+
+When CWA releases a new version:
+
+```text
+new CWA release
+      |
+      v
+CMA evaluates public capability delta
+      |
+      +-- no needed change -> remain pinned
+      |
+      `-- desired capability -> explicit migration PR
+```
+
+Examples:
+
+- CMA can remain on 0.2 while CWA experiments with browserless PR9.1.
+- CMA may later migrate to a 0.3 release to consume rich product observations or multimodal support.
+- CMA should never depend on experimental internals merely because they are present in CWA source.
+
+---
+
+## 9. Explicit non-overlap rules
 
 - CWA does not summarize project history; CMA does.
 - CWA does not decide when project context rolls over; CMA does.
 - CWA does not create `WorkOrder`; CMA does.
-- CWA does not interpret tool/search activity as project progress; CMA may interpret normalized observations if useful.
+- CWA does not interpret product search/tool activity as project progress; CMA may interpret normalized observations.
 - CMA does not reimplement ChatGPT stream parsing; it consumes CWA events.
 - CMA does not select or mutate Chrome/browser internals; it requests CWA product intent.
+- CMA does not implement browserless private web protocol details; CWA owns those experiments.
 - CMA patch authority does not imply Git commit/push authority.
-- GitHub-first project workflows do not bypass M2.4/M2.5 authority boundaries.
+- GitHub-first project workflows do not bypass CMA local authority boundaries.
 - Neither project treats conversational success text as proof that a filesystem/Git side effect occurred; local execution observations remain authoritative for local effects.
+- CWA product events are observations, not CMA local authority.
+- CMA local authority objects are not CWA product-transport concerns.
 
-## 6. Release synchronization checkpoint
+---
 
-Before CMA M3.0 is considered complete, CWA should have a stable enough 0.2-facing contract for the surfaces CMA consumes. CMA may integrate earlier against the feature branch for development, but the M3.0 completion gate should pin an explicit CWA version/commit and record the exact capability assumptions.
+## 10. Development cadence coordination
 
-After M3.0, future CWA implementation changes remain replaceable behind the product-runtime contract and should not require CMA orchestration redesign.
+CWA post-0.2 development now prefers large vertical milestones:
+
+```text
+implementation
++ deterministic tests
++ failure semantics
++ bounded live validation
++ docs/compatibility
+= one completed PR
+```
+
+CMA may continue using its own evidence/authority cadence where local mutation safety requires it.
+
+The two repositories do not need identical PR granularity.
+
+Cross-project coordination should happen at:
+
+- stable public contract changes;
+- explicit version pins;
+- capability additions/removals;
+- breaking migration requirements;
+- evidence that the current ownership boundary is wrong.
+
+Routine CWA polish should not block CMA, and routine CMA orchestration work should not block CWA.
+
+---
+
+## 11. Canonical relationship after CWA 0.2
+
+```text
+CWA
+standalone product bridge
+owns ChatGPT product/runtime mechanics
+        |
+        | stable versioned contract
+        v
+CMA
+project/orchestration runtime
+owns project meaning + local authority
+```
+
+The integration is intentionally asymmetric:
+
+- CWA does not know it is serving CMA;
+- CMA knows which CWA contract/version it consumes.
+
+That asymmetry is a feature. It keeps CWA reusable and keeps CMA insulated from browser/web-product implementation changes.


### PR DESCRIPTION
## Summary

Resets the canonical CWA roadmap after the `v0.2.0` release and synchronizes the CWA↔CMA coordination contract with the new baseline.

## Main roadmap changes

- make CWA explicitly standalone: SDK / CLI / local ChatGPT product bridge, not a CMA support project
- freeze `v0.2.0` / `f1ebfd671c45153a3279163dc624e0af7c00e3f9` as the post-0.2 baseline
- replace the stale pre-release PR8 sequence with a post-0.2 PR9 generation
- adopt large vertical milestones: implementation + deterministic regression/failure semantics + bounded live validation + docs/compatibility in one PR where practical
- retain strong verification while removing verification-only PR fragmentation
- define browser-owned as the production baseline and browserless direct requests as an explicit experimental transport

## PR9 sequence

```text
PR9.0 — Browser-Owned v1 Completion and Standalone SDK Architecture Freeze
PR9.1 — Experimental Browserless Request Transport
PR9.2 — Images / Files / Multimodal Product Runtime
PR9.3 — Search / Tools / Rich Product Turn Surface
PR9.4 — CWA 0.3 Stabilization and Release
```

## CWA ↔ CMA coordination changes

- preserve CMA as a demanding downstream consumer, not the owner of the CWA roadmap
- record CWA `0.2.0` as the stable CMA M3.0 migration baseline
- keep CMA M2.4.5 → M2.4.6 → M2.5 → M3.0 sequencing independent of CWA PR9
- require CMA to pin explicit CWA versions/commits instead of following moving `main`
- keep browserless experiments inside CWA rather than leaking private web-protocol details into CMA
- preserve the ownership split: CWA product/runtime mechanics; CMA project meaning/local authority

## Files

- `ROADMAP.md`
- `docs/cwa_cma_coordination_roadmap.md`

Documentation/planning only. No runtime, transport, CLI, packaging or product behavior changes.

Do not merge without explicit authorization.