### PR TITLE
PR11.7 — UI Drift Compatibility Pack

### DIFF
--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_rich_input_schema7_repair_pr9_2.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_rich_input_schema7_repair_pr9_2.js
@@ -32,6 +32,10 @@ importScripts("service_worker_rich_input_schema28_repair_pr9_2.js");
 importScripts("service_worker_rich_input_schema28_diagnostic_repair_pr9_2.js");
 importScripts("service_worker_rich_input_schema29_repair_pr9_2.js");
 
+// PR11.7 provides shared, bounded UI-drift discovery only. It owns no write
+// dispatch; PR11.3 remains the ordinary-text protected-submit authority layer.
+importScripts("service_worker_ui_compat_pr11_7.js");
+
 // PR11.3 text-only write-boundary hardening. This layer delegates active rich
 // contexts to the complete PR9.2 chain above and only removes post-mouse-release
 // fallback/retry authority from ordinary text submission.

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
@@ -37,7 +37,7 @@ function _pr113IsMouseReleaseOutcomeUnconfirmed(error) {
 }
 
 async function _pr113SubmitTextWithEnterOnce(debuggee) {
-  await locateAndFocusComposer(debuggee);
+  await _pr117LocateAndFocusComposer(debuggee);
 
   // Enter keyDown is the keyboard protected-write boundary. A rejected/lost CDP
   // ACK can coexist with a real keyDown, so the attempt itself is ambiguous and
@@ -123,7 +123,7 @@ submitOfficialPageTurn = async function _pr113SubmitOfficialTextWithoutPostCommi
 
   let point = null;
   try {
-    point = await waitForSendButtonPoint(
+    point = await _pr117WaitForSendButtonPoint(
       debuggee,
       Math.min(timeoutMs, DEFAULT_SUBMIT_READY_TIMEOUT_MS)
     );

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_text_submit_commit_hardening_pr11_3.js
@@ -36,8 +36,22 @@ function _pr113IsMouseReleaseOutcomeUnconfirmed(error) {
   );
 }
 
+async function _pr113LocateComposerForTextSubmit(debuggee) {
+  if (typeof _pr117LocateAndFocusComposer === "function") {
+    return _pr117LocateAndFocusComposer(debuggee);
+  }
+  return locateAndFocusComposer(debuggee);
+}
+
+async function _pr113WaitForSubmitPoint(debuggee, timeoutMs) {
+  if (typeof _pr117WaitForSendButtonPoint === "function") {
+    return _pr117WaitForSendButtonPoint(debuggee, timeoutMs);
+  }
+  return waitForSendButtonPoint(debuggee, timeoutMs);
+}
+
 async function _pr113SubmitTextWithEnterOnce(debuggee) {
-  await _pr117LocateAndFocusComposer(debuggee);
+  await _pr113LocateComposerForTextSubmit(debuggee);
 
   // Enter keyDown is the keyboard protected-write boundary. A rejected/lost CDP
   // ACK can coexist with a real keyDown, so the attempt itself is ambiguous and
@@ -123,7 +137,7 @@ submitOfficialPageTurn = async function _pr113SubmitOfficialTextWithoutPostCommi
 
   let point = null;
   try {
-    point = await _pr117WaitForSendButtonPoint(
+    point = await _pr113WaitForSubmitPoint(
       debuggee,
       Math.min(timeoutMs, DEFAULT_SUBMIT_READY_TIMEOUT_MS)
     );

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_ui_compat_pr11_7.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_ui_compat_pr11_7.js
@@ -3,8 +3,8 @@
 // This module owns no turn dispatch, submit action, Browser Authority, retry,
 // navigation, or canonical-finality semantics. It only broadens bounded DOM
 // discovery used by already-governed consumers when historical selectors fail.
-// Generic contenteditable elements are accepted only with structural textbox /
-// composer evidence; an arbitrary visible editor is never enough.
+// Generic contenteditable elements are accepted only with structural composer
+// evidence; an arbitrary visible editor is never enough.
 
 const PR117_UI_COMPAT_SCHEMA = 1;
 
@@ -28,12 +28,16 @@ function _pr117ComposerResolverSource() {
       return true;
     };
     const structuralGenericEvidence = (element) => {
-      if (element.getAttribute('role') === 'textbox') return true;
-      if (element.getAttribute('aria-multiline') === 'true') return true;
-      if (element.closest('form')) return true;
       if (element.closest('[data-testid*="composer"]')) return true;
       const testId = String(element.getAttribute('data-testid') || '').toLowerCase();
-      return testId.includes('composer') || testId.includes('prompt');
+      if (testId.includes('composer') || testId.includes('prompt')) return true;
+
+      const form = element.closest('form');
+      if (!form) return false;
+      const scopedSubmitControls = form.querySelectorAll(
+        'button[type="submit"],button[data-testid*="send"],button[data-testid*="submit"]'
+      );
+      return scopedSubmitControls.length > 0;
     };
     const score = (element) => {
       let value = 0;
@@ -185,6 +189,7 @@ function _pr117StructuralSubmitPointExpression() {
       const testId = String(button.getAttribute('data-testid') || '').toLowerCase();
       return testId.includes('send') || testId.includes('submit');
     });
+    if (semantic.length > 1) return null;
     const candidates = semantic.length === 1
       ? semantic
       : all.filter((button) => button.getAttribute('type') === 'submit');

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_ui_compat_pr11_7.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_ui_compat_pr11_7.js
@@ -1,0 +1,233 @@
+// PR11.7 shared UI-drift compatibility helpers.
+//
+// This module owns no turn dispatch, submit action, Browser Authority, retry,
+// navigation, or canonical-finality semantics. It only broadens bounded DOM
+// discovery used by already-governed consumers when historical selectors fail.
+// Generic contenteditable elements are accepted only with structural textbox /
+// composer evidence; an arbitrary visible editor is never enough.
+
+const PR117_UI_COMPAT_SCHEMA = 1;
+
+function _pr117ComposerResolverSource() {
+  return `() => {
+    const visible = (element) => {
+      if (!(element instanceof Element)) return false;
+      const rect = element.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = getComputedStyle(element);
+      return style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        style.opacity !== '0';
+    };
+    const writable = (element) => {
+      if (!(element instanceof Element)) return false;
+      if (element.getAttribute('aria-disabled') === 'true') return false;
+      if (element.disabled === true || element.readOnly === true) return false;
+      if (element.hasAttribute('contenteditable') &&
+          element.getAttribute('contenteditable') !== 'true') return false;
+      return true;
+    };
+    const structuralGenericEvidence = (element) => {
+      if (element.getAttribute('role') === 'textbox') return true;
+      if (element.getAttribute('aria-multiline') === 'true') return true;
+      if (element.closest('form')) return true;
+      if (element.closest('[data-testid*="composer"]')) return true;
+      const testId = String(element.getAttribute('data-testid') || '').toLowerCase();
+      return testId.includes('composer') || testId.includes('prompt');
+    };
+    const score = (element) => {
+      let value = 0;
+      if (element.id === 'prompt-textarea') value += 1000;
+      if (element.getAttribute('data-lexical-editor') === 'true') value += 900;
+      if (element.matches('textarea[placeholder]')) value += 800;
+      if (element.getAttribute('contenteditable') === 'true') value += 500;
+      if (element.getAttribute('role') === 'textbox') value += 120;
+      if (element.getAttribute('aria-multiline') === 'true') value += 100;
+      if (element.closest('form')) value += 120;
+      if (element.closest('[data-testid*="composer"]')) value += 120;
+      return value;
+    };
+
+    const selectors = [
+      '#prompt-textarea',
+      '[contenteditable="true"][data-lexical-editor="true"]',
+      'textarea[placeholder]',
+      '[contenteditable="true"]'
+    ];
+    const seen = new Set();
+    const candidates = [];
+    let order = 0;
+    for (const selector of selectors) {
+      for (const element of document.querySelectorAll(selector)) {
+        if (seen.has(element)) continue;
+        seen.add(element);
+        if (!visible(element) || !writable(element)) continue;
+        const genericOnly = (
+          element.getAttribute('contenteditable') === 'true' &&
+          element.id !== 'prompt-textarea' &&
+          element.getAttribute('data-lexical-editor') !== 'true'
+        );
+        if (genericOnly && !structuralGenericEvidence(element)) continue;
+        candidates.push({ element, score: score(element), order });
+        order += 1;
+      }
+    }
+    candidates.sort((left, right) =>
+      right.score - left.score || right.order - left.order
+    );
+    return candidates[0]?.element || null;
+  }`;
+}
+
+function _pr117ComposerReadinessExpression() {
+  const resolver = _pr117ComposerResolverSource();
+  return `(() => {
+    const resolveComposer = ${resolver};
+    const composer = resolveComposer();
+    if (!composer) return { ready: false, reason: 'composer_missing' };
+
+    const visible = (element) => {
+      if (!(element instanceof Element)) return false;
+      const rect = element.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = getComputedStyle(element);
+      return style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        style.opacity !== '0';
+    };
+    const stopSelectors = [
+      '[data-testid="stop-button"]',
+      '[data-testid="stop-generating-button"]',
+      'button[aria-label*="Stop generating"]',
+      'button[aria-label*="Остановить"]'
+    ];
+    const stopVisible = stopSelectors.some((selector) =>
+      visible(document.querySelector(selector))
+    );
+    const busy = composer.getAttribute('aria-busy') === 'true' ||
+      composer.getAttribute('contenteditable') === 'false' ||
+      composer.disabled === true;
+    return {
+      ready: !stopVisible && !busy,
+      reason: stopVisible
+        ? 'generation_control_visible'
+        : (busy ? 'composer_busy' : 'ready')
+    };
+  })()`;
+}
+
+async function _pr117QueryComposerReadiness(debuggee) {
+  try {
+    const historical = await queryComposerReadiness(debuggee);
+    if (historical?.reason !== 'composer_missing') return historical;
+  } catch {
+    // Fall through to the bounded structural compatibility probe.
+  }
+
+  const result = await sendCommand(debuggee, 'Runtime.evaluate', {
+    expression: _pr117ComposerReadinessExpression(),
+    returnByValue: true,
+    awaitPromise: true
+  });
+  return result?.result?.value || { ready: false, reason: 'unknown' };
+}
+
+async function _pr117LocateAndFocusComposer(debuggee) {
+  try {
+    return await locateAndFocusComposer(debuggee);
+  } catch {
+    // Historical AX/selector discovery failed; use the structural fallback only.
+  }
+
+  const resolver = _pr117ComposerResolverSource();
+  const result = await sendCommand(debuggee, 'Runtime.evaluate', {
+    expression: `(() => {
+      const resolveComposer = ${resolver};
+      const composer = resolveComposer();
+      if (!composer) return false;
+      composer.focus();
+      return true;
+    })()`,
+    returnByValue: true,
+    awaitPromise: true
+  });
+  if (!result?.result?.value) throw new Error('CHATGPT_COMPOSER_NOT_FOUND');
+  return 'pr11_7_structural_dom_fallback';
+}
+
+function _pr117StructuralSubmitPointExpression() {
+  const resolver = _pr117ComposerResolverSource();
+  return `(() => {
+    const resolveComposer = ${resolver};
+    const composer = resolveComposer();
+    if (!composer) return null;
+    const scope = composer.closest('form') ||
+      composer.closest('[data-testid*="composer"]');
+    if (!scope) return null;
+
+    const usable = (button) => {
+      if (!(button instanceof Element)) return false;
+      const rect = button.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = getComputedStyle(button);
+      const disabled = button.disabled === true ||
+        button.getAttribute('aria-disabled') === 'true';
+      return !disabled &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        style.opacity !== '0' &&
+        style.pointerEvents !== 'none';
+    };
+    const all = Array.from(scope.querySelectorAll(
+      'button[type="submit"],button[data-testid*="send"],button[data-testid*="submit"]'
+    )).filter(usable);
+    const semantic = all.filter((button) => {
+      const testId = String(button.getAttribute('data-testid') || '').toLowerCase();
+      return testId.includes('send') || testId.includes('submit');
+    });
+    const candidates = semantic.length === 1
+      ? semantic
+      : all.filter((button) => button.getAttribute('type') === 'submit');
+    if (candidates.length !== 1) return null;
+    const button = candidates[0];
+    const rect = button.getBoundingClientRect();
+    return {
+      selector: 'pr11_7_structural_submit_control',
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2
+    };
+  })()`;
+}
+
+async function _pr117QuerySendButtonPoint(debuggee) {
+  try {
+    const historical = await querySendButtonPoint(debuggee);
+    if (historical && Number.isFinite(historical.x) && Number.isFinite(historical.y)) {
+      return historical;
+    }
+  } catch {
+    // Fall through to the bounded structural submit-control probe.
+  }
+
+  const result = await sendCommand(debuggee, 'Runtime.evaluate', {
+    expression: _pr117StructuralSubmitPointExpression(),
+    returnByValue: true,
+    awaitPromise: true
+  });
+  const point = result?.result?.value || null;
+  if (!point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) return null;
+  return point;
+}
+
+async function _pr117WaitForSendButtonPoint(
+  debuggee,
+  timeoutMs = DEFAULT_SUBMIT_READY_TIMEOUT_MS
+) {
+  const startedAt = performance.now();
+  while (elapsedMs(startedAt) < timeoutMs) {
+    const point = await _pr117QuerySendButtonPoint(debuggee);
+    if (point) return point;
+    await sleep(100);
+  }
+  throw new Error('CHATGPT_SEND_BUTTON_NOT_READY');
+}

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_ui_liveness.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_ui_liveness.js
@@ -127,7 +127,7 @@ async function _cwaObserveUiLiveness() {
     }
     await chrome.debugger.sendCommand(debuggee, "Runtime.enable");
     try {
-      const readiness = await queryComposerReadiness(debuggee);
+      const readiness = await _pr117QueryComposerReadiness(debuggee);
       observation = _cwaUiLivenessFromComposerReadiness(readiness);
     } catch {
       observation = _cwaUiLivenessBase("UNKNOWN", "READINESS_PROBE_FAILED", {

--- a/tests/test_browser_ui_liveness_worker_pr11_5.py
+++ b/tests/test_browser_ui_liveness_worker_pr11_5.py
@@ -16,7 +16,7 @@ def test_liveness_worker_wraps_native_messages_without_wrapping_turn_dispatch() 
     assert 'message?.type !== "ui_liveness"' in source
     assert "onNativeMessage = async function" in source
     assert "executeNativeTurn =" not in source
-    assert "queryComposerReadiness(debuggee)" in source
+    assert "_pr117QueryComposerReadiness(debuggee)" in source
 
 
 def test_liveness_worker_requires_positive_generating_evidence() -> None:

--- a/tests/test_ui_drift_compatibility_pr11_7.py
+++ b/tests/test_ui_drift_compatibility_pr11_7.py
@@ -54,7 +54,8 @@ def test_compatibility_pack_loads_after_rich_authority_before_text_hardening() -
     assert loader.index(hardening) < loader.index(observation)
 
 
-def test_existing_consumers_use_shared_compatibility_without_changing_ownership() -> None:
+def test_existing_consumers_use_shared_compatibility_without_changing_ownership(
+) -> None:
     hardening = TEXT_HARDENING.read_text(encoding="utf-8")
     liveness = LIVENESS.read_text(encoding="utf-8")
 

--- a/tests/test_ui_drift_compatibility_pr11_7.py
+++ b/tests/test_ui_drift_compatibility_pr11_7.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+EXT = ROOT / "src" / "chatgpt_web_adapter" / "browser_native_extension"
+COMPAT = EXT / "service_worker_ui_compat_pr11_7.js"
+LOADER = EXT / "service_worker_rich_input_schema7_repair_pr9_2.js"
+TEXT_HARDENING = EXT / "service_worker_text_submit_commit_hardening_pr11_3.js"
+LIVENESS = EXT / "service_worker_ui_liveness.js"
+
+
+def test_compatibility_pack_is_shared_discovery_not_new_authority_layer() -> None:
+    source = COMPAT.read_text(encoding="utf-8")
+
+    assert "PR117_UI_COMPAT_SCHEMA = 1" in source
+    assert '[contenteditable="true"]' in source
+    assert "structuralGenericEvidence" in source
+    assert "genericOnly && !structuralGenericEvidence(element)" in source
+    assert "element.getAttribute('role') === 'textbox'" in source
+    assert "element.getAttribute('aria-multiline') === 'true'" in source
+    assert "element.closest('form')" in source
+    assert "candidates.length !== 1" in source
+    assert "pr11_7_structural_submit_control" in source
+
+    for forbidden in (
+        "submitOfficialPageTurn =",
+        "executeNativeTurn =",
+        "onNativeMessage =",
+        "Input.dispatchKeyEvent",
+        "Input.dispatchMouseEvent",
+        "Input.insertText",
+        "DOM.setFileInputFiles",
+        "chrome.tabs.create",
+        "chrome.tabs.update",
+        "fetch(",
+    ):
+        assert forbidden not in source
+
+
+def test_compatibility_pack_loads_after_rich_authority_before_text_hardening() -> None:
+    loader = LOADER.read_text(encoding="utf-8")
+    rich = 'importScripts("service_worker_rich_input_schema29_repair_pr9_2.js");'
+    compat = 'importScripts("service_worker_ui_compat_pr11_7.js");'
+    hardening = 'importScripts("service_worker_text_submit_commit_hardening_pr11_3.js");'
+    observation = 'importScripts("service_worker_product_source_citations_pr9_3.js");'
+
+    assert loader.index(rich) < loader.index(compat) < loader.index(hardening)
+    assert loader.index(hardening) < loader.index(observation)
+
+
+def test_existing_consumers_use_shared_compatibility_without_changing_ownership() -> None:
+    hardening = TEXT_HARDENING.read_text(encoding="utf-8")
+    liveness = LIVENESS.read_text(encoding="utf-8")
+
+    assert "_pr117LocateAndFocusComposer" in hardening
+    assert "_pr117WaitForSendButtonPoint" in hardening
+    assert "_pr92ActiveRichInputContext" in hardening
+    assert "_pr813TemporaryTurnContext" in hardening
+    assert "_pr117QueryComposerReadiness(debuggee)" in liveness
+    assert "executeNativeTurn =" not in liveness
+
+
+def _run_node_scenario(tmp_path: Path, scenario: str) -> dict:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is unavailable; source-contract tests remain active")
+
+    harness = tmp_path / f"pr11_7_{scenario}.js"
+    harness.write_text(
+        """
+const fs = require("fs");
+const vm = require("vm");
+const source = fs.readFileSync(process.argv[2], "utf8");
+const scenario = process.argv[3];
+const log = [];
+let now = 0;
+
+const context = {
+  console,
+  Number,
+  Error,
+  Promise,
+  performance: { now: () => now },
+  DEFAULT_SUBMIT_READY_TIMEOUT_MS: 1000,
+  elapsedMs: (startedAt) => now - startedAt,
+  sleep: async (ms) => { now += ms; },
+  queryComposerReadiness: async () => {
+    log.push("historical_readiness");
+    if (scenario === "historical_ready") return { ready: true, reason: "ready" };
+    return { ready: false, reason: "composer_missing" };
+  },
+  locateAndFocusComposer: async () => {
+    log.push("historical_focus");
+    if (scenario === "focus_fallback") throw new Error("historical-miss");
+    return "historical";
+  },
+  querySendButtonPoint: async () => {
+    log.push("historical_submit_point");
+    if (scenario === "historical_submit") {
+      return { x: 4, y: 5, selector: "historical" };
+    }
+    return null;
+  },
+  sendCommand: async (_debuggee, method, params) => {
+    log.push(`compat:${method}`);
+    const expression = String(params?.expression || "");
+    if (scenario === "focus_fallback") {
+      return { result: { value: true } };
+    }
+    if (scenario === "structural_submit") {
+      return {
+        result: {
+          value: { x: 10, y: 20, selector: "pr11_7_structural_submit_control" }
+        }
+      };
+    }
+    return { result: { value: { ready: true, reason: "ready" } } };
+  }
+};
+context.globalThis = context;
+vm.createContext(context);
+vm.runInContext(
+  source + `\n;globalThis.__exports = {\n` +
+    `queryReadiness: _pr117QueryComposerReadiness,\n` +
+    `focusComposer: _pr117LocateAndFocusComposer,\n` +
+    `querySubmitPoint: _pr117QuerySendButtonPoint\n` +
+  `};`,
+  context
+);
+
+(async () => {
+  let result;
+  if (scenario === "historical_ready" || scenario === "structural_readiness") {
+    result = await context.__exports.queryReadiness({});
+  } else if (scenario === "focus_fallback") {
+    result = await context.__exports.focusComposer({});
+  } else {
+    result = await context.__exports.querySubmitPoint({});
+  }
+  console.log(JSON.stringify({ result, log }));
+})();
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [node, str(harness), str(COMPAT), scenario],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def test_historical_composer_evidence_short_circuits_compatibility_probe(
+    tmp_path: Path,
+) -> None:
+    result = _run_node_scenario(tmp_path, "historical_ready")
+
+    assert result["result"] == {"ready": True, "reason": "ready"}
+    assert result["log"] == ["historical_readiness"]
+
+
+def test_composer_missing_uses_one_bounded_structural_probe(tmp_path: Path) -> None:
+    result = _run_node_scenario(tmp_path, "structural_readiness")
+
+    assert result["result"] == {"ready": True, "reason": "ready"}
+    assert result["log"] == ["historical_readiness", "compat:Runtime.evaluate"]
+
+
+def test_historical_submit_control_short_circuits_structural_fallback(
+    tmp_path: Path,
+) -> None:
+    result = _run_node_scenario(tmp_path, "historical_submit")
+
+    assert result["result"] == {"x": 4, "y": 5, "selector": "historical"}
+    assert result["log"] == ["historical_submit_point"]
+
+
+def test_structural_submit_fallback_requires_explicit_compatibility_probe(
+    tmp_path: Path,
+) -> None:
+    result = _run_node_scenario(tmp_path, "structural_submit")
+
+    assert result["result"] == {
+        "x": 10,
+        "y": 20,
+        "selector": "pr11_7_structural_submit_control",
+    }
+    assert result["log"] == ["historical_submit_point", "compat:Runtime.evaluate"]
+
+
+def test_focus_fallback_runs_only_after_historical_discovery_failure(
+    tmp_path: Path,
+) -> None:
+    result = _run_node_scenario(tmp_path, "focus_fallback")
+
+    assert result["result"] == "pr11_7_structural_dom_fallback"
+    assert result["log"] == ["historical_focus", "compat:Runtime.evaluate"]


### PR DESCRIPTION
## Purpose

Add one shared, bounded compatibility vocabulary for ordinary ChatGPT UI drift without creating another write-authority overlay.

Design input: `znanshan/chatgpt-web-adapter` commits `fa357d5319d59c365ca9a5c69a96b688dd2e3c79` and `5502b9e50c165a2e3f18a3f10ecdc0120dbd1363`, which independently showed that the current composer may be a generic `contenteditable` element rather than carrying the historical Lexical attribute.

## Compatibility boundary

The new `service_worker_ui_compat_pr11_7.js` is a shared discovery helper only. It does not wrap or replace:

- `executeNativeTurn`;
- `submitOfficialPageTurn`;
- `onNativeMessage`.

It contains no key/mouse/text/file-input dispatch, no browser navigation/runtime-tab creation, no fetch/canonical read, and no retry/finality authority.

## Composer drift

Historical strong selectors remain first. Generic `[contenteditable="true"]` is a final fallback and is accepted only with stronger composer structure: either explicit composer/prompt identity or a containing form with a submit-like control. Textbox/multiline semantics may improve candidate ranking but are not sufficient by themselves. Arbitrary visible editors are rejected.

Historical AX/DOM composer discovery remains preferred; the structural fallback runs only after it fails.

## Submit-control drift

Historical send-button discovery remains preferred. The structural fallback is scoped to the resolved composer form/composer container and returns a click point only when exactly one usable semantic/send/submit control can be identified. Multiple semantic candidates or otherwise ambiguous controls return no point and therefore do not acquire click authority.

PR11.3 still owns the protected mouseReleased / Enter keyDown commit boundaries and all no-replay semantics.

## Liveness

PR11.5 now consumes the same compatibility readiness helper so liveness and ordinary text submission do not disagree merely because the composer lost a historical attribute. UI liveness remains observation-only and continues to grant no write, retry, or canonical-finality authority.

## Tests

Added source-contract and Node behavioral coverage proving:

- generic contenteditable requires structural composer evidence;
- the compatibility module owns no turn/submit/message wrapper;
- historical composer evidence short-circuits fallback probing;
- historical send-control evidence short-circuits structural fallback;
- structural probes run only after historical misses;
- PR11.3 remains the write owner;
- rich-input and Temporary Chat context delegation remains intact.

## Scope

This is the final drift-hardening PR before PR12.0 browser-runtime consolidation. It intentionally does not consolidate the historical rich-input/service-worker overlay chain.

## Final verification

Exact head: `9da8dca6723d59d27c36c86742168b49a5449a29`.

CI #801 / run `33684738883`: **SUCCESS**.

- Ubuntu + Windows × Python 3.10–3.14: **10/10 green**;
- representative Ubuntu/Python 3.11 result: **2043 passed, 1 existing warning**;
- build wheel + sdist: **green**;
- package metadata + release artifact contract: **green**;
- exact installed-wheel smoke: **4/4 green**;
- `behind_by = 0` against current `main`;
- standalone diff: **6 files**;
- manifest and historical extension entrypoint unchanged;
- reviews: **0**;
- review threads: **0**.