### PR TITLE
PR11.1 — Canonical Read Failure Semantics

### DIFF
--- a/src/chatgpt_web_adapter/browser_native_client.py
+++ b/src/chatgpt_web_adapter/browser_native_client.py
@@ -109,7 +109,12 @@ def _wait_for_new_final_assistant(
             try:
                 canonical_payload_read_count += 1
                 payload = canonical_reader(conversation_id)
-            except Exception:
+            except RequestError as error:
+                # A freshly created conversation can briefly be absent from the
+                # canonical read plane. Other request failures are deterministic
+                # for this attempt and must not be hidden until the turn timeout.
+                if error.status_code != 404:
+                    raise
                 payload = None
 
             if isinstance(payload, dict):

--- a/tests/test_canonical_read_failure_semantics_pr11_1.py
+++ b/tests/test_canonical_read_failure_semantics_pr11_1.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+
+from chatgpt_web_adapter.browser_native_client import _wait_for_new_final_assistant
+from chatgpt_web_adapter.exceptions import RequestError
+
+
+def _canonical_payload() -> dict:
+    return {
+        "conversation_id": "conversation-1",
+        "title": "Canonical read retry",
+        "current_node": "assistant-node",
+        "mapping": {
+            "assistant-node": {
+                "id": "assistant-node",
+                "parent": None,
+                "children": [],
+                "message": {
+                    "id": "assistant-1",
+                    "author": {"role": "assistant"},
+                    "recipient": "all",
+                    "content": {
+                        "content_type": "text",
+                        "parts": ["CANONICAL_OK"],
+                    },
+                    "metadata": {
+                        "finish_details": {"type": "stop"},
+                        "model_slug": "gpt-test",
+                    },
+                },
+            }
+        },
+    }
+
+
+class _CanonicalReader:
+    def __init__(self, outcomes) -> None:
+        self.outcomes = list(outcomes)
+        self.reads = 0
+
+    def _get_conversation_payload(self, conversation_id: str):
+        assert conversation_id == "conversation-1"
+        self.reads += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+def test_deterministic_403_fails_immediately_after_one_read(monkeypatch) -> None:
+    client = _CanonicalReader(
+        [RequestError("conversation status=403: access challenged")]
+    )
+    monkeypatch.setattr("chatgpt_web_adapter.browser_native_client.time.sleep", lambda _: None)
+
+    with pytest.raises(RequestError) as raised:
+        _wait_for_new_final_assistant(
+            client,
+            "conversation-1",
+            baseline_assistant_ids=set(),
+            timeout=60.0,
+            interval=0.5,
+        )
+
+    assert raised.value.status_code == 403
+    assert client.reads == 1
+
+
+def test_exact_404_visibility_lag_is_retryable(monkeypatch) -> None:
+    client = _CanonicalReader(
+        [
+            RequestError("conversation status=404: not visible yet"),
+            _canonical_payload(),
+        ]
+    )
+    monkeypatch.setattr("chatgpt_web_adapter.browser_native_client.time.sleep", lambda _: None)
+
+    message = _wait_for_new_final_assistant(
+        client,
+        "conversation-1",
+        baseline_assistant_ids=set(),
+        timeout=60.0,
+        interval=0.5,
+    )
+
+    assert message.message_id == "assistant-1"
+    assert message.text == "CANONICAL_OK"
+    assert client.reads == 2
+
+
+def test_unclassified_canonical_reader_failure_is_not_hidden(monkeypatch) -> None:
+    client = _CanonicalReader([ValueError("canonical payload decoder failed")])
+    monkeypatch.setattr("chatgpt_web_adapter.browser_native_client.time.sleep", lambda _: None)
+
+    with pytest.raises(ValueError, match="canonical payload decoder failed"):
+        _wait_for_new_final_assistant(
+            client,
+            "conversation-1",
+            baseline_assistant_ids=set(),
+            timeout=60.0,
+            interval=0.5,
+        )
+
+    assert client.reads == 1


### PR DESCRIPTION
## Purpose

Stop deterministic post-write canonical read failures from being hidden behind the full browser-owned turn timeout.

## Problem

`_wait_for_new_final_assistant()` currently catches every canonical-reader exception and treats it as an empty poll. A stable auth/challenge/protocol failure after an already delegated browser write can therefore look like a long silent timeout rather than an immediate reconciliation-required failure.

## Change

- keep only exact canonical HTTP 404 as retryable visibility lag;
- re-raise other `RequestError` failures immediately;
- stop hiding unclassified canonical-reader exceptions;
- preserve canonical finality, no-write-retry, transport selection, and browser authority semantics;
- add focused regression coverage for 403 fail-fast, 404 retry, and unclassified reader failure propagation.

## Non-goals

- no browser-context canonical transport yet;
- no auth/session transport changes;
- no product write or submission-boundary changes;
- no public API expansion.

This is the narrow first hardening step before evaluating browser-context canonical reads in PR11.2.