### PR TITLE
PR11.3 — Text Submission Commit-Point Hardening

### DIFF
--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_rich_input_schema7_repair_pr9_2.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_rich_input_schema7_repair_pr9_2.js
@@ -2,8 +2,8 @@
 //
 // Keep the historical entrypoint import stable while preserving reviewed schema
 // generations as immutable layers. PR9.2 schema 29 remains the final rich-input
-// authority layer; later product-observation overlays may load after it but do
-// not acquire write authority.
+// authority layer; PR11.3 may harden only the text-only submit boundary after it,
+// while later product-observation/read overlays do not acquire write authority.
 importScripts("service_worker_rich_input_schema7_core_pr9_2.js");
 importScripts("service_worker_rich_input_schema8_repair_pr9_2.js");
 importScripts("service_worker_rich_input_schema9_repair_pr9_2.js");
@@ -32,12 +32,17 @@ importScripts("service_worker_rich_input_schema28_repair_pr9_2.js");
 importScripts("service_worker_rich_input_schema28_diagnostic_repair_pr9_2.js");
 importScripts("service_worker_rich_input_schema29_repair_pr9_2.js");
 
+// PR11.3 text-only write-boundary hardening. This layer delegates active rich
+// contexts to the complete PR9.2 chain above and only removes post-mouse-release
+// fallback/retry authority from ordinary text submission.
+importScripts("service_worker_text_submit_commit_hardening_pr11_3.js");
+
 // PR9.3 observational-only source/citation normalization. Loaded after the final
-// PR9.2 authority generation so it can observe PR8.12 message events without
+// write-authority layers so it can observe PR8.12 message events without
 // participating in attachment staging, protected submit, retry, or finality.
 importScripts("service_worker_product_source_citations_pr9_3.js");
 
 // PR11.2 canonical reads are an observation/read overlay only. Load them after
-// the final rich-input authority generation and PR9.3 observation layer, while
+// the final write-authority generations and PR9.3 observation layer, while
 // leaving the historical manifest and PR10.0 outer executeNativeTurn wrapper intact.
 importScripts("service_worker_canonical_read.js");

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
@@ -7,8 +7,9 @@
 // outcome is ambiguous on ACK loss and a second submit is forbidden.
 
 const _pr113PriorSubmitOfficialPageTurn = submitOfficialPageTurn;
-const PR113_TEXT_SUBMIT_SCHEMA = 2;
+const PR113_TEXT_SUBMIT_SCHEMA = 3;
 const PR113_MOUSE_RELEASE_UNCONFIRMED = "PR11_3_TEXT_MOUSE_RELEASE_OUTCOME_UNCONFIRMED";
+const PR113_ENTER_KEYDOWN_UNCONFIRMED = "PR11_3_TEXT_ENTER_KEYDOWN_OUTCOME_UNCONFIRMED";
 
 function _pr113SpecialSubmitContextActive() {
   try {
@@ -38,18 +39,26 @@ function _pr113IsMouseReleaseOutcomeUnconfirmed(error) {
 async function _pr113SubmitTextWithEnterOnce(debuggee) {
   await locateAndFocusComposer(debuggee);
 
-  // Enter keyDown is the keyboard protected-write boundary. Once it succeeds,
-  // keyUp is cleanup only and must not turn a possibly committed write into a
-  // local failure that callers could misinterpret as permission to retry.
-  await sendCommand(debuggee, "Input.dispatchKeyEvent", {
-    type: "keyDown",
-    key: "Enter",
-    code: "Enter",
-    text: "\r",
-    unmodifiedText: "\r",
-    windowsVirtualKeyCode: 13,
-    nativeVirtualKeyCode: 13
-  });
+  // Enter keyDown is the keyboard protected-write boundary. A rejected/lost CDP
+  // ACK can coexist with a real keyDown, so the attempt itself is ambiguous and
+  // must never look like proof that no write happened.
+  try {
+    await sendCommand(debuggee, "Input.dispatchKeyEvent", {
+      type: "keyDown",
+      key: "Enter",
+      code: "Enter",
+      text: "\r",
+      unmodifiedText: "\r",
+      windowsVirtualKeyCode: 13,
+      nativeVirtualKeyCode: 13
+    });
+  } catch {
+    throw new Error(PR113_ENTER_KEYDOWN_UNCONFIRMED);
+  }
+
+  // Once keyDown is acknowledged, keyUp is cleanup only and must not turn a
+  // possibly committed write into a local failure that callers could interpret
+  // as permission to retry.
   try {
     Promise.resolve(sendCommand(debuggee, "Input.dispatchKeyEvent", {
       type: "keyUp",

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
@@ -1,22 +1,29 @@
-// PR11.3 text-only protected-submit hardening.
+// PR11.3 ordinary-text protected-submit hardening.
 //
-// Rich-input turns already have their own deadline/commit-point authority chain.
-// This layer delegates those turns unchanged and fixes only the ordinary text
-// path: Enter fallback is permitted only before the click commit boundary is
-// attempted. Once mouseReleased is delegated, the outcome is ambiguous on ACK
-// loss and a second submit is forbidden.
+// Rich-input and Temporary Chat turns already have specialized submit authority
+// chains. This layer delegates those contexts unchanged and fixes only ordinary
+// browser-owned text submission: Enter fallback is permitted only before the
+// click commit boundary is attempted. Once mouseReleased is delegated, the
+// outcome is ambiguous on ACK loss and a second submit is forbidden.
 
 const _pr113PriorSubmitOfficialPageTurn = submitOfficialPageTurn;
-const PR113_TEXT_SUBMIT_SCHEMA = 1;
+const PR113_TEXT_SUBMIT_SCHEMA = 2;
 const PR113_MOUSE_RELEASE_UNCONFIRMED = "PR11_3_TEXT_MOUSE_RELEASE_OUTCOME_UNCONFIRMED";
 
-function _pr113RichInputContextActive() {
+function _pr113SpecialSubmitContextActive() {
   try {
-    return (
+    const richInputActive = (
       typeof _pr92ActiveRichInputContext !== "undefined" &&
       _pr92ActiveRichInputContext !== null
     );
+    const temporaryChatActive = (
+      typeof _pr813TemporaryTurnContext !== "undefined" &&
+      _pr813TemporaryTurnContext !== null
+    );
+    return richInputActive || temporaryChatActive;
   } catch {
+    // Missing historical context markers mean this is not one of those specialized
+    // paths. The ordinary text path remains eligible for PR11.3 hardening.
     return false;
   }
 }
@@ -101,7 +108,7 @@ submitOfficialPageTurn = async function _pr113SubmitOfficialTextWithoutPostCommi
   debuggee,
   timeoutMs
 ) {
-  if (_pr113RichInputContextActive()) {
+  if (_pr113SpecialSubmitContextActive()) {
     return _pr113PriorSubmitOfficialPageTurn(debuggee, timeoutMs);
   }
 

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
@@ -1,0 +1,126 @@
+// PR11.3 text-only protected-submit hardening.
+//
+// Rich-input turns already have their own deadline/commit-point authority chain.
+// This layer delegates those turns unchanged and fixes only the ordinary text
+// path: Enter fallback is permitted only before the click commit boundary is
+// attempted. Once mouseReleased is delegated, the outcome is ambiguous on ACK
+// loss and a second submit is forbidden.
+
+const _pr113PriorSubmitOfficialPageTurn = submitOfficialPageTurn;
+const PR113_TEXT_SUBMIT_SCHEMA = 1;
+const PR113_MOUSE_RELEASE_UNCONFIRMED = "PR11_3_TEXT_MOUSE_RELEASE_OUTCOME_UNCONFIRMED";
+
+function _pr113RichInputContextActive() {
+  try {
+    return (
+      typeof _pr92ActiveRichInputContext !== "undefined" &&
+      _pr92ActiveRichInputContext !== null
+    );
+  } catch {
+    return false;
+  }
+}
+
+function _pr113IsMouseReleaseOutcomeUnconfirmed(error) {
+  return Boolean(
+    error instanceof Error &&
+    error.message === PR113_MOUSE_RELEASE_UNCONFIRMED
+  );
+}
+
+async function _pr113SubmitTextWithEnterOnce(debuggee) {
+  await locateAndFocusComposer(debuggee);
+
+  // Enter keyDown is the keyboard protected-write boundary. Once it succeeds,
+  // keyUp is cleanup only and must not turn a possibly committed write into a
+  // local failure that callers could misinterpret as permission to retry.
+  await sendCommand(debuggee, "Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "Enter",
+    code: "Enter",
+    text: "\r",
+    unmodifiedText: "\r",
+    windowsVirtualKeyCode: 13,
+    nativeVirtualKeyCode: 13
+  });
+  try {
+    Promise.resolve(sendCommand(debuggee, "Input.dispatchKeyEvent", {
+      type: "keyUp",
+      key: "Enter",
+      code: "Enter",
+      windowsVirtualKeyCode: 13,
+      nativeVirtualKeyCode: 13
+    })).catch(() => {});
+  } catch {}
+
+  return { strategy: "enter_fallback", selector: null };
+}
+
+async function _pr113SubmitTextWithMouseOnce(debuggee, point) {
+  const x = Number(point?.x);
+  const y = Number(point?.y);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    throw new Error("CHATGPT_SEND_BUTTON_POINT_INVALID");
+  }
+
+  // move/press are pre-commit for the established CWA click contract. If either
+  // fails, Enter remains a single safe fallback because mouseReleased has not
+  // been attempted.
+  await sendCommand(debuggee, "Input.dispatchMouseEvent", {
+    type: "mouseMoved",
+    x,
+    y
+  });
+  await sendCommand(debuggee, "Input.dispatchMouseEvent", {
+    type: "mousePressed",
+    x,
+    y,
+    button: "left",
+    clickCount: 1
+  });
+
+  // mouseReleased is the click protected-write boundary. Mark the outcome
+  // ambiguous as soon as the command is attempted: a rejected/lost CDP ACK can
+  // coexist with a real page click and therefore can never authorize Enter.
+  try {
+    await sendCommand(debuggee, "Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      x,
+      y,
+      button: "left",
+      clickCount: 1
+    });
+  } catch {
+    throw new Error(PR113_MOUSE_RELEASE_UNCONFIRMED);
+  }
+
+  return { strategy: "send_button_click", selector: point?.selector ?? null };
+}
+
+submitOfficialPageTurn = async function _pr113SubmitOfficialTextWithoutPostCommitRetry(
+  debuggee,
+  timeoutMs
+) {
+  if (_pr113RichInputContextActive()) {
+    return _pr113PriorSubmitOfficialPageTurn(debuggee, timeoutMs);
+  }
+
+  let point = null;
+  try {
+    point = await waitForSendButtonPoint(
+      debuggee,
+      Math.min(timeoutMs, DEFAULT_SUBMIT_READY_TIMEOUT_MS)
+    );
+  } catch {
+    return _pr113SubmitTextWithEnterOnce(debuggee);
+  }
+
+  try {
+    return await _pr113SubmitTextWithMouseOnce(debuggee, point);
+  } catch (error) {
+    if (_pr113IsMouseReleaseOutcomeUnconfirmed(error)) {
+      throw error;
+    }
+    return _pr113SubmitTextWithEnterOnce(debuggee);
+  }
+};

--- a/tests/test_text_submit_commit_point_hardening_pr11_3.py
+++ b/tests/test_text_submit_commit_point_hardening_pr11_3.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -28,6 +28,7 @@ def test_text_submit_hardening_declares_exact_protected_boundaries() -> None:
     text = OVERLAY.read_text(encoding="utf-8")
 
     assert 'PR11_3_TEXT_MOUSE_RELEASE_OUTCOME_UNCONFIRMED' in text
+    assert 'PR11_3_TEXT_ENTER_KEYDOWN_OUTCOME_UNCONFIRMED' in text
     assert 'type: "mouseReleased"' in text
     assert 'type: "keyDown"' in text
     assert 'type: "keyUp"' in text
@@ -172,11 +173,11 @@ def test_enter_keyup_failure_is_post_commit_cleanup_only(tmp_path: Path) -> None
     assert len(_enter_keydowns(result["log"])) == 1
 
 
-def test_enter_keydown_failure_propagates_without_second_submit(tmp_path: Path) -> None:
+def test_enter_keydown_ack_loss_is_ambiguous_and_never_retries(tmp_path: Path) -> None:
     result = _run_node_scenario(tmp_path, "enter_keydown_fail")
 
     assert result["ok"] is False
-    assert result["error"] == "enter-keydown-failed"
+    assert result["error"] == "PR11_3_TEXT_ENTER_KEYDOWN_OUTCOME_UNCONFIRMED"
     assert len(_enter_keydowns(result["log"])) == 1
 
 

--- a/tests/test_text_submit_commit_point_hardening_pr11_3.py
+++ b/tests/test_text_submit_commit_point_hardening_pr11_3.py
@@ -32,6 +32,8 @@ def test_text_submit_hardening_declares_exact_protected_boundaries() -> None:
     assert 'type: "keyDown"' in text
     assert 'type: "keyUp"' in text
     assert "_pr113IsMouseReleaseOutcomeUnconfirmed(error)" in text
+    assert "_pr813TemporaryTurnContext" in text
+    assert "_pr92ActiveRichInputContext" in text
     assert "throw error;" in text
     assert "return _pr113SubmitTextWithEnterOnce(debuggee);" in text
     assert text.index("throw error;") < text.rindex(
@@ -52,11 +54,12 @@ const overlaySource = fs.readFileSync(process.argv[2], "utf8");
 const scenario = process.argv[3];
 const log = [];
 let _pr92ActiveRichInputContext = null;
+let _pr813TemporaryTurnContext = null;
 const DEFAULT_SUBMIT_READY_TIMEOUT_MS = 10000;
 
 async function submitOfficialPageTurn() {
   log.push("prior_submit");
-  return { strategy: "prior_rich", selector: null };
+  return { strategy: "prior_specialized", selector: null };
 }
 
 async function waitForSendButtonPoint() {
@@ -96,6 +99,9 @@ async function sendCommand(_debuggee, method, params) {
 eval(overlaySource);
 if (scenario === "rich") {
   _pr92ActiveRichInputContext = { staged: true };
+}
+if (scenario === "temporary") {
+  _pr813TemporaryTurnContext = { tabId: 77 };
 }
 
 (async () => {
@@ -174,9 +180,13 @@ def test_enter_keydown_failure_propagates_without_second_submit(tmp_path: Path) 
     assert len(_enter_keydowns(result["log"])) == 1
 
 
-def test_rich_input_context_delegates_to_existing_authority_chain(tmp_path: Path) -> None:
-    result = _run_node_scenario(tmp_path, "rich")
+@pytest.mark.parametrize("scenario", ["rich", "temporary"])
+def test_specialized_submit_contexts_delegate_to_existing_authority_chain(
+    tmp_path: Path,
+    scenario: str,
+) -> None:
+    result = _run_node_scenario(tmp_path, scenario)
 
     assert result["ok"] is True
-    assert result["result"]["strategy"] == "prior_rich"
+    assert result["result"]["strategy"] == "prior_specialized"
     assert result["log"] == ["prior_submit"]

--- a/tests/test_text_submit_commit_point_hardening_pr11_3.py
+++ b/tests/test_text_submit_commit_point_hardening_pr11_3.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+EXTENSION = ROOT / "src" / "chatgpt_web_adapter" / "browser_native_extension"
+OVERLAY = EXTENSION / "service_worker_text_submit_commit_hardening_pr11_3.js"
+LOADER = EXTENSION / "service_worker_rich_input_schema7_repair_pr9_2.js"
+
+
+def test_text_submit_hardening_loads_after_rich_authority_before_observation_layers() -> None:
+    text = LOADER.read_text(encoding="utf-8")
+    rich = 'importScripts("service_worker_rich_input_schema29_repair_pr9_2.js");'
+    hardening = 'importScripts("service_worker_text_submit_commit_hardening_pr11_3.js");'
+    observation = 'importScripts("service_worker_product_source_citations_pr9_3.js");'
+    canonical_read = 'importScripts("service_worker_canonical_read.js");'
+
+    assert text.index(rich) < text.index(hardening) < text.index(observation)
+    assert text.index(hardening) < text.index(canonical_read)
+
+
+def test_text_submit_hardening_declares_exact_protected_boundaries() -> None:
+    text = OVERLAY.read_text(encoding="utf-8")
+
+    assert 'PR11_3_TEXT_MOUSE_RELEASE_OUTCOME_UNCONFIRMED' in text
+    assert 'type: "mouseReleased"' in text
+    assert 'type: "keyDown"' in text
+    assert 'type: "keyUp"' in text
+    assert "_pr113IsMouseReleaseOutcomeUnconfirmed(error)" in text
+    assert "throw error;" in text
+    assert "return _pr113SubmitTextWithEnterOnce(debuggee);" in text
+    assert text.index("throw error;") < text.rindex(
+        "return _pr113SubmitTextWithEnterOnce(debuggee);"
+    )
+
+
+def _run_node_scenario(tmp_path: Path, scenario: str) -> dict:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is unavailable; source-contract tests remain active")
+
+    harness = tmp_path / f"pr11_3_{scenario}.js"
+    harness.write_text(
+        """
+const fs = require("fs");
+const overlaySource = fs.readFileSync(process.argv[2], "utf8");
+const scenario = process.argv[3];
+const log = [];
+let _pr92ActiveRichInputContext = null;
+const DEFAULT_SUBMIT_READY_TIMEOUT_MS = 10000;
+
+async function submitOfficialPageTurn() {
+  log.push("prior_submit");
+  return { strategy: "prior_rich", selector: null };
+}
+
+async function waitForSendButtonPoint() {
+  log.push("wait_button");
+  if (scenario === "wait_fail" || scenario === "enter_keyup_fail" || scenario === "enter_keydown_fail") {
+    throw new Error("button-not-ready");
+  }
+  return { x: 10, y: 20, selector: "send-selector" };
+}
+
+async function locateAndFocusComposer() {
+  log.push("focus_composer");
+  return "test";
+}
+
+async function sendCommand(_debuggee, method, params) {
+  const marker = `${method}:${params?.type || "none"}:${params?.key || "none"}`;
+  log.push(marker);
+  if (scenario === "move_fail" && params?.type === "mouseMoved") {
+    throw new Error("move-failed");
+  }
+  if (scenario === "press_fail" && params?.type === "mousePressed") {
+    throw new Error("press-failed");
+  }
+  if (scenario === "release_fail" && params?.type === "mouseReleased") {
+    throw new Error("release-ack-lost");
+  }
+  if (scenario === "enter_keydown_fail" && params?.type === "keyDown" && params?.key === "Enter") {
+    throw new Error("enter-keydown-failed");
+  }
+  if (scenario === "enter_keyup_fail" && params?.type === "keyUp" && params?.key === "Enter") {
+    throw new Error("enter-keyup-failed");
+  }
+  return {};
+}
+
+eval(overlaySource);
+if (scenario === "rich") {
+  _pr92ActiveRichInputContext = { staged: true };
+}
+
+(async () => {
+  try {
+    const result = await submitOfficialPageTurn({}, 1000);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    console.log(JSON.stringify({ ok: true, result, log }));
+  } catch (error) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    console.log(JSON.stringify({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      log
+    }));
+  }
+})();
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [node, str(harness), str(OVERLAY), scenario],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def _enter_keydowns(log: list[str]) -> list[str]:
+    return [item for item in log if item.endswith(":keyDown:Enter")]
+
+
+def test_pre_commit_failures_allow_exactly_one_enter_fallback(tmp_path: Path) -> None:
+    for scenario in ("wait_fail", "move_fail", "press_fail"):
+        result = _run_node_scenario(tmp_path, scenario)
+        assert result["ok"] is True, scenario
+        assert result["result"]["strategy"] == "enter_fallback", scenario
+        assert len(_enter_keydowns(result["log"])) == 1, scenario
+
+
+def test_mouse_release_ack_loss_never_authorizes_enter_retry(tmp_path: Path) -> None:
+    result = _run_node_scenario(tmp_path, "release_fail")
+
+    assert result["ok"] is False
+    assert result["error"] == "PR11_3_TEXT_MOUSE_RELEASE_OUTCOME_UNCONFIRMED"
+    assert len(_enter_keydowns(result["log"])) == 0
+    assert sum("mouseReleased" in item for item in result["log"]) == 1
+
+
+def test_successful_click_uses_one_mouse_commit_and_no_enter(tmp_path: Path) -> None:
+    result = _run_node_scenario(tmp_path, "success")
+
+    assert result["ok"] is True
+    assert result["result"] == {
+        "strategy": "send_button_click",
+        "selector": "send-selector",
+    }
+    assert len(_enter_keydowns(result["log"])) == 0
+    assert sum("mouseReleased" in item for item in result["log"]) == 1
+
+
+def test_enter_keyup_failure_is_post_commit_cleanup_only(tmp_path: Path) -> None:
+    result = _run_node_scenario(tmp_path, "enter_keyup_fail")
+
+    assert result["ok"] is True
+    assert result["result"]["strategy"] == "enter_fallback"
+    assert len(_enter_keydowns(result["log"])) == 1
+
+
+def test_enter_keydown_failure_propagates_without_second_submit(tmp_path: Path) -> None:
+    result = _run_node_scenario(tmp_path, "enter_keydown_fail")
+
+    assert result["ok"] is False
+    assert result["error"] == "enter-keydown-failed"
+    assert len(_enter_keydowns(result["log"])) == 1
+
+
+def test_rich_input_context_delegates_to_existing_authority_chain(tmp_path: Path) -> None:
+    result = _run_node_scenario(tmp_path, "rich")
+
+    assert result["ok"] is True
+    assert result["result"]["strategy"] == "prior_rich"
+    assert result["log"] == ["prior_submit"]


### PR DESCRIPTION
## Purpose

Harden the ordinary text-only browser submit path so ambiguous CDP acknowledgement at either protected submit boundary can never authorize a second submit.

## Problem

The historical ordinary-text helper wraps send-button discovery and the full click sequence in one `try/catch`. A failure while awaiting `mouseReleased` therefore falls into `submitWithEnter()`, even though the page click may already have committed a conversation write. The keyboard fallback also needs the same commit-point semantics at Enter `keyDown`.

## Change

- preserve Enter as a compatibility fallback only before the click commit boundary;
- treat `mouseMoved` / `mousePressed` failures as pre-commit and eligible for one Enter fallback;
- treat the first attempted `mouseReleased` as the click protected-write boundary;
- if the `mouseReleased` acknowledgement is lost/rejected, return `PR11_3_TEXT_MOUSE_RELEASE_OUTCOME_UNCONFIRMED` and never issue Enter;
- treat Enter `keyDown` as the keyboard protected-write boundary;
- if the Enter `keyDown` acknowledgement is lost/rejected, return `PR11_3_TEXT_ENTER_KEYDOWN_OUTCOME_UNCONFIRMED` and never issue a second submit;
- make Enter `keyUp` best-effort cleanup so a post-commit key-up failure cannot turn a possibly committed write into apparent retry authority;
- delegate active rich-input **and Temporary Chat** contexts unchanged to their existing specialized authority chains;
- do not change canonical finality, Browser Authority, product transport selection, or automatic-retry policy.

## Composition

The PR11.3 layer loads after the final PR9.2 rich-input authority generation and before PR9.3 observation / PR11.2 canonical-read overlays. It owns only ordinary browser-owned text submit commit semantics; specialized rich-input and Temporary Chat contexts are explicitly excluded.

## Behavioral proof

The executable Node harness covers:

- send-button readiness failure -> exactly one Enter fallback;
- mouse-move failure -> exactly one Enter fallback;
- mouse-press failure -> exactly one Enter fallback;
- mouse-release ACK loss -> explicit ambiguous outcome, zero Enter retries;
- successful click -> one mouse-release commit, zero Enter submits;
- Enter key-up failure -> committed fallback remains successful;
- Enter key-down ACK loss -> explicit ambiguous outcome, no second submit;
- active rich-input context -> exact delegation to prior authority chain;
- active Temporary Chat context -> exact delegation to prior authority chain.

The existing Python browser-owned runtime already treats a pre-`browser_native_write_completed` adapter failure conservatively as `WRITE_OUTCOME_UNKNOWN`: automatic retry is forbidden, the write may have been submitted, and reconciliation is required.

## Verification

- final head: `39fe497e3dd91511ec3991687e648e5e8c2e6eff`;
- base: `main` at `3ceb12af3aad7b4e7f489a9339a5eb3876e26b4e`;
- `behind_by = 0`;
- CI #758: **success**;
- full Ubuntu + Windows Python 3.10–3.14 test matrix green;
- package/release gates green;
- no unresolved review threads;
- diff limited to 3 files;
- no automatic replay or fallback transport introduced.

## Non-goals

- no submission-ack public API yet (planned separately);
- no canonical-read changes;
- no browserless changes;
- no UI liveness changes.
