### PR TITLE
PR11.6a — Strict ChatGPT Cookie Domain Validation

### DIFF
--- a/src/chatgpt_web_adapter/browser_cookies.py
+++ b/src/chatgpt_web_adapter/browser_cookies.py
@@ -20,6 +20,13 @@ _COOKIE_FIELDS = (
 )
 
 
+def _is_chatgpt_cookie_domain(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    domain = value.strip().lstrip(".").lower()
+    return domain == "chatgpt.com" or domain.endswith(".chatgpt.com")
+
+
 def serialize_browser_cookies(browser_cookies: Any) -> list[dict[str, Any]]:
     """Keep portable CDP cookie attributes without persisting runtime objects."""
 
@@ -31,8 +38,7 @@ def serialize_browser_cookies(browser_cookies: Any) -> list[dict[str, Any]]:
         name = getattr(cookie, "name", None)
         value = getattr(cookie, "value", None)
         if not (
-            isinstance(domain, str)
-            and domain.lstrip(".").lower().endswith("chatgpt.com")
+            _is_chatgpt_cookie_domain(domain)
             and isinstance(name, str)
             and isinstance(value, str)
         ):
@@ -79,8 +85,7 @@ def flatten_browser_cookies(records: Any) -> dict[str, str]:
         if (
             isinstance(name, str)
             and isinstance(value, str)
-            and isinstance(domain, str)
-            and domain.lstrip(".").lower().endswith("chatgpt.com")
+            and _is_chatgpt_cookie_domain(domain)
         ):
             cookies[name] = value
     return cookies
@@ -103,7 +108,10 @@ def browser_cookie_params(
             name = record.get("name")
             value = record.get("value")
             domain = record.get("domain")
-            if not all(isinstance(item, str) and item for item in (name, value, domain)):
+            if not (
+                all(isinstance(item, str) and item for item in (name, value, domain))
+                and _is_chatgpt_cookie_domain(domain)
+            ):
                 continue
             kwargs: dict[str, Any] = {
                 "name": name,

--- a/tests/test_browser_cookies.py
+++ b/tests/test_browser_cookies.py
@@ -46,6 +46,35 @@ def test_browser_cookie_round_trip_preserves_scope() -> None:
     assert flatten_browser_cookies(records) == {"session.0": "chunk"}
 
 
+def test_browser_cookie_domain_validation_rejects_lookalikes() -> None:
+    records = serialize_browser_cookies(
+        [
+            SimpleNamespace(name="exact", value="ok", domain="chatgpt.com"),
+            SimpleNamespace(name="subdomain", value="ok", domain=".auth.chatgpt.com"),
+            SimpleNamespace(name="prefix-lookalike", value="bad", domain="evilchatgpt.com"),
+            SimpleNamespace(
+                name="suffix-lookalike",
+                value="bad",
+                domain="chatgpt.com.evil.example",
+            ),
+        ]
+    )
+
+    assert [record["name"] for record in records] == ["exact", "subdomain"]
+    assert flatten_browser_cookies(
+        [
+            {"name": "exact", "value": "ok", "domain": "chatgpt.com"},
+            {"name": "subdomain", "value": "ok", "domain": ".auth.chatgpt.com"},
+            {"name": "prefix-lookalike", "value": "bad", "domain": "evilchatgpt.com"},
+            {
+                "name": "suffix-lookalike",
+                "value": "bad",
+                "domain": "chatgpt.com.evil.example",
+            },
+        ]
+    ) == {"exact": "ok", "subdomain": "ok"}
+
+
 def test_cookie_params_prefer_structured_records() -> None:
     network = SimpleNamespace(
         CookieParam=lambda **kwargs: kwargs,
@@ -78,6 +107,43 @@ def test_cookie_params_prefer_structured_records() -> None:
             "secure": True,
             "http_only": True,
             "expires": 1234.0,
+        }
+    ]
+
+
+def test_cookie_params_reject_lookalike_structured_domains() -> None:
+    network = SimpleNamespace(
+        CookieParam=lambda **kwargs: kwargs,
+        TimeSinceEpoch=float,
+    )
+    cdp = SimpleNamespace(network=network)
+
+    params = browser_cookie_params(
+        cdp,
+        [
+            {
+                "name": "poisoned",
+                "value": "bad",
+                "domain": "evilchatgpt.com",
+                "path": "/",
+            },
+            {
+                "name": "also-poisoned",
+                "value": "bad",
+                "domain": "chatgpt.com.evil.example",
+                "path": "/",
+            },
+        ],
+        {"safe-fallback": "value"},
+    )
+
+    assert params == [
+        {
+            "name": "safe-fallback",
+            "value": "value",
+            "url": "https://chatgpt.com/",
+            "secure": True,
+            "expires": None,
         }
     ]
 


### PR DESCRIPTION
## Purpose

Close a cookie-domain validation bug identified while reviewing external PR #67 from Snidget.

The existing helper logic accepted any domain whose normalized text ended with `chatgpt.com`, which incorrectly includes lookalikes such as `evilchatgpt.com`.

Thanks to @Snidget for surfacing the defect in #67.

## Change

Introduce one internal exact-domain predicate:

- allow `chatgpt.com`;
- allow true subdomains such as `.auth.chatgpt.com`;
- reject prefix lookalikes such as `evilchatgpt.com`;
- reject suffix lookalikes such as `chatgpt.com.evil.example`.

Apply the predicate at all structured-cookie trust boundaries:

1. browser cookie serialization;
2. flattening structured records into the HTTP cookie map;
3. reconstructing structured cookie records into CDP `CookieParam` objects.

The third boundary intentionally goes beyond the minimal change in #67: an old or manually edited auth file must not be able to reintroduce a foreign-domain cookie through the restore path.

## Verification

Focused tests cover exact domain, real subdomain, both lookalike classes, and safe fallback when all structured records are rejected.

## Scope

- no current-Chrome credential capture;
- no auth API changes;
- no browser runtime changes;
- no retry/finality changes;
- no merge of PR #67 as part of this PR.