### PR TITLE
PR9.0 — Browser-Owned v1 Completion and Standalone SDK Architecture Freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 ## Unreleased
 
+- runtime-contract: add schema-1 `ProductRuntimeContract` inspection, validate the complete stable runtime operation/interface boundary, and fail closed on missing or contradictory retry, fallback, reconciliation, finality, transport, or product-semantics governance
+- transport: classify built-in `browser-owned` as `PRODUCTION` while unknown/future transports default to `EXPERIMENTAL`; keep transport support tier independent from capability state and derive support/schema metadata rather than accepting caller self-promotion
+- compatibility: preserve the released `ChatGPTProductRuntime` method surface and the minimal `ProductWriteTransport` protocol while exposing new contract/support metadata through the primary Python SDK and capability/health serialization
+
 ## 0.2.0 - 2026-08-22
 
 - runtime: graduate `ChatGPTProductRuntime` as the primary forward-looking text-turn boundary with browser-owned product writes, canonical browserless read/status/final readback where available, explicit completion provenance, no automatic ambiguous-write retry, and no hidden compatibility fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is intentionally lightweight. Keep entries focused on user-visible be
 
 - runtime-contract: add schema-1 `ProductRuntimeContract` inspection, validate the complete stable runtime operation/interface boundary, and fail closed on missing or contradictory retry, fallback, reconciliation, finality, transport, or product-semantics governance
 - transport: classify built-in `browser-owned` as `PRODUCTION` while unknown/future transports default to `EXPERIMENTAL`; keep transport support tier independent from capability state and derive support/schema metadata rather than accepting caller self-promotion
-- compatibility: preserve the released `ChatGPTProductRuntime` method surface and the minimal `ProductWriteTransport` protocol while exposing new contract/support metadata through the primary Python SDK and capability/health serialization
+- compatibility: preserve the released `ChatGPTProductRuntime`, `ProductRuntimeHealth`, and minimal `ProductWriteTransport` surfaces while exposing new contract/support authority through the primary Python SDK and capability/contract serialization
 
 ## 0.2.0 - 2026-08-22
 

--- a/docs/browser_owned_v1_contract.md
+++ b/docs/browser_owned_v1_contract.md
@@ -45,6 +45,8 @@ governance
 
 The separate `product_runtime_contract(runtime)` inspector is intentionally additive. PR9.0 does not require adding another method to the already-released `ChatGPTProductRuntime` class.
 
+The inspector verifies that every schema-1 operation is actually callable before returning a conforming contract. It does not manufacture an operation list for a partial runtime-like object.
+
 ## Stable interface split
 
 ```text
@@ -62,9 +64,9 @@ ChatGPTProductRuntime
 
 Application callers depend on these product-level interfaces. They do not depend on Chrome tab ids, extension workers, Native Messaging implementation details, debugger target ids, Sentinel internals or concrete writer classes.
 
-`ProductWriteTransport` now explicitly permits runtime-mediated keyword extensions on its write methods. This reflects the existing model/Temporary/browser-authority dispatch behavior and gives future transports a clean implementation seam without changing the application-facing runtime API.
+`ProductWriteTransport` remains deliberately minimal so existing transport implementations do not need to accept arbitrary future keyword arguments merely to satisfy the base protocol. Concrete transports may expose additional capability-gated keyword options consumed by `ChatGPTProductRuntime`; those concrete signatures remain implementation details.
 
-Concrete transport keyword arguments remain implementation details; applications should request product intent through `ChatGPTProductRuntime`.
+Applications should request product intent through `ChatGPTProductRuntime`, not by depending on concrete transport keyword names. New product-level intents may extend the runtime and transport implementation together without exposing browser mechanics above this boundary.
 
 ## Capability state and transport support tier are independent
 
@@ -106,7 +108,7 @@ future browserless transport:
 
 `AVAILABLE` answers whether a capability is implemented and evidence-backed on that transport. `EXPERIMENTAL` answers what stability/support promise applies to the transport itself.
 
-Unknown future transport identities default conservatively to `EXPERIMENTAL` until explicitly graduated.
+Transport support tier and runtime-contract schema are derived CWA metadata. Callers and transport implementations cannot self-promote a transport by supplying constructor metadata. Unknown future transport identities default conservatively to `EXPERIMENTAL` until explicitly graduated.
 
 ## Browser-owned v1 production baseline
 
@@ -133,15 +135,21 @@ Images, general files, multimodal continuation, web search, tools/connectors and
 Schema 1 requires the runtime contract to preserve:
 
 ```text
+transport identity agrees across runtime, governance and capabilities
+product semantics = ordinary-chatgpt
+canonical interface = CanonicalConversationClient
+write interface = ProductWriteTransport
 automatic_write_retry = false
-fallback_transport = none
+fallback_transport = explicitly none
 legacy_direct_write_fallback = false
 ambiguous_write_requires_reconciliation = true
-incremental observation != canonical finality
+incremental_observation_is_canonical_finality = false
 runtime caller does not depend on concrete browser implementation
 ```
 
-The contract inspector fails closed when these invariants are violated instead of describing an unsafe runtime as conforming.
+The browser-owned production transport now declares `incremental_observation_is_canonical_finality=False` explicitly. The contract inspector requires that exact evidence; missing or contradictory finality governance fails closed.
+
+The inspector also rejects a missing fallback declaration, interface drift, transport-identity disagreement, support-tier disagreement, and an incomplete stable operation surface instead of filling those gaps with expected values.
 
 Ordinary ChatGPT product semantics remain first-class. A transport must not silently substitute a different API/product surface while claiming equivalence.
 
@@ -171,6 +179,8 @@ Browserless work must not require CMA, HDE or ordinary SDK callers to redesign t
 
 A browserless capability may become `AVAILABLE` while the transport remains `EXPERIMENTAL`. Site-protocol drift is therefore represented honestly rather than hidden inside capability state.
 
+A PR9.1 transport must satisfy the same schema-1 fail-closed invariants rather than inheriting browser-owned production status or browser implementation assumptions.
+
 ## Acceptance gate
 
 PR9.0 is complete when:
@@ -178,8 +188,9 @@ PR9.0 is complete when:
 - schema-1 runtime contract metadata is public and deterministic;
 - browser-owned is explicitly machine-readable as `PRODUCTION`;
 - capability state and transport support tier are orthogonal;
-- the transport protocol is formally suitable for future runtime-mediated implementation extensions;
+- the transport/canonical boundary remains minimal and suitable for alternative implementations;
+- stable operations and interface identities are validated rather than merely reported;
 - existing CWA 0.2 runtime behavior remains compatible;
-- contract violations fail closed;
+- contract violations and missing evidence fail closed;
 - the full regression/release CI remains green;
 - no downstream-specific CMA/HDE orchestration enters the CWA SDK boundary.

--- a/docs/browser_owned_v1_contract.md
+++ b/docs/browser_owned_v1_contract.md
@@ -110,6 +110,8 @@ future browserless transport:
 
 Transport support tier and runtime-contract schema are derived CWA metadata. Callers and transport implementations cannot self-promote a transport by supplying constructor metadata. Unknown future transport identities default conservatively to `EXPERIMENTAL` until explicitly graduated.
 
+The authority-bearing schema/tier metadata is exposed through `ProductCapabilities` and `ProductRuntimeContract`, where transport identity is cross-validated. `ProductRuntimeHealth` remains the released 0.2 observational readiness payload and is intentionally not extended with support-tier or contract-schema authority. This avoids turning a transport-supplied health observation into a second, potentially contradictory support classification.
+
 ## Browser-owned v1 production baseline
 
 The built-in `browser-owned` transport is the PR9.0 production baseline.
@@ -190,7 +192,7 @@ PR9.0 is complete when:
 - capability state and transport support tier are orthogonal;
 - the transport/canonical boundary remains minimal and suitable for alternative implementations;
 - stable operations and interface identities are validated rather than merely reported;
-- existing CWA 0.2 runtime behavior remains compatible;
+- existing CWA 0.2 runtime and health serialization remain compatible;
 - contract violations and missing evidence fail closed;
 - the full regression/release CI remains green;
 - no downstream-specific CMA/HDE orchestration enters the CWA SDK boundary.

--- a/docs/browser_owned_v1_contract.md
+++ b/docs/browser_owned_v1_contract.md
@@ -1,0 +1,185 @@
+# Browser-Owned v1 and Standalone SDK Contract
+
+_Status: PR9.0 architecture freeze_
+
+_Date: 2026-08-22_
+
+## Purpose
+
+PR9.0 closes the browser-owned text generation as the mature production baseline of `chatgpt-web-adapter` (CWA) and freezes the application-facing contract that later transports must preserve.
+
+CWA remains a standalone SDK / CLI / local ChatGPT product bridge. CMA, HDE, terminal users and other applications are consumers of this contract; no downstream project owns it.
+
+This freeze is additive. It does not rewrite the released CWA 0.2 `ChatGPTProductRuntime` method surface and it does not begin the experimental browserless write work planned for PR9.1.
+
+## Contract schema
+
+The standalone runtime contract is machine-readable and versioned:
+
+```python
+from chatgpt_web_adapter import (
+    PRODUCT_RUNTIME_CONTRACT_SCHEMA,
+    assemble_product_runtime,
+    product_runtime_contract,
+)
+
+runtime = assemble_product_runtime()
+contract = product_runtime_contract(runtime)
+
+assert PRODUCT_RUNTIME_CONTRACT_SCHEMA == 1
+print(contract.to_dict())
+```
+
+Schema `1` freezes the upper product-runtime boundary rather than the internal browser implementation.
+
+The stable runtime operations are:
+
+```text
+health / readiness
+capabilities
+send / send_text / send_text_observed
+get_status / get_messages / attach_conversation
+end_temporary_chat / temporary_lifecycle_snapshot
+governance
+```
+
+The separate `product_runtime_contract(runtime)` inspector is intentionally additive. PR9.0 does not require adding another method to the already-released `ChatGPTProductRuntime` class.
+
+## Stable interface split
+
+```text
+application
+    |
+    v
+ChatGPTProductRuntime
+    |
+    +-- CanonicalConversationClient
+    |      attach / messages / status / readback
+    |
+    `-- ProductWriteTransport
+           explicit product mutation transport
+```
+
+Application callers depend on these product-level interfaces. They do not depend on Chrome tab ids, extension workers, Native Messaging implementation details, debugger target ids, Sentinel internals or concrete writer classes.
+
+`ProductWriteTransport` now explicitly permits runtime-mediated keyword extensions on its write methods. This reflects the existing model/Temporary/browser-authority dispatch behavior and gives future transports a clean implementation seam without changing the application-facing runtime API.
+
+Concrete transport keyword arguments remain implementation details; applications should request product intent through `ChatGPTProductRuntime`.
+
+## Capability state and transport support tier are independent
+
+PR9.0 freezes two separate axes.
+
+### Capability state
+
+One feature on one transport is declared as exactly one of:
+
+```text
+AVAILABLE
+UNSUPPORTED
+UNKNOWN
+UNIMPLEMENTED
+```
+
+### Transport support tier
+
+One concrete transport is declared as:
+
+```text
+PRODUCTION
+EXPERIMENTAL
+```
+
+These values must never be combined into synthetic states such as `AVAILABLE-experimental`.
+
+Example:
+
+```text
+browser-owned:
+    transport support tier = PRODUCTION
+    text_turns state        = AVAILABLE
+
+future browserless transport:
+    transport support tier = EXPERIMENTAL
+    text_turns state        = AVAILABLE   # possible after evidence exists
+```
+
+`AVAILABLE` answers whether a capability is implemented and evidence-backed on that transport. `EXPERIMENTAL` answers what stability/support promise applies to the transport itself.
+
+Unknown future transport identities default conservatively to `EXPERIMENTAL` until explicitly graduated.
+
+## Browser-owned v1 production baseline
+
+The built-in `browser-owned` transport is the PR9.0 production baseline.
+
+Its proven text-era product surface includes:
+
+- ordinary text turns;
+- new chat;
+- continuation;
+- canonical durable read/status/attach/readback where applicable;
+- revision-safe streaming and final-only observation;
+- Temporary Chat text turns with session-local lifecycle authority;
+- product model/reasoning profile selection for the proven profile set;
+- Browser Authority lifecycle policy;
+- explicit finality/reconciliation governance;
+- no automatic retry after an ambiguous write;
+- no hidden direct-write fallback.
+
+Images, general files, multimodal continuation, web search, tools/connectors and other rich product surfaces are not promoted by PR9.0. They remain capability work for later PR9 milestones.
+
+## Frozen safety and correctness invariants
+
+Schema 1 requires the runtime contract to preserve:
+
+```text
+automatic_write_retry = false
+fallback_transport = none
+legacy_direct_write_fallback = false
+ambiguous_write_requires_reconciliation = true
+incremental observation != canonical finality
+runtime caller does not depend on concrete browser implementation
+```
+
+The contract inspector fails closed when these invariants are violated instead of describing an unsafe runtime as conforming.
+
+Ordinary ChatGPT product semantics remain first-class. A transport must not silently substitute a different API/product surface while claiming equivalence.
+
+## Browser-owned internals are not the SDK contract
+
+Historical module names such as `*_pr8_*` may remain internally while they still contain tested production implementation. PR9.0 does not mass-rename or rewrite those modules merely to remove historical names.
+
+The architecture freeze is defined by the public contract, support-tier/capability metadata, conformance tests and observable behavior—not by internal filenames.
+
+Internal cleanup is justified when it materially improves correctness, maintainability or performance without widening risk.
+
+## PR9.1 boundary
+
+PR9.1 may add an experimental direct-request browserless transport behind the same upper contract:
+
+```text
+                 ChatGPTProductRuntime
+                         |
+          +--------------+--------------+
+          |                             |
+          v                             v
+BrowserOwnedProductTransport   BrowserlessRequestTransport
+PRODUCTION                     EXPERIMENTAL
+```
+
+Browserless work must not require CMA, HDE or ordinary SDK callers to redesign their orchestration around private web protocol details.
+
+A browserless capability may become `AVAILABLE` while the transport remains `EXPERIMENTAL`. Site-protocol drift is therefore represented honestly rather than hidden inside capability state.
+
+## Acceptance gate
+
+PR9.0 is complete when:
+
+- schema-1 runtime contract metadata is public and deterministic;
+- browser-owned is explicitly machine-readable as `PRODUCTION`;
+- capability state and transport support tier are orthogonal;
+- the transport protocol is formally suitable for future runtime-mediated implementation extensions;
+- existing CWA 0.2 runtime behavior remains compatible;
+- contract violations fail closed;
+- the full regression/release CI remains green;
+- no downstream-specific CMA/HDE orchestration enters the CWA SDK boundary.

--- a/src/chatgpt_web_adapter/__init__.py
+++ b/src/chatgpt_web_adapter/__init__.py
@@ -40,6 +40,7 @@ from .product_capabilities import (
     ProductCapabilities,
     ProductCapability,
 )
+from .product_contract import ProductRuntimeContract, product_runtime_contract
 from .product_provenance import (
     CompletionSource,
     ProductCompletionProvenance,
@@ -54,6 +55,11 @@ from .product_runtime import (
     ProductRuntimeExecution,
     ProductRuntimeHealth,
     assemble_product_runtime,
+)
+from .product_support import (
+    PRODUCT_RUNTIME_CONTRACT_SCHEMA,
+    ProductTransportSupportTier,
+    product_transport_support_tier,
 )
 from .product_transport import CanonicalConversationClient, ProductWriteTransport
 from .public_surface import (
@@ -197,8 +203,7 @@ ChatGPTWebClient.wait_and_approve_pending_actions = _policy_wait_and_approve_pen
 ChatGPTWebClient.wait_until_completed = _wait_until_completed
 WebChatClient = ChatGPTWebClient
 
-# PR8.6 keeps the historical core prefix for import-order compatibility while
-# reclassifying it as shared/compatibility surface. The forward-looking primary
+# The historical core prefix remains import-compatible. The forward-looking
 # production API is PRODUCT_RUNTIME_EXPORTS below.
 CORE_PUBLIC_API = [
     "ChatGPTWebClient",
@@ -279,7 +284,7 @@ EXPERIMENTAL_PREPARE_EXPORTS = [
     "prepare_text_turn",
 ]
 
-# Kept import-compatible, but PR8.6 classifies these as research/diagnostic.
+# Kept import-compatible, but classified as research/diagnostic.
 EXPERIMENTAL_SENTINEL_EXPORTS = [
     "FinalizedSentinelBundle",
     "OBSERVED_FINALIZE_REQUEST_KEYS",

--- a/src/chatgpt_web_adapter/browser_owned_product_transport.py
+++ b/src/chatgpt_web_adapter/browser_owned_product_transport.py
@@ -475,6 +475,7 @@ class BrowserOwnedProductTransport:
                 "streaming_delivery": "REVISION_SAFE_EVENT_STREAM",
                 "streaming_canonical_finality": "BROWSERLESS_CANONICAL_HTTP",
                 "streaming_canonical_finality_authoritative": True,
+                "incremental_observation_is_canonical_finality": False,
                 "streaming_reconciliation_states": [
                     "EXACT_MATCH",
                     "CANONICAL_EXTENDS_STREAM",

--- a/src/chatgpt_web_adapter/browser_owned_product_transport.py
+++ b/src/chatgpt_web_adapter/browser_owned_product_transport.py
@@ -431,6 +431,8 @@ class BrowserOwnedProductTransport:
         governance.update(
             {
                 "product_semantics": ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
+                "fallback_transport": None,
+                "legacy_direct_write_fallback": False,
                 "browser_authority_product_runtime_policy_supported": True,
                 "browser_authority_runtime_default_configurable": True,
                 "browser_authority_per_turn_override_configurable": True,

--- a/src/chatgpt_web_adapter/product_capabilities.py
+++ b/src/chatgpt_web_adapter/product_capabilities.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Iterable
 
 from .product_support import (
     PRODUCT_RUNTIME_CONTRACT_SCHEMA,
     ProductTransportSupportTier,
-    normalize_product_transport_support_tier,
     product_transport_support_tier,
 )
 
@@ -125,8 +124,14 @@ class ProductCapabilities:
     transport: str
     product_semantics: str
     entries: tuple[ProductCapability, ...]
-    runtime_contract_schema: int = PRODUCT_RUNTIME_CONTRACT_SCHEMA
-    transport_support_tier: ProductTransportSupportTier | str | None = None
+    runtime_contract_schema: int = field(
+        init=False,
+        default=PRODUCT_RUNTIME_CONTRACT_SCHEMA,
+    )
+    transport_support_tier: ProductTransportSupportTier = field(
+        init=False,
+        default=ProductTransportSupportTier.EXPERIMENTAL,
+    )
 
     def __post_init__(self) -> None:
         transport = _required_name(self.transport).lower()
@@ -140,23 +145,14 @@ class ProductCapabilities:
                 raise ValueError(f"duplicate capability declaration: {entry.name}")
             seen.add(entry.name)
 
-        schema = int(self.runtime_contract_schema)
-        if schema != PRODUCT_RUNTIME_CONTRACT_SCHEMA:
-            raise ValueError(
-                "unsupported product runtime contract schema "
-                f"{schema}; expected {PRODUCT_RUNTIME_CONTRACT_SCHEMA}"
-            )
-        support_tier = (
-            product_transport_support_tier(transport)
-            if self.transport_support_tier is None
-            else normalize_product_transport_support_tier(self.transport_support_tier)
-        )
-
         object.__setattr__(self, "transport", transport)
         object.__setattr__(self, "product_semantics", semantics)
         object.__setattr__(self, "entries", entries)
-        object.__setattr__(self, "runtime_contract_schema", schema)
-        object.__setattr__(self, "transport_support_tier", support_tier)
+        object.__setattr__(
+            self,
+            "transport_support_tier",
+            product_transport_support_tier(transport),
+        )
 
     @classmethod
     def from_entries(
@@ -165,13 +161,11 @@ class ProductCapabilities:
         transport: str,
         entries: Iterable[ProductCapability],
         product_semantics: str = ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
-        transport_support_tier: ProductTransportSupportTier | str | None = None,
     ) -> "ProductCapabilities":
         return cls(
             transport=transport,
             product_semantics=product_semantics,
             entries=tuple(entries),
-            transport_support_tier=transport_support_tier,
         )
 
     def get(self, name: str) -> ProductCapability | None:
@@ -188,12 +182,10 @@ class ProductCapabilities:
         return entry.state
 
     def to_dict(self) -> dict[str, Any]:
-        support_tier = self.transport_support_tier
-        assert isinstance(support_tier, ProductTransportSupportTier)
         return {
             "runtime_contract_schema": self.runtime_contract_schema,
             "transport": self.transport,
-            "transport_support_tier": support_tier.value,
+            "transport_support_tier": self.transport_support_tier.value,
             "product_semantics": self.product_semantics,
             "capabilities": {
                 entry.name: entry.to_dict()

--- a/src/chatgpt_web_adapter/product_capabilities.py
+++ b/src/chatgpt_web_adapter/product_capabilities.py
@@ -4,6 +4,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Iterable
 
+from .product_support import (
+    PRODUCT_RUNTIME_CONTRACT_SCHEMA,
+    ProductTransportSupportTier,
+    normalize_product_transport_support_tier,
+    product_transport_support_tier,
+)
+
 ORDINARY_CHATGPT_PRODUCT_SEMANTICS = "ordinary-chatgpt"
 
 TEXT_TURNS = "text_turns"
@@ -118,6 +125,8 @@ class ProductCapabilities:
     transport: str
     product_semantics: str
     entries: tuple[ProductCapability, ...]
+    runtime_contract_schema: int = PRODUCT_RUNTIME_CONTRACT_SCHEMA
+    transport_support_tier: ProductTransportSupportTier | str | None = None
 
     def __post_init__(self) -> None:
         transport = _required_name(self.transport).lower()
@@ -130,9 +139,24 @@ class ProductCapabilities:
             if entry.name in seen:
                 raise ValueError(f"duplicate capability declaration: {entry.name}")
             seen.add(entry.name)
+
+        schema = int(self.runtime_contract_schema)
+        if schema != PRODUCT_RUNTIME_CONTRACT_SCHEMA:
+            raise ValueError(
+                "unsupported product runtime contract schema "
+                f"{schema}; expected {PRODUCT_RUNTIME_CONTRACT_SCHEMA}"
+            )
+        support_tier = (
+            product_transport_support_tier(transport)
+            if self.transport_support_tier is None
+            else normalize_product_transport_support_tier(self.transport_support_tier)
+        )
+
         object.__setattr__(self, "transport", transport)
         object.__setattr__(self, "product_semantics", semantics)
         object.__setattr__(self, "entries", entries)
+        object.__setattr__(self, "runtime_contract_schema", schema)
+        object.__setattr__(self, "transport_support_tier", support_tier)
 
     @classmethod
     def from_entries(
@@ -141,11 +165,13 @@ class ProductCapabilities:
         transport: str,
         entries: Iterable[ProductCapability],
         product_semantics: str = ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
+        transport_support_tier: ProductTransportSupportTier | str | None = None,
     ) -> "ProductCapabilities":
         return cls(
             transport=transport,
             product_semantics=product_semantics,
             entries=tuple(entries),
+            transport_support_tier=transport_support_tier,
         )
 
     def get(self, name: str) -> ProductCapability | None:
@@ -162,8 +188,12 @@ class ProductCapabilities:
         return entry.state
 
     def to_dict(self) -> dict[str, Any]:
+        support_tier = self.transport_support_tier
+        assert isinstance(support_tier, ProductTransportSupportTier)
         return {
+            "runtime_contract_schema": self.runtime_contract_schema,
             "transport": self.transport,
+            "transport_support_tier": support_tier.value,
             "product_semantics": self.product_semantics,
             "capabilities": {
                 entry.name: entry.to_dict()

--- a/src/chatgpt_web_adapter/product_contract.py
+++ b/src/chatgpt_web_adapter/product_contract.py
@@ -53,6 +53,7 @@ class ProductRuntimeContract:
     capability_states: tuple[str, ...]
     automatic_write_retry: bool
     fallback_transport: str | None
+    legacy_direct_write_fallback: bool
     ambiguous_write_requires_reconciliation: bool
     incremental_observation_is_canonical_finality: bool
     browser_implementation_required_by_caller: bool
@@ -105,6 +106,10 @@ class ProductRuntimeContract:
             )
         if self.fallback_transport is not None:
             raise RuntimeError("ProductRuntimeContract requires fallback_transport=None")
+        if self.legacy_direct_write_fallback is not False:
+            raise RuntimeError(
+                "ProductRuntimeContract requires legacy_direct_write_fallback=False"
+            )
         if self.ambiguous_write_requires_reconciliation is not True:
             raise RuntimeError(
                 "ProductRuntimeContract requires ambiguous_write_requires_reconciliation=True"
@@ -136,6 +141,7 @@ class ProductRuntimeContract:
             "invariants": {
                 "automatic_write_retry": self.automatic_write_retry,
                 "fallback_transport": self.fallback_transport,
+                "legacy_direct_write_fallback": self.legacy_direct_write_fallback,
                 "ambiguous_write_requires_reconciliation": (
                     self.ambiguous_write_requires_reconciliation
                 ),
@@ -289,7 +295,10 @@ def build_product_runtime_contract(
 
     automatic_write_retry = _require_false(governance, "automatic_write_retry")
     fallback_transport = _require_none(governance, "fallback_transport")
-    _require_false(governance, "legacy_direct_write_fallback")
+    legacy_direct_write_fallback = _require_false(
+        governance,
+        "legacy_direct_write_fallback",
+    )
     ambiguous_write_requires_reconciliation = _require_true(
         governance,
         "ambiguous_write_requires_reconciliation",
@@ -312,6 +321,7 @@ def build_product_runtime_contract(
         capability_states=tuple(state.value for state in CapabilityState),
         automatic_write_retry=automatic_write_retry,
         fallback_transport=fallback_transport,
+        legacy_direct_write_fallback=legacy_direct_write_fallback,
         ambiguous_write_requires_reconciliation=(
             ambiguous_write_requires_reconciliation
         ),

--- a/src/chatgpt_web_adapter/product_contract.py
+++ b/src/chatgpt_web_adapter/product_contract.py
@@ -18,7 +18,6 @@ STABLE_PRODUCT_RUNTIME_OPERATIONS: tuple[str, ...] = (
     "health",
     "readiness",
     "capabilities",
-    "contract",
     "send",
     "send_text",
     "send_text_observed",
@@ -106,6 +105,8 @@ def build_product_runtime_contract(
 
     if not isinstance(capabilities, ProductCapabilities):
         raise TypeError("capabilities must be ProductCapabilities")
+    if not isinstance(transport, str) or not transport.strip():
+        raise ValueError("runtime transport identity is required")
     normalized_transport = transport.strip().lower()
     if capabilities.transport != normalized_transport:
         raise RuntimeError(
@@ -155,4 +156,26 @@ def build_product_runtime_contract(
         browser_implementation_required_by_caller=(
             browser_implementation_required_by_caller
         ),
+    )
+
+
+def product_runtime_contract(runtime: Any) -> ProductRuntimeContract:
+    """Inspect the frozen public contract of a ChatGPTProductRuntime-like object.
+
+    The inspector intentionally lives outside the runtime class so PR9.0 can add
+    a versioned contract without changing the already-released 0.2 runtime method
+    surface. Future transports are validated against the same upper contract.
+    """
+
+    transport = getattr(runtime, "transport", None)
+    capabilities = getattr(runtime, "capabilities", None)
+    governance = getattr(runtime, "governance", None)
+    if not isinstance(transport, str) or not transport.strip():
+        raise TypeError("runtime must expose a non-empty transport identity")
+    if not callable(capabilities) or not callable(governance):
+        raise TypeError("runtime must expose callable capabilities() and governance()")
+    return build_product_runtime_contract(
+        transport=transport,
+        capabilities=capabilities(),
+        governance=dict(governance()),
     )

--- a/src/chatgpt_web_adapter/product_contract.py
+++ b/src/chatgpt_web_adapter/product_contract.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 from .product_capabilities import (
     ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
@@ -28,6 +29,11 @@ STABLE_PRODUCT_RUNTIME_OPERATIONS: tuple[str, ...] = (
     "temporary_lifecycle_snapshot",
     "governance",
 )
+
+_CANONICAL_INTERFACE = "CanonicalConversationClient"
+_WRITE_TRANSPORT_INTERFACE = "ProductWriteTransport"
+_INCREMENTAL_FINALITY_KEY = "incremental_observation_is_canonical_finality"
+_LEGACY_CANONICAL_FINALITY_KEY = "streaming_canonical_finality_authoritative"
 
 
 @dataclass(frozen=True)
@@ -95,6 +101,54 @@ def _require_true(governance: Mapping[str, Any], name: str) -> bool:
     return True
 
 
+def _require_none(governance: Mapping[str, Any], name: str) -> None:
+    if name not in governance:
+        raise RuntimeError(
+            f"product runtime contract requires explicit {name}=None; observed missing"
+        )
+    value = governance[name]
+    if value is not None:
+        raise RuntimeError(
+            f"product runtime contract requires {name}=None; observed {value!r}"
+        )
+    return None
+
+
+def _require_value(
+    governance: Mapping[str, Any],
+    name: str,
+    expected: Any,
+) -> Any:
+    value = governance.get(name)
+    if value != expected:
+        raise RuntimeError(
+            f"product runtime contract requires {name}={expected!r}; observed {value!r}"
+        )
+    return value
+
+
+def _require_incremental_observation_not_final(
+    governance: Mapping[str, Any],
+) -> bool:
+    """Require explicit evidence that incremental observation is not finality.
+
+    Schema 1 accepts the direct PR9 governance key. For the already-released 0.2
+    browser-owned implementation, the older explicit statement that canonical
+    finality is authoritative is accepted as equivalent evidence. Missing evidence
+    and contradictory direct declarations both fail closed.
+    """
+
+    if _INCREMENTAL_FINALITY_KEY in governance:
+        return _require_false(governance, _INCREMENTAL_FINALITY_KEY)
+    if governance.get(_LEGACY_CANONICAL_FINALITY_KEY) is True:
+        return False
+    raise RuntimeError(
+        "product runtime contract requires explicit non-incremental finality evidence; "
+        f"expected {_INCREMENTAL_FINALITY_KEY}=False or "
+        f"{_LEGACY_CANONICAL_FINALITY_KEY}=True"
+    )
+
+
 def build_product_runtime_contract(
     *,
     transport: str,
@@ -105,29 +159,61 @@ def build_product_runtime_contract(
 
     if not isinstance(capabilities, ProductCapabilities):
         raise TypeError("capabilities must be ProductCapabilities")
+    if not isinstance(governance, Mapping):
+        raise TypeError("governance must be a mapping")
     if not isinstance(transport, str) or not transport.strip():
         raise ValueError("runtime transport identity is required")
+
     normalized_transport = transport.strip().lower()
+    expected_support_tier = product_transport_support_tier(normalized_transport)
+
     if capabilities.transport != normalized_transport:
         raise RuntimeError(
             "runtime contract capability transport mismatch: "
             f"{capabilities.transport!r} != {normalized_transport!r}"
+        )
+    if capabilities.runtime_contract_schema != PRODUCT_RUNTIME_CONTRACT_SCHEMA:
+        raise RuntimeError(
+            "runtime contract capability schema mismatch: "
+            f"{capabilities.runtime_contract_schema!r} != "
+            f"{PRODUCT_RUNTIME_CONTRACT_SCHEMA!r}"
+        )
+    if capabilities.transport_support_tier != expected_support_tier:
+        raise RuntimeError(
+            "runtime contract capability support-tier mismatch: "
+            f"{capabilities.transport_support_tier!r} != {expected_support_tier!r}"
         )
     if capabilities.product_semantics != ORDINARY_CHATGPT_PRODUCT_SEMANTICS:
         raise RuntimeError(
             "ChatGPTProductRuntime contract requires ordinary ChatGPT product semantics"
         )
 
+    _require_value(governance, "transport", normalized_transport)
+    _require_value(
+        governance,
+        "product_semantics",
+        ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
+    )
+    canonical_interface = _require_value(
+        governance,
+        "canonical_interface",
+        _CANONICAL_INTERFACE,
+    )
+    write_transport_interface = _require_value(
+        governance,
+        "write_transport_interface",
+        _WRITE_TRANSPORT_INTERFACE,
+    )
+
     automatic_write_retry = _require_false(governance, "automatic_write_retry")
-    if governance.get("fallback_transport") is not None:
-        raise RuntimeError(
-            "product runtime contract requires fallback_transport=None; observed "
-            f"{governance.get('fallback_transport')!r}"
-        )
+    fallback_transport = _require_none(governance, "fallback_transport")
     _require_false(governance, "legacy_direct_write_fallback")
     ambiguous_write_requires_reconciliation = _require_true(
         governance,
         "ambiguous_write_requires_reconciliation",
+    )
+    incremental_observation_is_canonical_finality = (
+        _require_incremental_observation_not_final(governance)
     )
     browser_implementation_required_by_caller = _require_false(
         governance,
@@ -138,21 +224,19 @@ def build_product_runtime_contract(
         schema=PRODUCT_RUNTIME_CONTRACT_SCHEMA,
         product_semantics=capabilities.product_semantics,
         transport=normalized_transport,
-        transport_support_tier=product_transport_support_tier(normalized_transport),
-        canonical_interface=str(
-            governance.get("canonical_interface") or "CanonicalConversationClient"
-        ),
-        write_transport_interface=str(
-            governance.get("write_transport_interface") or "ProductWriteTransport"
-        ),
+        transport_support_tier=expected_support_tier,
+        canonical_interface=canonical_interface,
+        write_transport_interface=write_transport_interface,
         operations=STABLE_PRODUCT_RUNTIME_OPERATIONS,
         capability_states=tuple(state.value for state in CapabilityState),
         automatic_write_retry=automatic_write_retry,
-        fallback_transport=None,
+        fallback_transport=fallback_transport,
         ambiguous_write_requires_reconciliation=(
             ambiguous_write_requires_reconciliation
         ),
-        incremental_observation_is_canonical_finality=False,
+        incremental_observation_is_canonical_finality=(
+            incremental_observation_is_canonical_finality
+        ),
         browser_implementation_required_by_caller=(
             browser_implementation_required_by_caller
         ),
@@ -174,8 +258,25 @@ def product_runtime_contract(runtime: Any) -> ProductRuntimeContract:
         raise TypeError("runtime must expose a non-empty transport identity")
     if not callable(capabilities) or not callable(governance):
         raise TypeError("runtime must expose callable capabilities() and governance()")
+
+    missing_operations = tuple(
+        name
+        for name in STABLE_PRODUCT_RUNTIME_OPERATIONS
+        if not callable(getattr(runtime, name, None))
+    )
+    if missing_operations:
+        missing = ", ".join(missing_operations)
+        raise TypeError(
+            "runtime does not implement the frozen schema-1 operation surface: "
+            f"{missing}"
+        )
+
+    governance_payload = governance()
+    if not isinstance(governance_payload, Mapping):
+        raise TypeError("runtime governance() must return a mapping")
+
     return build_product_runtime_contract(
         transport=transport,
         capabilities=capabilities(),
-        governance=dict(governance()),
+        governance=governance_payload,
     )

--- a/src/chatgpt_web_adapter/product_contract.py
+++ b/src/chatgpt_web_adapter/product_contract.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from .product_capabilities import (
@@ -37,12 +37,16 @@ _INCREMENTAL_FINALITY_KEY = "incremental_observation_is_canonical_finality"
 
 @dataclass(frozen=True)
 class ProductRuntimeContract:
-    """Versioned standalone SDK contract above concrete product transports."""
+    """Versioned standalone SDK contract above concrete product transports.
 
-    schema: int
+    Schema and transport support tier are authority metadata owned by CWA. They
+    are derived from the frozen schema registry and transport identity rather
+    than accepted from callers. Direct construction therefore cannot self-promote
+    an unknown transport or publish an arbitrary schema value.
+    """
+
     product_semantics: str
     transport: str
-    transport_support_tier: ProductTransportSupportTier
     canonical_interface: str
     write_transport_interface: str
     operations: tuple[str, ...]
@@ -52,6 +56,69 @@ class ProductRuntimeContract:
     ambiguous_write_requires_reconciliation: bool
     incremental_observation_is_canonical_finality: bool
     browser_implementation_required_by_caller: bool
+    schema: int = field(
+        init=False,
+        default=PRODUCT_RUNTIME_CONTRACT_SCHEMA,
+    )
+    transport_support_tier: ProductTransportSupportTier = field(
+        init=False,
+        default=ProductTransportSupportTier.EXPERIMENTAL,
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.transport, str) or not self.transport.strip():
+            raise ValueError("runtime contract transport identity is required")
+        normalized_transport = self.transport.strip().lower()
+        object.__setattr__(self, "transport", normalized_transport)
+        object.__setattr__(
+            self,
+            "transport_support_tier",
+            product_transport_support_tier(normalized_transport),
+        )
+
+        if self.product_semantics != ORDINARY_CHATGPT_PRODUCT_SEMANTICS:
+            raise RuntimeError(
+                "ProductRuntimeContract requires ordinary ChatGPT product semantics"
+            )
+        if self.canonical_interface != _CANONICAL_INTERFACE:
+            raise RuntimeError(
+                "ProductRuntimeContract requires canonical_interface="
+                f"{_CANONICAL_INTERFACE!r}; observed {self.canonical_interface!r}"
+            )
+        if self.write_transport_interface != _WRITE_TRANSPORT_INTERFACE:
+            raise RuntimeError(
+                "ProductRuntimeContract requires write_transport_interface="
+                f"{_WRITE_TRANSPORT_INTERFACE!r}; observed {self.write_transport_interface!r}"
+            )
+        if self.operations != STABLE_PRODUCT_RUNTIME_OPERATIONS:
+            raise RuntimeError(
+                "ProductRuntimeContract requires the complete frozen schema-1 operation surface"
+            )
+        expected_states = tuple(state.value for state in CapabilityState)
+        if self.capability_states != expected_states:
+            raise RuntimeError(
+                "ProductRuntimeContract requires the frozen capability-state set"
+            )
+        if self.automatic_write_retry is not False:
+            raise RuntimeError(
+                "ProductRuntimeContract requires automatic_write_retry=False"
+            )
+        if self.fallback_transport is not None:
+            raise RuntimeError("ProductRuntimeContract requires fallback_transport=None")
+        if self.ambiguous_write_requires_reconciliation is not True:
+            raise RuntimeError(
+                "ProductRuntimeContract requires ambiguous_write_requires_reconciliation=True"
+            )
+        if self.incremental_observation_is_canonical_finality is not False:
+            raise RuntimeError(
+                "ProductRuntimeContract requires "
+                "incremental_observation_is_canonical_finality=False"
+            )
+        if self.browser_implementation_required_by_caller is not False:
+            raise RuntimeError(
+                "ProductRuntimeContract requires "
+                "browser_implementation_required_by_caller=False"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -124,6 +191,55 @@ def _require_value(
             f"product runtime contract requires {name}={expected!r}; observed {value!r}"
         )
     return value
+
+
+def _validate_raw_write_transport_governance(
+    runtime: Any,
+    *,
+    normalized_transport: str,
+) -> None:
+    """Reject transport-level fallback declarations before runtime normalization.
+
+    ChatGPTProductRuntime.governance() intentionally adds high-level no-fallback
+    defaults. An injected transport can still expose its own contradictory
+    governance, so schema-1 certification must inspect that raw declaration before
+    the runtime view can mask it.
+    """
+
+    write_transport = getattr(runtime, "write_transport", None)
+    transport_id = getattr(write_transport, "transport_id", None)
+    if not isinstance(transport_id, str) or not transport_id.strip():
+        raise TypeError(
+            "runtime must expose an inspectable write_transport with transport_id"
+        )
+    if transport_id.strip().lower() != normalized_transport:
+        raise RuntimeError(
+            "runtime contract write-transport identity mismatch: "
+            f"{transport_id!r} != {normalized_transport!r}"
+        )
+
+    raw_governance = getattr(write_transport, "governance", None)
+    if not callable(raw_governance):
+        raise TypeError(
+            "runtime write_transport must expose callable governance() for schema-1 validation"
+        )
+    raw_payload = raw_governance()
+    if not isinstance(raw_payload, Mapping):
+        raise TypeError("runtime write_transport governance() must return a mapping")
+
+    if "fallback_transport" in raw_payload and raw_payload["fallback_transport"] is not None:
+        raise RuntimeError(
+            "product runtime contract rejects raw write-transport fallback_transport="
+            f"{raw_payload['fallback_transport']!r}"
+        )
+    if (
+        "legacy_direct_write_fallback" in raw_payload
+        and raw_payload["legacy_direct_write_fallback"] is not False
+    ):
+        raise RuntimeError(
+            "product runtime contract rejects raw write-transport "
+            "legacy_direct_write_fallback; expected False"
+        )
 
 
 def build_product_runtime_contract(
@@ -199,10 +315,8 @@ def build_product_runtime_contract(
     )
 
     return ProductRuntimeContract(
-        schema=PRODUCT_RUNTIME_CONTRACT_SCHEMA,
         product_semantics=capabilities.product_semantics,
         transport=normalized_transport,
-        transport_support_tier=expected_support_tier,
         canonical_interface=canonical_interface,
         write_transport_interface=write_transport_interface,
         operations=STABLE_PRODUCT_RUNTIME_OPERATIONS,
@@ -249,12 +363,18 @@ def product_runtime_contract(runtime: Any) -> ProductRuntimeContract:
             f"{missing}"
         )
 
+    normalized_transport = transport.strip().lower()
+    _validate_raw_write_transport_governance(
+        runtime,
+        normalized_transport=normalized_transport,
+    )
+
     governance_payload = governance()
     if not isinstance(governance_payload, Mapping):
         raise TypeError("runtime governance() must return a mapping")
 
     return build_product_runtime_contract(
-        transport=transport,
+        transport=normalized_transport,
         capabilities=capabilities(),
         governance=governance_payload,
     )

--- a/src/chatgpt_web_adapter/product_contract.py
+++ b/src/chatgpt_web_adapter/product_contract.py
@@ -33,7 +33,6 @@ STABLE_PRODUCT_RUNTIME_OPERATIONS: tuple[str, ...] = (
 _CANONICAL_INTERFACE = "CanonicalConversationClient"
 _WRITE_TRANSPORT_INTERFACE = "ProductWriteTransport"
 _INCREMENTAL_FINALITY_KEY = "incremental_observation_is_canonical_finality"
-_LEGACY_CANONICAL_FINALITY_KEY = "streaming_canonical_finality_authoritative"
 
 
 @dataclass(frozen=True)
@@ -127,28 +126,6 @@ def _require_value(
     return value
 
 
-def _require_incremental_observation_not_final(
-    governance: Mapping[str, Any],
-) -> bool:
-    """Require explicit evidence that incremental observation is not finality.
-
-    Schema 1 accepts the direct PR9 governance key. For the already-released 0.2
-    browser-owned implementation, the older explicit statement that canonical
-    finality is authoritative is accepted as equivalent evidence. Missing evidence
-    and contradictory direct declarations both fail closed.
-    """
-
-    if _INCREMENTAL_FINALITY_KEY in governance:
-        return _require_false(governance, _INCREMENTAL_FINALITY_KEY)
-    if governance.get(_LEGACY_CANONICAL_FINALITY_KEY) is True:
-        return False
-    raise RuntimeError(
-        "product runtime contract requires explicit non-incremental finality evidence; "
-        f"expected {_INCREMENTAL_FINALITY_KEY}=False or "
-        f"{_LEGACY_CANONICAL_FINALITY_KEY}=True"
-    )
-
-
 def build_product_runtime_contract(
     *,
     transport: str,
@@ -212,8 +189,9 @@ def build_product_runtime_contract(
         governance,
         "ambiguous_write_requires_reconciliation",
     )
-    incremental_observation_is_canonical_finality = (
-        _require_incremental_observation_not_final(governance)
+    incremental_observation_is_canonical_finality = _require_false(
+        governance,
+        _INCREMENTAL_FINALITY_KEY,
     )
     browser_implementation_required_by_caller = _require_false(
         governance,

--- a/src/chatgpt_web_adapter/product_contract.py
+++ b/src/chatgpt_web_adapter/product_contract.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .product_capabilities import (
+    ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
+    CapabilityState,
+    ProductCapabilities,
+)
+from .product_support import (
+    PRODUCT_RUNTIME_CONTRACT_SCHEMA,
+    ProductTransportSupportTier,
+    product_transport_support_tier,
+)
+
+STABLE_PRODUCT_RUNTIME_OPERATIONS: tuple[str, ...] = (
+    "health",
+    "readiness",
+    "capabilities",
+    "contract",
+    "send",
+    "send_text",
+    "send_text_observed",
+    "get_status",
+    "get_messages",
+    "attach_conversation",
+    "end_temporary_chat",
+    "temporary_lifecycle_snapshot",
+    "governance",
+)
+
+
+@dataclass(frozen=True)
+class ProductRuntimeContract:
+    """Versioned standalone SDK contract above concrete product transports."""
+
+    schema: int
+    product_semantics: str
+    transport: str
+    transport_support_tier: ProductTransportSupportTier
+    canonical_interface: str
+    write_transport_interface: str
+    operations: tuple[str, ...]
+    capability_states: tuple[str, ...]
+    automatic_write_retry: bool
+    fallback_transport: str | None
+    ambiguous_write_requires_reconciliation: bool
+    incremental_observation_is_canonical_finality: bool
+    browser_implementation_required_by_caller: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "runtime": "ChatGPTProductRuntime",
+            "product_semantics": self.product_semantics,
+            "transport": self.transport,
+            "transport_support_tier": self.transport_support_tier.value,
+            "interfaces": {
+                "canonical": self.canonical_interface,
+                "write_transport": self.write_transport_interface,
+            },
+            "operations": list(self.operations),
+            "capability_states": list(self.capability_states),
+            "invariants": {
+                "automatic_write_retry": self.automatic_write_retry,
+                "fallback_transport": self.fallback_transport,
+                "ambiguous_write_requires_reconciliation": (
+                    self.ambiguous_write_requires_reconciliation
+                ),
+                "incremental_observation_is_canonical_finality": (
+                    self.incremental_observation_is_canonical_finality
+                ),
+                "browser_implementation_required_by_caller": (
+                    self.browser_implementation_required_by_caller
+                ),
+            },
+        }
+
+
+def _require_false(governance: Mapping[str, Any], name: str) -> bool:
+    value = governance.get(name)
+    if value is not False:
+        raise RuntimeError(
+            f"product runtime contract requires {name}=False; observed {value!r}"
+        )
+    return False
+
+
+def _require_true(governance: Mapping[str, Any], name: str) -> bool:
+    value = governance.get(name)
+    if value is not True:
+        raise RuntimeError(
+            f"product runtime contract requires {name}=True; observed {value!r}"
+        )
+    return True
+
+
+def build_product_runtime_contract(
+    *,
+    transport: str,
+    capabilities: ProductCapabilities,
+    governance: Mapping[str, Any],
+) -> ProductRuntimeContract:
+    """Build and validate the schema-1 runtime contract for one runtime instance."""
+
+    if not isinstance(capabilities, ProductCapabilities):
+        raise TypeError("capabilities must be ProductCapabilities")
+    normalized_transport = transport.strip().lower()
+    if capabilities.transport != normalized_transport:
+        raise RuntimeError(
+            "runtime contract capability transport mismatch: "
+            f"{capabilities.transport!r} != {normalized_transport!r}"
+        )
+    if capabilities.product_semantics != ORDINARY_CHATGPT_PRODUCT_SEMANTICS:
+        raise RuntimeError(
+            "ChatGPTProductRuntime contract requires ordinary ChatGPT product semantics"
+        )
+
+    automatic_write_retry = _require_false(governance, "automatic_write_retry")
+    if governance.get("fallback_transport") is not None:
+        raise RuntimeError(
+            "product runtime contract requires fallback_transport=None; observed "
+            f"{governance.get('fallback_transport')!r}"
+        )
+    _require_false(governance, "legacy_direct_write_fallback")
+    ambiguous_write_requires_reconciliation = _require_true(
+        governance,
+        "ambiguous_write_requires_reconciliation",
+    )
+    browser_implementation_required_by_caller = _require_false(
+        governance,
+        "runtime_depends_on_concrete_browser_transport",
+    )
+
+    return ProductRuntimeContract(
+        schema=PRODUCT_RUNTIME_CONTRACT_SCHEMA,
+        product_semantics=capabilities.product_semantics,
+        transport=normalized_transport,
+        transport_support_tier=product_transport_support_tier(normalized_transport),
+        canonical_interface=str(
+            governance.get("canonical_interface") or "CanonicalConversationClient"
+        ),
+        write_transport_interface=str(
+            governance.get("write_transport_interface") or "ProductWriteTransport"
+        ),
+        operations=STABLE_PRODUCT_RUNTIME_OPERATIONS,
+        capability_states=tuple(state.value for state in CapabilityState),
+        automatic_write_retry=automatic_write_retry,
+        fallback_transport=None,
+        ambiguous_write_requires_reconciliation=(
+            ambiguous_write_requires_reconciliation
+        ),
+        incremental_observation_is_canonical_finality=False,
+        browser_implementation_required_by_caller=(
+            browser_implementation_required_by_caller
+        ),
+    )

--- a/src/chatgpt_web_adapter/product_contract.py
+++ b/src/chatgpt_web_adapter/product_contract.py
@@ -198,12 +198,12 @@ def _validate_raw_write_transport_governance(
     *,
     normalized_transport: str,
 ) -> None:
-    """Reject transport-level fallback declarations before runtime normalization.
+    """Require explicit transport-level no-fallback evidence before normalization.
 
     ChatGPTProductRuntime.governance() intentionally adds high-level no-fallback
-    defaults. An injected transport can still expose its own contradictory
-    governance, so schema-1 certification must inspect that raw declaration before
-    the runtime view can mask it.
+    defaults. An injected transport can still expose contradictory or incomplete
+    governance, so schema-1 certification must inspect the raw declaration before
+    the runtime view can mask it. Missing declarations fail closed as well.
     """
 
     write_transport = getattr(runtime, "write_transport", None)
@@ -227,19 +227,8 @@ def _validate_raw_write_transport_governance(
     if not isinstance(raw_payload, Mapping):
         raise TypeError("runtime write_transport governance() must return a mapping")
 
-    if "fallback_transport" in raw_payload and raw_payload["fallback_transport"] is not None:
-        raise RuntimeError(
-            "product runtime contract rejects raw write-transport fallback_transport="
-            f"{raw_payload['fallback_transport']!r}"
-        )
-    if (
-        "legacy_direct_write_fallback" in raw_payload
-        and raw_payload["legacy_direct_write_fallback"] is not False
-    ):
-        raise RuntimeError(
-            "product runtime contract rejects raw write-transport "
-            "legacy_direct_write_fallback; expected False"
-        )
+    _require_none(raw_payload, "fallback_transport")
+    _require_false(raw_payload, "legacy_direct_write_fallback")
 
 
 def build_product_runtime_contract(

--- a/src/chatgpt_web_adapter/product_support.py
+++ b/src/chatgpt_web_adapter/product_support.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+PRODUCT_RUNTIME_CONTRACT_SCHEMA = 1
+
+
+class ProductTransportSupportTier(str, Enum):
+    """Stability/support tier for one concrete ChatGPT product transport.
+
+    This is deliberately independent from capability state. A transport can be
+    EXPERIMENTAL while an individual capability is AVAILABLE on that transport.
+    """
+
+    PRODUCTION = "PRODUCTION"
+    EXPERIMENTAL = "EXPERIMENTAL"
+
+
+_BUILTIN_PRODUCT_TRANSPORT_SUPPORT_TIERS: dict[str, ProductTransportSupportTier] = {
+    "browser-owned": ProductTransportSupportTier.PRODUCTION,
+}
+
+
+def normalize_product_transport_support_tier(
+    value: ProductTransportSupportTier | str,
+) -> ProductTransportSupportTier:
+    if isinstance(value, ProductTransportSupportTier):
+        return value
+    if not isinstance(value, str):
+        raise TypeError("transport support tier must be a string or ProductTransportSupportTier")
+    normalized = value.strip().upper()
+    try:
+        return ProductTransportSupportTier(normalized)
+    except ValueError as error:
+        supported = ", ".join(tier.value for tier in ProductTransportSupportTier)
+        raise ValueError(
+            f"unsupported transport support tier {value!r}; expected one of: {supported}"
+        ) from error
+
+
+def product_transport_support_tier(transport: Any) -> ProductTransportSupportTier:
+    """Return the frozen support tier for a transport identity.
+
+    Unknown/future transport ids are conservative by default: they are
+    EXPERIMENTAL until explicitly graduated. This prevents adding a working
+    prototype from silently acquiring production support semantics.
+    """
+
+    if not isinstance(transport, str) or not transport.strip():
+        raise ValueError("transport identity is required")
+    normalized = transport.strip().lower()
+    return _BUILTIN_PRODUCT_TRANSPORT_SUPPORT_TIERS.get(
+        normalized,
+        ProductTransportSupportTier.EXPERIMENTAL,
+    )

--- a/src/chatgpt_web_adapter/product_support.py
+++ b/src/chatgpt_web_adapter/product_support.py
@@ -22,23 +22,6 @@ _BUILTIN_PRODUCT_TRANSPORT_SUPPORT_TIERS: dict[str, ProductTransportSupportTier]
 }
 
 
-def normalize_product_transport_support_tier(
-    value: ProductTransportSupportTier | str,
-) -> ProductTransportSupportTier:
-    if isinstance(value, ProductTransportSupportTier):
-        return value
-    if not isinstance(value, str):
-        raise TypeError("transport support tier must be a string or ProductTransportSupportTier")
-    normalized = value.strip().upper()
-    try:
-        return ProductTransportSupportTier(normalized)
-    except ValueError as error:
-        supported = ", ".join(tier.value for tier in ProductTransportSupportTier)
-        raise ValueError(
-            f"unsupported transport support tier {value!r}; expected one of: {supported}"
-        ) from error
-
-
 def product_transport_support_tier(transport: Any) -> ProductTransportSupportTier:
     """Return the frozen support tier for a transport identity.
 

--- a/src/chatgpt_web_adapter/product_transport.py
+++ b/src/chatgpt_web_adapter/product_transport.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from typing import Any, Callable, Protocol, runtime_checkable
 
 from .product_capabilities import ProductCapabilities
 from .product_provenance import ProductExecutionProvenance
-from .product_support import (
-    PRODUCT_RUNTIME_CONTRACT_SCHEMA,
-    ProductTransportSupportTier,
-    product_transport_support_tier,
-)
 from .types import ChatConversation, ChatMessage, ChatResponse, ConversationRef, ConversationStatus
 
 BROWSER_OWNED_PRODUCT_TRANSPORT = "browser-owned"
@@ -35,7 +30,7 @@ def normalize_product_transport(value: str) -> str:
 
 @dataclass(frozen=True)
 class ProductRuntimeHealth:
-    """Implementation-independent runtime readiness plus transport metadata."""
+    """Implementation-independent runtime readiness plus optional transport metadata."""
 
     transport: str
     ready: bool
@@ -54,30 +49,9 @@ class ProductRuntimeHealth:
     extension_connected: bool | None = None
     runtime_tab_id: int | None = None
     runtime_tab_preexisting: bool | None = None
-    runtime_contract_schema: int = field(
-        init=False,
-        default=PRODUCT_RUNTIME_CONTRACT_SCHEMA,
-    )
-    transport_support_tier: ProductTransportSupportTier = field(
-        init=False,
-        default=ProductTransportSupportTier.EXPERIMENTAL,
-    )
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.transport, str) or not self.transport.strip():
-            raise ValueError("runtime health transport identity is required")
-        transport = self.transport.strip().lower()
-        object.__setattr__(self, "transport", transport)
-        object.__setattr__(
-            self,
-            "transport_support_tier",
-            product_transport_support_tier(transport),
-        )
 
     def to_dict(self) -> dict[str, Any]:
-        payload = asdict(self)
-        payload["transport_support_tier"] = self.transport_support_tier.value
-        return payload
+        return asdict(self)
 
 
 @dataclass(frozen=True)

--- a/src/chatgpt_web_adapter/product_transport.py
+++ b/src/chatgpt_web_adapter/product_transport.py
@@ -5,6 +5,12 @@ from typing import Any, Callable, Protocol, runtime_checkable
 
 from .product_capabilities import ProductCapabilities
 from .product_provenance import ProductExecutionProvenance
+from .product_support import (
+    PRODUCT_RUNTIME_CONTRACT_SCHEMA,
+    ProductTransportSupportTier,
+    normalize_product_transport_support_tier,
+    product_transport_support_tier,
+)
 from .types import ChatConversation, ChatMessage, ChatResponse, ConversationRef, ConversationStatus
 
 BROWSER_OWNED_PRODUCT_TRANSPORT = "browser-owned"
@@ -30,7 +36,7 @@ def normalize_product_transport(value: str) -> str:
 
 @dataclass(frozen=True)
 class ProductRuntimeHealth:
-    """Implementation-independent runtime readiness plus optional transport metadata."""
+    """Implementation-independent runtime readiness plus transport metadata."""
 
     transport: str
     ready: bool
@@ -43,15 +49,40 @@ class ProductRuntimeHealth:
     write_plane: str
     automatic_write_retry: bool = False
     fallback_transport: str | None = None
-    # PR8.3 compatibility metadata. Future non-browser transports are not
+    # Browser-owned compatibility metadata. Future non-browser transports are not
     # required to synthesize these fields.
     bridge_available: bool | None = None
     extension_connected: bool | None = None
     runtime_tab_id: int | None = None
     runtime_tab_preexisting: bool | None = None
+    runtime_contract_schema: int = PRODUCT_RUNTIME_CONTRACT_SCHEMA
+    transport_support_tier: ProductTransportSupportTier | str | None = None
+
+    def __post_init__(self) -> None:
+        transport = self.transport.strip().lower()
+        if not transport:
+            raise ValueError("runtime health transport identity is required")
+        schema = int(self.runtime_contract_schema)
+        if schema != PRODUCT_RUNTIME_CONTRACT_SCHEMA:
+            raise ValueError(
+                "unsupported product runtime contract schema "
+                f"{schema}; expected {PRODUCT_RUNTIME_CONTRACT_SCHEMA}"
+            )
+        support_tier = (
+            product_transport_support_tier(transport)
+            if self.transport_support_tier is None
+            else normalize_product_transport_support_tier(self.transport_support_tier)
+        )
+        object.__setattr__(self, "transport", transport)
+        object.__setattr__(self, "runtime_contract_schema", schema)
+        object.__setattr__(self, "transport_support_tier", support_tier)
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        payload = asdict(self)
+        support_tier = self.transport_support_tier
+        assert isinstance(support_tier, ProductTransportSupportTier)
+        payload["transport_support_tier"] = support_tier.value
+        return payload
 
 
 @dataclass(frozen=True)
@@ -75,19 +106,21 @@ class CanonicalConversationClient(Protocol):
 
 @runtime_checkable
 class CanonicalSessionClient(Protocol):
-    """Optional canonical session/auth lifecycle surface.
-
-    Product-runtime orchestration does not require explicit refresh yet. The
-    existing canonical client may implement this while browserless automatic
-    session renewal remains assembly/client-owned.
-    """
+    """Optional canonical session/auth lifecycle surface."""
 
     def refresh_auth(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 @runtime_checkable
 class ProductWriteTransport(Protocol):
-    """Implementation-independent ordinary-product write contract."""
+    """Replaceable ordinary-product write contract below ChatGPTProductRuntime.
+
+    Runtime-mediated keyword options are deliberately allowed so new transports
+    can implement product features such as conversation mode or model intent
+    without changing the application-facing ChatGPTProductRuntime API. Callers
+    should invoke those options through ChatGPTProductRuntime rather than relying
+    on concrete transport keyword names.
+    """
 
     @property
     def transport_id(self) -> str: ...
@@ -108,6 +141,7 @@ class ProductWriteTransport(Protocol):
         poll_interval: float = 0.5,
         on_token: TokenCallback = None,
         on_event: EventCallback = None,
+        **kwargs: Any,
     ) -> ChatResponse: ...
 
     def send_text_observed(
@@ -119,6 +153,7 @@ class ProductWriteTransport(Protocol):
         poll_interval: float = 0.5,
         on_token: TokenCallback = None,
         on_event: EventCallback = None,
+        **kwargs: Any,
     ) -> ProductRuntimeExecution: ...
 
     def governance(self) -> dict[str, Any]: ...

--- a/src/chatgpt_web_adapter/product_transport.py
+++ b/src/chatgpt_web_adapter/product_transport.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, Protocol, runtime_checkable
 
 from .product_capabilities import ProductCapabilities
@@ -8,7 +8,6 @@ from .product_provenance import ProductExecutionProvenance
 from .product_support import (
     PRODUCT_RUNTIME_CONTRACT_SCHEMA,
     ProductTransportSupportTier,
-    normalize_product_transport_support_tier,
     product_transport_support_tier,
 )
 from .types import ChatConversation, ChatMessage, ChatResponse, ConversationRef, ConversationStatus
@@ -55,33 +54,29 @@ class ProductRuntimeHealth:
     extension_connected: bool | None = None
     runtime_tab_id: int | None = None
     runtime_tab_preexisting: bool | None = None
-    runtime_contract_schema: int = PRODUCT_RUNTIME_CONTRACT_SCHEMA
-    transport_support_tier: ProductTransportSupportTier | str | None = None
+    runtime_contract_schema: int = field(
+        init=False,
+        default=PRODUCT_RUNTIME_CONTRACT_SCHEMA,
+    )
+    transport_support_tier: ProductTransportSupportTier = field(
+        init=False,
+        default=ProductTransportSupportTier.EXPERIMENTAL,
+    )
 
     def __post_init__(self) -> None:
-        transport = self.transport.strip().lower()
-        if not transport:
+        if not isinstance(self.transport, str) or not self.transport.strip():
             raise ValueError("runtime health transport identity is required")
-        schema = int(self.runtime_contract_schema)
-        if schema != PRODUCT_RUNTIME_CONTRACT_SCHEMA:
-            raise ValueError(
-                "unsupported product runtime contract schema "
-                f"{schema}; expected {PRODUCT_RUNTIME_CONTRACT_SCHEMA}"
-            )
-        support_tier = (
-            product_transport_support_tier(transport)
-            if self.transport_support_tier is None
-            else normalize_product_transport_support_tier(self.transport_support_tier)
-        )
+        transport = self.transport.strip().lower()
         object.__setattr__(self, "transport", transport)
-        object.__setattr__(self, "runtime_contract_schema", schema)
-        object.__setattr__(self, "transport_support_tier", support_tier)
+        object.__setattr__(
+            self,
+            "transport_support_tier",
+            product_transport_support_tier(transport),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
-        support_tier = self.transport_support_tier
-        assert isinstance(support_tier, ProductTransportSupportTier)
-        payload["transport_support_tier"] = support_tier.value
+        payload["transport_support_tier"] = self.transport_support_tier.value
         return payload
 
 

--- a/src/chatgpt_web_adapter/product_transport.py
+++ b/src/chatgpt_web_adapter/product_transport.py
@@ -108,13 +108,12 @@ class CanonicalSessionClient(Protocol):
 
 @runtime_checkable
 class ProductWriteTransport(Protocol):
-    """Replaceable ordinary-product write contract below ChatGPTProductRuntime.
+    """Minimal replaceable ordinary-product write contract.
 
-    Runtime-mediated keyword options are deliberately allowed so new transports
-    can implement product features such as conversation mode or model intent
-    without changing the application-facing ChatGPTProductRuntime API. Callers
-    should invoke those options through ChatGPTProductRuntime rather than relying
-    on concrete transport keyword names.
+    The base protocol intentionally stays narrow for compatibility. Concrete
+    transports may expose additional capability-gated keyword options consumed by
+    ChatGPTProductRuntime, but callers should request those product intents through
+    the runtime rather than depending on transport-specific signatures.
     """
 
     @property
@@ -136,7 +135,6 @@ class ProductWriteTransport(Protocol):
         poll_interval: float = 0.5,
         on_token: TokenCallback = None,
         on_event: EventCallback = None,
-        **kwargs: Any,
     ) -> ChatResponse: ...
 
     def send_text_observed(
@@ -148,7 +146,6 @@ class ProductWriteTransport(Protocol):
         poll_interval: float = 0.5,
         on_token: TokenCallback = None,
         on_event: EventCallback = None,
-        **kwargs: Any,
     ) -> ProductRuntimeExecution: ...
 
     def governance(self) -> dict[str, Any]: ...

--- a/src/chatgpt_web_adapter/public_surface.py
+++ b/src/chatgpt_web_adapter/public_surface.py
@@ -17,6 +17,11 @@ PRIMARY_PRODUCT_RUNTIME_EXPORTS: tuple[str, ...] = (
     "BROWSER_OWNED_PRODUCT_TRANSPORT",
     "DEFAULT_PRODUCT_TRANSPORT",
     "SUPPORTED_PRODUCT_TRANSPORTS",
+    "PRODUCT_RUNTIME_CONTRACT_SCHEMA",
+    "ProductTransportSupportTier",
+    "product_transport_support_tier",
+    "ProductRuntimeContract",
+    "product_runtime_contract",
     "ORDINARY_CHATGPT_PRODUCT_SEMANTICS",
     "PRODUCT_CAPABILITY_NAMES",
     "CapabilityState",
@@ -132,7 +137,7 @@ PUBLIC_SURFACE_CLASSIFICATION: Mapping[str, PublicSurfaceTier] = MappingProxyTyp
 
 
 def public_surface_tier(symbol: str) -> PublicSurfaceTier | None:
-    """Return the PR8.6 support tier for a root-package symbol, if classified."""
+    """Return the support tier for a classified root-package symbol."""
 
     if not isinstance(symbol, str):
         raise TypeError("symbol must be a string")

--- a/tests/test_browser_owned_v1_contract_pr9_0.py
+++ b/tests/test_browser_owned_v1_contract_pr9_0.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import chatgpt_web_adapter as adapter
+from chatgpt_web_adapter.browser_owned_product_transport import BrowserOwnedProductTransport
+
+
+class _Canonical:
+    def get_status(self, conversation):
+        return SimpleNamespace(status="completed")
+
+    def get_messages(self, conversation, **kwargs):
+        return []
+
+    def attach_conversation(self, conversation):
+        return SimpleNamespace(conversation_id=conversation)
+
+
+class _NoWriteProvider:
+    """Construction-only provider; contract inspection must never perform a write."""
+
+    def send_text(self, *args, **kwargs):
+        raise AssertionError("PR9.0 contract inspection must not perform a product write")
+
+
+def test_real_browser_owned_transport_declares_schema1_finality_governance() -> None:
+    transport = BrowserOwnedProductTransport(
+        _Canonical(),
+        provider=_NoWriteProvider(),
+    )
+
+    governance = transport.governance()
+
+    assert governance["incremental_observation_is_canonical_finality"] is False
+    assert governance["streaming_canonical_finality_authoritative"] is True
+    assert governance["automatic_write_retry"] is False
+    assert governance["ambiguous_write_requires_reconciliation"] is True
+
+
+def test_real_browser_owned_runtime_satisfies_frozen_schema1_contract_without_write() -> None:
+    transport = BrowserOwnedProductTransport(
+        _Canonical(),
+        provider=_NoWriteProvider(),
+    )
+    runtime = adapter.ChatGPTProductRuntime(
+        _Canonical(),
+        write_transport=transport,
+    )
+
+    contract = adapter.product_runtime_contract(runtime)
+    payload = contract.to_dict()
+
+    assert payload["schema"] == adapter.PRODUCT_RUNTIME_CONTRACT_SCHEMA == 1
+    assert payload["transport"] == "browser-owned"
+    assert payload["transport_support_tier"] == "PRODUCTION"
+    assert payload["product_semantics"] == "ordinary-chatgpt"
+    assert payload["interfaces"] == {
+        "canonical": "CanonicalConversationClient",
+        "write_transport": "ProductWriteTransport",
+    }
+    assert payload["invariants"]["automatic_write_retry"] is False
+    assert payload["invariants"]["fallback_transport"] is None
+    assert payload["invariants"]["ambiguous_write_requires_reconciliation"] is True
+    assert payload["invariants"]["incremental_observation_is_canonical_finality"] is False
+    assert payload["invariants"]["browser_implementation_required_by_caller"] is False

--- a/tests/test_product_runtime_contract_final_review_pr9_0.py
+++ b/tests/test_product_runtime_contract_final_review_pr9_0.py
@@ -106,6 +106,7 @@ def _direct_contract_kwargs(*, transport: str = "future-browserless") -> dict:
         "capability_states": tuple(state.value for state in CapabilityState),
         "automatic_write_retry": False,
         "fallback_transport": None,
+        "legacy_direct_write_fallback": False,
         "ambiguous_write_requires_reconciliation": True,
         "incremental_observation_is_canonical_finality": False,
         "browser_implementation_required_by_caller": False,
@@ -167,6 +168,7 @@ def test_direct_contract_construction_derives_schema_and_support_tier() -> None:
     assert contract.schema == adapter.PRODUCT_RUNTIME_CONTRACT_SCHEMA == 1
     assert contract.transport == "future-browserless"
     assert contract.transport_support_tier is ProductTransportSupportTier.EXPERIMENTAL
+    assert contract.legacy_direct_write_fallback is False
 
 
 def test_direct_contract_cannot_self_supply_schema_or_support_tier() -> None:
@@ -180,6 +182,22 @@ def test_direct_contract_cannot_self_supply_schema_or_support_tier() -> None:
             **kwargs,
             transport_support_tier=ProductTransportSupportTier.PRODUCTION,
         )
+
+
+def test_direct_contract_requires_legacy_fallback_invariant() -> None:
+    kwargs = _direct_contract_kwargs()
+    kwargs.pop("legacy_direct_write_fallback")
+
+    with pytest.raises(TypeError, match="legacy_direct_write_fallback"):
+        ProductRuntimeContract(**kwargs)
+
+
+def test_direct_contract_rejects_legacy_fallback() -> None:
+    kwargs = _direct_contract_kwargs(transport="browser-owned")
+    kwargs["legacy_direct_write_fallback"] = True
+
+    with pytest.raises(RuntimeError, match="legacy_direct_write_fallback=False"):
+        ProductRuntimeContract(**kwargs)
 
 
 def test_direct_contract_constructor_rejects_unsafe_invariants() -> None:

--- a/tests/test_product_runtime_contract_final_review_pr9_0.py
+++ b/tests/test_product_runtime_contract_final_review_pr9_0.py
@@ -85,6 +85,17 @@ class _UnsafeFallbackTransport:
         }
 
 
+class _MissingFallbackDeclarationTransport(_UnsafeFallbackTransport):
+    def __init__(self, missing_key: str) -> None:
+        super().__init__()
+        self._missing_key = missing_key
+
+    def governance(self):
+        payload = super().governance()
+        payload.pop(self._missing_key)
+        return payload
+
+
 def _direct_contract_kwargs(*, transport: str = "future-browserless") -> dict:
     return {
         "product_semantics": ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
@@ -110,7 +121,7 @@ def test_inspector_rejects_raw_fallback_before_runtime_governance_masks_it() -> 
     # The high-level runtime view deliberately normalizes its own fallback policy.
     assert runtime.governance()["fallback_transport"] is None
 
-    with pytest.raises(RuntimeError, match="raw write-transport fallback_transport"):
+    with pytest.raises(RuntimeError, match="fallback_transport=None"):
         adapter.product_runtime_contract(runtime)
 
 
@@ -122,7 +133,31 @@ def test_inspector_rejects_raw_legacy_fallback_before_runtime_normalization() ->
 
     assert runtime.governance()["legacy_direct_write_fallback"] is False
 
-    with pytest.raises(RuntimeError, match="legacy_direct_write_fallback"):
+    with pytest.raises(RuntimeError, match="legacy_direct_write_fallback=False"):
+        adapter.product_runtime_contract(runtime)
+
+
+@pytest.mark.parametrize(
+    ("missing_key", "message"),
+    (
+        ("fallback_transport", "explicit fallback_transport=None"),
+        ("legacy_direct_write_fallback", "legacy_direct_write_fallback=False"),
+    ),
+)
+def test_inspector_requires_explicit_raw_no_fallback_declarations(
+    missing_key: str,
+    message: str,
+) -> None:
+    runtime = adapter.ChatGPTProductRuntime(
+        _Canonical(),
+        write_transport=_MissingFallbackDeclarationTransport(missing_key),
+    )
+
+    # Runtime-level defaults must not substitute for missing transport evidence.
+    assert runtime.governance()["fallback_transport"] is None
+    assert runtime.governance()["legacy_direct_write_fallback"] is False
+
+    with pytest.raises(RuntimeError, match=message):
         adapter.product_runtime_contract(runtime)
 
 

--- a/tests/test_product_runtime_contract_final_review_pr9_0.py
+++ b/tests/test_product_runtime_contract_final_review_pr9_0.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import chatgpt_web_adapter as adapter
+from chatgpt_web_adapter.product_capabilities import (
+    ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
+    CapabilityState,
+    ProductCapabilities,
+)
+from chatgpt_web_adapter.product_contract import (
+    STABLE_PRODUCT_RUNTIME_OPERATIONS,
+    ProductRuntimeContract,
+)
+from chatgpt_web_adapter.product_support import ProductTransportSupportTier
+from chatgpt_web_adapter.product_transport import (
+    ProductRuntimeExecution,
+    ProductRuntimeHealth,
+)
+
+
+class _Canonical:
+    def get_status(self, conversation):
+        return SimpleNamespace(status="completed")
+
+    def get_messages(self, conversation, **kwargs):
+        return []
+
+    def attach_conversation(self, conversation):
+        return SimpleNamespace(conversation_id=conversation)
+
+
+class _UnsafeFallbackTransport:
+    transport_id = "browser-owned"
+
+    def __init__(
+        self,
+        *,
+        fallback_transport=None,
+        legacy_direct_write_fallback=False,
+    ) -> None:
+        self._fallback_transport = fallback_transport
+        self._legacy_direct_write_fallback = legacy_direct_write_fallback
+
+    def health(self, conversation=None):
+        return ProductRuntimeHealth(
+            transport=self.transport_id,
+            ready=True,
+            reason="READY",
+            conversation_id=conversation,
+            canonical_status="completed" if conversation else None,
+            canonical_read_checked=conversation is not None,
+            read_plane="CANONICAL",
+            session_plane="CANONICAL_SESSION",
+            write_plane="TEST_WRITE",
+        )
+
+    def capabilities(self):
+        return ProductCapabilities.from_entries(
+            transport=self.transport_id,
+            entries=(),
+        )
+
+    def send_text(self, text, **kwargs):
+        return SimpleNamespace(text=text)
+
+    def send_text_observed(self, text, **kwargs):
+        response = SimpleNamespace(text=text)
+        return ProductRuntimeExecution(
+            transport=self.transport_id,
+            response=response,
+            observation=SimpleNamespace(source="fixture"),
+        )
+
+    def governance(self):
+        return {
+            "product_semantics": ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
+            "automatic_write_retry": False,
+            "fallback_transport": self._fallback_transport,
+            "legacy_direct_write_fallback": self._legacy_direct_write_fallback,
+            "ambiguous_write_requires_reconciliation": True,
+            "incremental_observation_is_canonical_finality": False,
+        }
+
+
+def _direct_contract_kwargs(*, transport: str = "future-browserless") -> dict:
+    return {
+        "product_semantics": ORDINARY_CHATGPT_PRODUCT_SEMANTICS,
+        "transport": transport,
+        "canonical_interface": "CanonicalConversationClient",
+        "write_transport_interface": "ProductWriteTransport",
+        "operations": STABLE_PRODUCT_RUNTIME_OPERATIONS,
+        "capability_states": tuple(state.value for state in CapabilityState),
+        "automatic_write_retry": False,
+        "fallback_transport": None,
+        "ambiguous_write_requires_reconciliation": True,
+        "incremental_observation_is_canonical_finality": False,
+        "browser_implementation_required_by_caller": False,
+    }
+
+
+def test_inspector_rejects_raw_fallback_before_runtime_governance_masks_it() -> None:
+    runtime = adapter.ChatGPTProductRuntime(
+        _Canonical(),
+        write_transport=_UnsafeFallbackTransport(fallback_transport="legacy"),
+    )
+
+    # The high-level runtime view deliberately normalizes its own fallback policy.
+    assert runtime.governance()["fallback_transport"] is None
+
+    with pytest.raises(RuntimeError, match="raw write-transport fallback_transport"):
+        adapter.product_runtime_contract(runtime)
+
+
+def test_inspector_rejects_raw_legacy_fallback_before_runtime_normalization() -> None:
+    runtime = adapter.ChatGPTProductRuntime(
+        _Canonical(),
+        write_transport=_UnsafeFallbackTransport(legacy_direct_write_fallback=True),
+    )
+
+    assert runtime.governance()["legacy_direct_write_fallback"] is False
+
+    with pytest.raises(RuntimeError, match="legacy_direct_write_fallback"):
+        adapter.product_runtime_contract(runtime)
+
+
+def test_direct_contract_construction_derives_schema_and_support_tier() -> None:
+    contract = ProductRuntimeContract(**_direct_contract_kwargs())
+
+    assert contract.schema == adapter.PRODUCT_RUNTIME_CONTRACT_SCHEMA == 1
+    assert contract.transport == "future-browserless"
+    assert contract.transport_support_tier is ProductTransportSupportTier.EXPERIMENTAL
+
+
+def test_direct_contract_cannot_self_supply_schema_or_support_tier() -> None:
+    kwargs = _direct_contract_kwargs()
+
+    with pytest.raises(TypeError, match="schema"):
+        ProductRuntimeContract(**kwargs, schema=999)
+
+    with pytest.raises(TypeError, match="transport_support_tier"):
+        ProductRuntimeContract(
+            **kwargs,
+            transport_support_tier=ProductTransportSupportTier.PRODUCTION,
+        )
+
+
+def test_direct_contract_constructor_rejects_unsafe_invariants() -> None:
+    kwargs = _direct_contract_kwargs(transport="browser-owned")
+    kwargs["automatic_write_retry"] = True
+
+    with pytest.raises(RuntimeError, match="automatic_write_retry=False"):
+        ProductRuntimeContract(**kwargs)

--- a/tests/test_product_runtime_contract_pr9_0.py
+++ b/tests/test_product_runtime_contract_pr9_0.py
@@ -210,24 +210,9 @@ def test_runtime_contract_freezes_standalone_sdk_invariants() -> None:
     assert "governance" in payload["operations"]
 
 
-def test_contract_accepts_existing_browser_owned_canonical_finality_evidence() -> None:
-    governance = _conforming_governance()
-    governance.pop("incremental_observation_is_canonical_finality")
-    governance["streaming_canonical_finality_authoritative"] = True
-
-    contract = build_product_runtime_contract(
-        transport="browser-owned",
-        capabilities=_capabilities(),
-        governance=governance,
-    )
-
-    assert contract.incremental_observation_is_canonical_finality is False
-
-
 def test_contract_fails_closed_if_incremental_observation_claims_finality() -> None:
     governance = _conforming_governance()
     governance["incremental_observation_is_canonical_finality"] = True
-    governance["streaming_canonical_finality_authoritative"] = True
 
     with pytest.raises(
         RuntimeError,
@@ -244,7 +229,10 @@ def test_contract_fails_closed_if_incremental_finality_evidence_is_missing() -> 
     governance = _conforming_governance()
     governance.pop("incremental_observation_is_canonical_finality")
 
-    with pytest.raises(RuntimeError, match="non-incremental finality evidence"):
+    with pytest.raises(
+        RuntimeError,
+        match="incremental_observation_is_canonical_finality=False",
+    ):
         build_product_runtime_contract(
             transport="browser-owned",
             capabilities=_capabilities(),
@@ -317,5 +305,5 @@ def test_runtime_inspector_requires_every_frozen_operation() -> None:
         governance=lambda: _conforming_governance(),
     )
 
-    with pytest.raises(RuntimeError, match="operation surface"):
+    with pytest.raises(TypeError, match="operation surface"):
         adapter.product_runtime_contract(runtime)

--- a/tests/test_product_runtime_contract_pr9_0.py
+++ b/tests/test_product_runtime_contract_pr9_0.py
@@ -68,10 +68,37 @@ class _Transport:
 
     def governance(self):
         return {
+            "product_semantics": "ordinary-chatgpt",
             "automatic_write_retry": False,
             "canonical_readback_required": True,
             "ambiguous_write_requires_reconciliation": True,
+            "incremental_observation_is_canonical_finality": False,
         }
+
+
+def _capabilities(transport: str = "browser-owned") -> ProductCapabilities:
+    return ProductCapabilities.from_entries(
+        transport=transport,
+        entries=(),
+    )
+
+
+def _conforming_governance(
+    *,
+    transport: str = "browser-owned",
+) -> dict[str, object]:
+    return {
+        "transport": transport,
+        "product_semantics": "ordinary-chatgpt",
+        "canonical_interface": "CanonicalConversationClient",
+        "write_transport_interface": "ProductWriteTransport",
+        "automatic_write_retry": False,
+        "fallback_transport": None,
+        "legacy_direct_write_fallback": False,
+        "ambiguous_write_requires_reconciliation": True,
+        "incremental_observation_is_canonical_finality": False,
+        "runtime_depends_on_concrete_browser_transport": False,
+    }
 
 
 def test_browser_owned_is_frozen_production_transport() -> None:
@@ -183,43 +210,112 @@ def test_runtime_contract_freezes_standalone_sdk_invariants() -> None:
     assert "governance" in payload["operations"]
 
 
-def test_contract_fails_closed_if_transport_governance_violates_no_retry() -> None:
-    capabilities = ProductCapabilities.from_entries(
+def test_contract_accepts_existing_browser_owned_canonical_finality_evidence() -> None:
+    governance = _conforming_governance()
+    governance.pop("incremental_observation_is_canonical_finality")
+    governance["streaming_canonical_finality_authoritative"] = True
+
+    contract = build_product_runtime_contract(
         transport="browser-owned",
-        entries=(),
+        capabilities=_capabilities(),
+        governance=governance,
     )
-    governance = {
-        "automatic_write_retry": True,
-        "fallback_transport": None,
-        "legacy_direct_write_fallback": False,
-        "ambiguous_write_requires_reconciliation": True,
-        "runtime_depends_on_concrete_browser_transport": False,
-    }
+
+    assert contract.incremental_observation_is_canonical_finality is False
+
+
+def test_contract_fails_closed_if_incremental_observation_claims_finality() -> None:
+    governance = _conforming_governance()
+    governance["incremental_observation_is_canonical_finality"] = True
+    governance["streaming_canonical_finality_authoritative"] = True
+
+    with pytest.raises(
+        RuntimeError,
+        match="incremental_observation_is_canonical_finality=False",
+    ):
+        build_product_runtime_contract(
+            transport="browser-owned",
+            capabilities=_capabilities(),
+            governance=governance,
+        )
+
+
+def test_contract_fails_closed_if_incremental_finality_evidence_is_missing() -> None:
+    governance = _conforming_governance()
+    governance.pop("incremental_observation_is_canonical_finality")
+
+    with pytest.raises(RuntimeError, match="non-incremental finality evidence"):
+        build_product_runtime_contract(
+            transport="browser-owned",
+            capabilities=_capabilities(),
+            governance=governance,
+        )
+
+
+def test_contract_fails_closed_if_transport_governance_violates_no_retry() -> None:
+    governance = _conforming_governance()
+    governance["automatic_write_retry"] = True
 
     with pytest.raises(RuntimeError, match="automatic_write_retry=False"):
         build_product_runtime_contract(
             transport="browser-owned",
-            capabilities=capabilities,
+            capabilities=_capabilities(),
             governance=governance,
         )
 
 
 def test_contract_fails_closed_if_hidden_fallback_is_present() -> None:
-    capabilities = ProductCapabilities.from_entries(
-        transport="browser-owned",
-        entries=(),
-    )
-    governance = {
-        "automatic_write_retry": False,
-        "fallback_transport": "legacy",
-        "legacy_direct_write_fallback": False,
-        "ambiguous_write_requires_reconciliation": True,
-        "runtime_depends_on_concrete_browser_transport": False,
-    }
+    governance = _conforming_governance()
+    governance["fallback_transport"] = "legacy"
 
     with pytest.raises(RuntimeError, match="fallback_transport=None"):
         build_product_runtime_contract(
             transport="browser-owned",
-            capabilities=capabilities,
+            capabilities=_capabilities(),
             governance=governance,
         )
+
+
+def test_contract_fails_closed_if_fallback_declaration_is_missing() -> None:
+    governance = _conforming_governance()
+    governance.pop("fallback_transport")
+
+    with pytest.raises(RuntimeError, match="explicit fallback_transport=None"):
+        build_product_runtime_contract(
+            transport="browser-owned",
+            capabilities=_capabilities(),
+            governance=governance,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("canonical_interface", "ConcreteCanonicalClient"),
+        ("write_transport_interface", "ConcreteBrowserWriter"),
+    ),
+)
+def test_contract_fails_closed_if_interface_boundary_drifts(
+    field: str,
+    value: str,
+) -> None:
+    governance = _conforming_governance()
+    governance[field] = value
+
+    with pytest.raises(RuntimeError, match=field):
+        build_product_runtime_contract(
+            transport="browser-owned",
+            capabilities=_capabilities(),
+            governance=governance,
+        )
+
+
+def test_runtime_inspector_requires_every_frozen_operation() -> None:
+    runtime = SimpleNamespace(
+        transport="browser-owned",
+        capabilities=lambda: _capabilities(),
+        governance=lambda: _conforming_governance(),
+    )
+
+    with pytest.raises(RuntimeError, match="operation surface"):
+        adapter.product_runtime_contract(runtime)

--- a/tests/test_product_runtime_contract_pr9_0.py
+++ b/tests/test_product_runtime_contract_pr9_0.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import chatgpt_web_adapter as adapter
+from chatgpt_web_adapter.product_capabilities import (
+    CapabilityOwner,
+    CapabilityState,
+    ProductCapabilities,
+    ProductCapability,
+)
+from chatgpt_web_adapter.product_contract import build_product_runtime_contract
+from chatgpt_web_adapter.product_transport import ProductRuntimeExecution, ProductRuntimeHealth
+
+
+class _Canonical:
+    def get_status(self, conversation):
+        return SimpleNamespace(status="completed")
+
+    def get_messages(self, conversation, **kwargs):
+        return []
+
+    def attach_conversation(self, conversation):
+        return SimpleNamespace(conversation_id=conversation)
+
+
+class _Transport:
+    transport_id = "browser-owned"
+
+    def health(self, conversation=None):
+        return ProductRuntimeHealth(
+            transport=self.transport_id,
+            ready=True,
+            reason="READY",
+            conversation_id=conversation,
+            canonical_status="completed" if conversation else None,
+            canonical_read_checked=conversation is not None,
+            read_plane="CANONICAL",
+            session_plane="CANONICAL_SESSION",
+            write_plane="BROWSER_OWNED",
+        )
+
+    def capabilities(self):
+        return ProductCapabilities.from_entries(
+            transport=self.transport_id,
+            entries=(
+                ProductCapability(
+                    name="text_turns",
+                    state=CapabilityState.AVAILABLE,
+                    owner=CapabilityOwner.TRANSPORT,
+                    evidence="contract fixture",
+                ),
+            ),
+        )
+
+    def send_text(self, text, **kwargs):
+        return SimpleNamespace(text=text)
+
+    def send_text_observed(self, text, **kwargs):
+        response = SimpleNamespace(text=text)
+        return ProductRuntimeExecution(
+            transport=self.transport_id,
+            response=response,
+            observation=SimpleNamespace(source="fixture"),
+        )
+
+    def governance(self):
+        return {
+            "automatic_write_retry": False,
+            "canonical_readback_required": True,
+            "ambiguous_write_requires_reconciliation": True,
+        }
+
+
+def test_browser_owned_is_frozen_production_transport() -> None:
+    assert adapter.PRODUCT_RUNTIME_CONTRACT_SCHEMA == 1
+    assert adapter.product_transport_support_tier("browser-owned") is (
+        adapter.ProductTransportSupportTier.PRODUCTION
+    )
+
+
+def test_unknown_future_transport_defaults_to_experimental() -> None:
+    assert adapter.product_transport_support_tier("browserless-request") is (
+        adapter.ProductTransportSupportTier.EXPERIMENTAL
+    )
+
+
+def test_capability_state_and_transport_support_tier_are_orthogonal() -> None:
+    production = ProductCapabilities.from_entries(
+        transport="browser-owned",
+        entries=(
+            ProductCapability(
+                name="text_turns",
+                state=CapabilityState.AVAILABLE,
+                owner=CapabilityOwner.TRANSPORT,
+            ),
+        ),
+    ).to_dict()
+    experimental = ProductCapabilities.from_entries(
+        transport="browserless-request",
+        entries=(
+            ProductCapability(
+                name="text_turns",
+                state=CapabilityState.AVAILABLE,
+                owner=CapabilityOwner.TRANSPORT,
+            ),
+        ),
+    ).to_dict()
+
+    assert production["transport_support_tier"] == "PRODUCTION"
+    assert production["capabilities"]["text_turns"]["state"] == "AVAILABLE"
+    assert experimental["transport_support_tier"] == "EXPERIMENTAL"
+    assert experimental["capabilities"]["text_turns"]["state"] == "AVAILABLE"
+
+
+def test_runtime_health_serializes_contract_schema_and_support_tier() -> None:
+    payload = _Transport().health("conversation-1").to_dict()
+
+    assert payload["runtime_contract_schema"] == 1
+    assert payload["transport"] == "browser-owned"
+    assert payload["transport_support_tier"] == "PRODUCTION"
+
+
+def test_runtime_contract_freezes_standalone_sdk_invariants() -> None:
+    runtime = adapter.ChatGPTProductRuntime(
+        _Canonical(),
+        write_transport=_Transport(),
+    )
+
+    contract = adapter.product_runtime_contract(runtime)
+    payload = contract.to_dict()
+
+    assert isinstance(contract, adapter.ProductRuntimeContract)
+    assert payload["schema"] == 1
+    assert payload["runtime"] == "ChatGPTProductRuntime"
+    assert payload["product_semantics"] == "ordinary-chatgpt"
+    assert payload["transport"] == "browser-owned"
+    assert payload["transport_support_tier"] == "PRODUCTION"
+    assert payload["interfaces"] == {
+        "canonical": "CanonicalConversationClient",
+        "write_transport": "ProductWriteTransport",
+    }
+    assert payload["capability_states"] == [
+        "AVAILABLE",
+        "UNSUPPORTED",
+        "UNKNOWN",
+        "UNIMPLEMENTED",
+    ]
+    assert payload["invariants"] == {
+        "automatic_write_retry": False,
+        "fallback_transport": None,
+        "ambiguous_write_requires_reconciliation": True,
+        "incremental_observation_is_canonical_finality": False,
+        "browser_implementation_required_by_caller": False,
+    }
+    assert "send_text_observed" in payload["operations"]
+    assert "governance" in payload["operations"]
+
+
+def test_contract_fails_closed_if_transport_governance_violates_no_retry() -> None:
+    capabilities = ProductCapabilities.from_entries(
+        transport="browser-owned",
+        entries=(),
+    )
+    governance = {
+        "automatic_write_retry": True,
+        "fallback_transport": None,
+        "legacy_direct_write_fallback": False,
+        "ambiguous_write_requires_reconciliation": True,
+        "runtime_depends_on_concrete_browser_transport": False,
+    }
+
+    with pytest.raises(RuntimeError, match="automatic_write_retry=False"):
+        build_product_runtime_contract(
+            transport="browser-owned",
+            capabilities=capabilities,
+            governance=governance,
+        )
+
+
+def test_contract_fails_closed_if_hidden_fallback_is_present() -> None:
+    capabilities = ProductCapabilities.from_entries(
+        transport="browser-owned",
+        entries=(),
+    )
+    governance = {
+        "automatic_write_retry": False,
+        "fallback_transport": "legacy",
+        "legacy_direct_write_fallback": False,
+        "ambiguous_write_requires_reconciliation": True,
+        "runtime_depends_on_concrete_browser_transport": False,
+    }
+
+    with pytest.raises(RuntimeError, match="fallback_transport=None"):
+        build_product_runtime_contract(
+            transport="browser-owned",
+            capabilities=capabilities,
+            governance=governance,
+        )

--- a/tests/test_product_runtime_contract_pr9_0.py
+++ b/tests/test_product_runtime_contract_pr9_0.py
@@ -70,6 +70,8 @@ class _Transport:
         return {
             "product_semantics": "ordinary-chatgpt",
             "automatic_write_retry": False,
+            "fallback_transport": None,
+            "legacy_direct_write_fallback": False,
             "canonical_readback_required": True,
             "ambiguous_write_requires_reconciliation": True,
             "incremental_observation_is_canonical_finality": False,

--- a/tests/test_product_runtime_contract_pr9_0.py
+++ b/tests/test_product_runtime_contract_pr9_0.py
@@ -115,6 +115,30 @@ def test_capability_state_and_transport_support_tier_are_orthogonal() -> None:
     assert experimental["capabilities"]["text_turns"]["state"] == "AVAILABLE"
 
 
+def test_contract_metadata_is_derived_not_caller_self_declared() -> None:
+    with pytest.raises(TypeError, match="transport_support_tier"):
+        ProductCapabilities(
+            transport="browser-owned",
+            product_semantics="ordinary-chatgpt",
+            entries=(),
+            transport_support_tier="EXPERIMENTAL",
+        )
+
+    with pytest.raises(TypeError, match="runtime_contract_schema"):
+        ProductRuntimeHealth(
+            transport="browser-owned",
+            ready=True,
+            reason="READY",
+            conversation_id=None,
+            canonical_status=None,
+            canonical_read_checked=False,
+            read_plane="CANONICAL",
+            session_plane="CANONICAL_SESSION",
+            write_plane="BROWSER_OWNED",
+            runtime_contract_schema=999,
+        )
+
+
 def test_runtime_health_serializes_contract_schema_and_support_tier() -> None:
     payload = _Transport().health("conversation-1").to_dict()
 

--- a/tests/test_product_runtime_contract_pr9_0.py
+++ b/tests/test_product_runtime_contract_pr9_0.py
@@ -206,6 +206,7 @@ def test_runtime_contract_freezes_standalone_sdk_invariants() -> None:
     assert payload["invariants"] == {
         "automatic_write_retry": False,
         "fallback_transport": None,
+        "legacy_direct_write_fallback": False,
         "ambiguous_write_requires_reconciliation": True,
         "incremental_observation_is_canonical_finality": False,
         "browser_implementation_required_by_caller": False,

--- a/tests/test_product_runtime_contract_pr9_0.py
+++ b/tests/test_product_runtime_contract_pr9_0.py
@@ -151,6 +151,8 @@ def test_contract_metadata_is_derived_not_caller_self_declared() -> None:
             transport_support_tier="EXPERIMENTAL",
         )
 
+    # Health stays on the released 0.2 constructor/schema rather than becoming
+    # another authority source for contract/support metadata.
     with pytest.raises(TypeError, match="runtime_contract_schema"):
         ProductRuntimeHealth(
             transport="browser-owned",
@@ -166,12 +168,12 @@ def test_contract_metadata_is_derived_not_caller_self_declared() -> None:
         )
 
 
-def test_runtime_health_serializes_contract_schema_and_support_tier() -> None:
+def test_runtime_health_serialization_remains_frozen_to_0_2_shape() -> None:
     payload = _Transport().health("conversation-1").to_dict()
 
-    assert payload["runtime_contract_schema"] == 1
     assert payload["transport"] == "browser-owned"
-    assert payload["transport_support_tier"] == "PRODUCTION"
+    assert "runtime_contract_schema" not in payload
+    assert "transport_support_tier" not in payload
 
 
 def test_runtime_contract_freezes_standalone_sdk_invariants() -> None:

--- a/tests/test_product_runtime_public_api.py
+++ b/tests/test_product_runtime_public_api.py
@@ -7,6 +7,11 @@ PRODUCT_RUNTIME_EXPORTS = [
     "BROWSER_OWNED_PRODUCT_TRANSPORT",
     "DEFAULT_PRODUCT_TRANSPORT",
     "SUPPORTED_PRODUCT_TRANSPORTS",
+    "PRODUCT_RUNTIME_CONTRACT_SCHEMA",
+    "ProductTransportSupportTier",
+    "product_transport_support_tier",
+    "ProductRuntimeContract",
+    "product_runtime_contract",
     "ORDINARY_CHATGPT_PRODUCT_SEMANTICS",
     "PRODUCT_CAPABILITY_NAMES",
     "CapabilityState",
@@ -35,6 +40,10 @@ def test_product_runtime_is_public_production_surface() -> None:
 def test_product_runtime_transport_default_is_browser_owned() -> None:
     assert adapter.DEFAULT_PRODUCT_TRANSPORT == "browser-owned"
     assert adapter.SUPPORTED_PRODUCT_TRANSPORTS == ("browser-owned",)
+    assert adapter.PRODUCT_RUNTIME_CONTRACT_SCHEMA == 1
+    assert adapter.product_transport_support_tier("browser-owned") is (
+        adapter.ProductTransportSupportTier.PRODUCTION
+    )
     assert adapter.ORDINARY_CHATGPT_PRODUCT_SEMANTICS == "ordinary-chatgpt"
 
 
@@ -44,4 +53,11 @@ def test_capability_state_contract_is_stable_and_non_boolean() -> None:
         "UNSUPPORTED",
         "UNKNOWN",
         "UNIMPLEMENTED",
+    ]
+
+
+def test_transport_support_tier_is_stable_and_separate_from_capabilities() -> None:
+    assert [tier.value for tier in adapter.ProductTransportSupportTier] == [
+        "PRODUCTION",
+        "EXPERIMENTAL",
     ]

--- a/tests/test_public_surface_classification.py
+++ b/tests/test_public_surface_classification.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import chatgpt_web_adapter as adapter
 
 
-
 def test_every_root_public_export_has_exactly_one_surface_tier() -> None:
     classified = adapter.PUBLIC_SURFACE_CLASSIFICATION
 
@@ -26,6 +25,11 @@ def test_primary_product_runtime_is_forward_looking_surface() -> None:
         "CanonicalConversationClient",
         "ProductCapabilities",
         "ProductExecutionProvenance",
+        "PRODUCT_RUNTIME_CONTRACT_SCHEMA",
+        "ProductTransportSupportTier",
+        "ProductRuntimeContract",
+        "product_runtime_contract",
+        "product_transport_support_tier",
     ):
         assert adapter.public_surface_tier(symbol) is primary
 


### PR DESCRIPTION
## Summary

Finalize the browser-owned text runtime as the mature production baseline and freeze the standalone CWA SDK boundary for future transport implementations.

## Changes

- add Product Runtime Contract schema 1
- add machine-readable transport support tiers: PRODUCTION / EXPERIMENTAL
- keep transport support tier independent from capability state
- freeze browser-owned as the production transport baseline
- expose contract/support metadata through the primary Python SDK
- derive contract schema and transport tier in `ProductCapabilities` / `ProductRuntimeContract` while preserving the released `ProductRuntimeHealth` serialization
- preserve the minimal `ProductWriteTransport` protocol as the replaceable implementation boundary
- add fail-closed conformance tests for retry/fallback/finality/interface/operation-surface invariants and support-tier self-promotion
- add direct no-write conformance coverage for the real `BrowserOwnedProductTransport`
- add `docs/browser_owned_v1_contract.md`
- record the new public contract in `CHANGELOG.md` under Unreleased

## Review repairs

Final review found and repaired several contract-certification and compatibility gaps:

1. **Incremental finality was initially hard-coded rather than proven.**
   - `BrowserOwnedProductTransport.governance()` now explicitly declares `incremental_observation_is_canonical_finality=False`.
   - schema 1 requires that exact false value; missing or contradictory evidence fails closed.

2. **Support tier could initially be caller-supplied.**
   - `runtime_contract_schema` and `transport_support_tier` are now derived `init=False` capability metadata.
   - contract construction re-validates capability tier against the canonical CWA registry.
   - unknown/future transports remain `EXPERIMENTAL` until CWA explicitly graduates them.

3. **Missing fallback evidence could be interpreted as safe.**
   - raw write-transport governance must explicitly declare `fallback_transport=None` and `legacy_direct_write_fallback=False`.
   - missing or contradictory declarations fail closed before runtime normalization can mask them.

4. **The legacy-fallback proof could be validated but then discarded.**
   - `ProductRuntimeContract` now carries `legacy_direct_write_fallback` as a required frozen invariant.
   - direct construction validates it is exactly `False` and serialized contract output preserves it under `invariants`.

5. **Interface and operation metadata could overstate a partial runtime.**
   - runtime/governance/capability transport and product semantics must agree;
   - canonical/write interface identities are validated rather than defaulted;
   - every frozen schema-1 runtime operation must actually be callable.

6. **An intermediate change broadened the public `ProductWriteTransport` Protocol with arbitrary `**kwargs`.**
   - reverted during review to preserve the minimal released protocol and downstream structural-typing compatibility;
   - capability-gated concrete transport options remain implementation details below `ChatGPTProductRuntime`.

7. **Support metadata in `ProductRuntimeHealth` could contradict an injected transport's runtime identity.**
   - removed schema/tier authority from health entirely instead of changing the released `ChatGPTProductRuntime.health()` validation contract;
   - `ProductRuntimeHealth` is restored to the frozen 0.2 observational JSON shape;
   - support/schema authority exists only in cross-validated `ProductCapabilities` and `ProductRuntimeContract`.

8. **Fixture-only conformance was insufficient for the production baseline.**
   - added no-write tests that instantiate the real `BrowserOwnedProductTransport` and prove its governance plus `ChatGPTProductRuntime -> product_runtime_contract()` satisfy schema 1.

## Compatibility

This PR does not rewrite `ChatGPTProductRuntime`, browser-owned write execution, Temporary lifecycle, stream/finality algorithms, model-profile behavior, or Browser Authority behavior.

The released `ProductRuntimeHealth` constructor and JSON shape remain unchanged. The minimal `ProductWriteTransport` protocol remains unchanged. New support/contract authority is additive through `ProductCapabilities`, `ProductRuntimeContract`, and root production exports.

CWA remains a standalone SDK/CLI product. CMA and HDE remain downstream consumers of the same public contract.

## Validation

Final exact head:

`3718ba9962e7c0d37ab289b55865b720bce96f26`

GitHub Actions CI **#235: SUCCESS**.

```text
Ubuntu   Python 3.10-3.14   PASS
Windows  Python 3.10-3.14   PASS
full pytest suite            PASS (1312 passed on Ubuntu 3.10 reference job)
build wheel + sdist          PASS
package metadata validation  PASS
release artifact contract    PASS
installed wheel Ubuntu       PASS (Python 3.10 / 3.14)
installed wheel Windows      PASS (Python 3.10 / 3.14)
```

The only pytest warning is the pre-existing invalid-escape `DeprecationWarning` in `tests/test_payload_validation.py:117`; it is unrelated to PR9.0.

A new live product-write gate is not required for this PR because it changes no product-write algorithm, Temporary lifecycle, stream/finality algorithm, model selection behavior, or Browser Authority behavior. Existing live-validated browser-owned behavior remains the baseline; PR9.0 adds explicit contract metadata and fail-closed conformance enforcement around it.

## Review status

- all Codex P2 findings were repaired on subsequent exact heads
- final Codex review on `3718ba9962` reported: **“Didn't find any major issues.”**
- exact-head CI #235 is fully green
- authorized for merge on 2026-08-22

## Next milestones

PR9.1 remains the experimental alternative-transport milestone. PR9.2 covers images/files/multimodal. PR9.3 covers richer product observations.