### PR TITLE
PR12.1 — Engineering Quality Baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,22 +34,16 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[test]
 
-      - name: Ruff lint
-        run: python -m ruff check src tests tools
-
-      - name: Ruff format
-        run: python -m ruff format --check src tests tools
+      - name: Ruff delta quality and architecture debt
+        env:
+          QUALITY_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: python tools/engineering_quality_gate.py --base-ref "$QUALITY_BASE_SHA"
 
       - name: Compile Python sources
         run: python -m compileall -q src tests tools
 
       - name: Validate extension JavaScript syntax
         run: python tools/check_extension_js_syntax.py
-
-      - name: Prevent new research-era architecture debt
-        env:
-          QUALITY_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-        run: python tools/engineering_quality_gate.py --base-ref "$QUALITY_BASE_SHA"
 
   tests:
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  quality:
+    name: Engineering quality
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install package and quality tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[test]
+
+      - name: Ruff lint
+        run: python -m ruff check src tests tools
+
+      - name: Ruff format
+        run: python -m ruff format --check src tests tools
+
+      - name: Compile Python sources
+        run: python -m compileall -q src tests tools
+
+      - name: Validate extension JavaScript syntax
+        run: python tools/check_extension_js_syntax.py
+
+      - name: Prevent new research-era architecture debt
+        env:
+          QUALITY_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: python tools/engineering_quality_gate.py --base-ref "$QUALITY_BASE_SHA"
+
   tests:
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
@@ -51,6 +88,7 @@ jobs:
     name: Build release artifacts
     runs-on: ubuntu-latest
     needs:
+      - quality
       - tests
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,10 @@ Security = "https://github.com/kymuco/chatgpt-web-adapter/blob/main/SECURITY.md"
 Releases = "https://github.com/kymuco/chatgpt-web-adapter/releases"
 
 [project.optional-dependencies]
-test = ["pytest>=8"]
+test = [
+  "pytest>=8",
+  "ruff>=0.11",
+]
 browser = ["zendriver==0.15.3"]
 
 [project.scripts]
@@ -69,3 +72,25 @@ chatgpt_web_adapter = [
   "browser_native_extension/*.css",
   "browser_native_extension/*.png",
 ]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+extend-exclude = [
+  "build",
+  "dist",
+]
+
+[tool.ruff.lint]
+select = [
+  "E4",
+  "E7",
+  "E9",
+  "F",
+  "I",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"

--- a/tools/check_extension_js_syntax.py
+++ b/tools/check_extension_js_syntax.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXTENSION = ROOT / "src" / "chatgpt_web_adapter" / "browser_native_extension"
+
+
+def main() -> int:
+    node = shutil.which("node")
+    if node is None:
+        raise SystemExit("Node.js is required for extension syntax validation")
+
+    files = sorted(EXTENSION.glob("*.js"))
+    if not files:
+        raise SystemExit("no extension JavaScript files found")
+
+    for path in files:
+        subprocess.run(
+            [node, "--check", str(path)],
+            check=True,
+            cwd=ROOT,
+        )
+
+    print(f"validated JavaScript syntax for {len(files)} extension files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_extension_js_syntax.py
+++ b/tools/check_extension_js_syntax.py
@@ -4,7 +4,6 @@ import shutil
 import subprocess
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 EXTENSION = ROOT / "src" / "chatgpt_web_adapter" / "browser_native_extension"
 

--- a/tools/engineering_quality_gate.py
+++ b/tools/engineering_quality_gate.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import argparse
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+QUALITY_ROOTS = ("src", "tests", "tools")
 PRODUCTION_PREFIX = "src/chatgpt_web_adapter/"
 LEGACY_PRODUCTION_NAME = re.compile(r"(?:_pr\d+|repair)", re.IGNORECASE)
 MODULE_ATTRIBUTE_ASSIGNMENT = re.compile(
@@ -33,6 +35,44 @@ def _resolve_base_ref(value: str | None) -> str:
     if candidate and set(candidate) != {"0"}:
         return candidate
     return "HEAD^"
+
+
+def _changed_python_files(base_ref: str) -> list[str]:
+    output = _git(
+        "diff",
+        "--name-only",
+        "--diff-filter=ACMR",
+        f"{base_ref}...HEAD",
+        "--",
+        *QUALITY_ROOTS,
+    )
+    paths = [line.strip() for line in output.splitlines() if line.strip()]
+    return [
+        path
+        for path in paths
+        if Path(path).suffix.lower() == ".py" and (ROOT / path).is_file()
+    ]
+
+
+def _run_python_quality(files: list[str]) -> bool:
+    if not files:
+        print("ruff delta gate passed: no changed Python files")
+        return True
+
+    print("ruff delta gate targets:")
+    for path in files:
+        print(f"- {path}")
+
+    commands = (
+        [sys.executable, "-m", "ruff", "check", *files],
+        [sys.executable, "-m", "ruff", "format", "--check", *files],
+    )
+    passed = True
+    for command in commands:
+        completed = subprocess.run(command, cwd=ROOT, check=False)
+        if completed.returncode != 0:
+            passed = False
+    return passed
 
 
 def _added_production_files(base_ref: str) -> list[str]:
@@ -80,7 +120,10 @@ def _new_import_time_mutations(base_ref: str) -> list[str]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Prevent new research-era production topology and import-time mutation debt."
+        description=(
+            "Require changed Python files to be Ruff-clean and prevent new "
+            "research-era production topology or import-time mutation debt."
+        )
     )
     parser.add_argument(
         "--base-ref",
@@ -90,10 +133,14 @@ def main() -> int:
     args = parser.parse_args()
     base_ref = _resolve_base_ref(args.base_ref)
 
+    python_quality_passed = _run_python_quality(_changed_python_files(base_ref))
+
     violations: list[str] = []
     for path in _added_production_files(base_ref):
         suffix = Path(path).suffix.lower()
-        if suffix in {".py", ".js"} and LEGACY_PRODUCTION_NAME.search(Path(path).name):
+        if suffix in {".py", ".js"} and LEGACY_PRODUCTION_NAME.search(
+            Path(path).name
+        ):
             violations.append(
                 f"new production module uses research-era PR/repair naming: {path}"
             )
@@ -102,18 +149,20 @@ def main() -> int:
         violations.append(f"new module-level runtime mutation: {mutation}")
 
     if violations:
-        print("engineering quality gate failed:")
+        print("engineering architecture debt gate failed:")
         for violation in violations:
             print(f"- {violation}")
         print(
             "Existing legacy debt is grandfathered, but new debt is blocked. "
             "Refactor through explicit composition instead."
         )
+
+    if not python_quality_passed or violations:
         return 1
 
     print(
-        "engineering quality gate passed: no new PR/repair-named production modules "
-        "or module-level runtime mutation debt"
+        "engineering quality gate passed: changed Python is Ruff-clean and no new "
+        "PR/repair-named production modules or module-level runtime mutation debt"
     )
     return 0
 

--- a/tools/engineering_quality_gate.py
+++ b/tools/engineering_quality_gate.py
@@ -6,14 +6,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 QUALITY_ROOTS = ("src", "tests", "tools")
 PRODUCTION_PREFIX = "src/chatgpt_web_adapter/"
 LEGACY_PRODUCTION_NAME = re.compile(r"(?:_pr\d+|repair)", re.IGNORECASE)
-MODULE_ATTRIBUTE_ASSIGNMENT = re.compile(
-    r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+\s*="
-)
+MODULE_ATTRIBUTE_ASSIGNMENT = re.compile(r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+\s*=")
 TOP_LEVEL_SETATTR = re.compile(r"^setattr\(")
 TOP_LEVEL_INSTALL = re.compile(r"^install_[A-Za-z0-9_]\w*\(")
 ALLOW_MARKER = "engineering-quality: allow-import-time-mutation"
@@ -138,9 +135,7 @@ def main() -> int:
     violations: list[str] = []
     for path in _added_production_files(base_ref):
         suffix = Path(path).suffix.lower()
-        if suffix in {".py", ".js"} and LEGACY_PRODUCTION_NAME.search(
-            Path(path).name
-        ):
+        if suffix in {".py", ".js"} and LEGACY_PRODUCTION_NAME.search(Path(path).name):
             violations.append(
                 f"new production module uses research-era PR/repair naming: {path}"
             )

--- a/tools/engineering_quality_gate.py
+++ b/tools/engineering_quality_gate.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PRODUCTION_PREFIX = "src/chatgpt_web_adapter/"
+LEGACY_PRODUCTION_NAME = re.compile(r"(?:_pr\d+|repair)", re.IGNORECASE)
+MODULE_ATTRIBUTE_ASSIGNMENT = re.compile(
+    r"^[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+\s*="
+)
+TOP_LEVEL_SETATTR = re.compile(r"^setattr\(")
+TOP_LEVEL_INSTALL = re.compile(r"^install_[A-Za-z0-9_]\w*\(")
+ALLOW_MARKER = "engineering-quality: allow-import-time-mutation"
+
+
+def _git(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def _resolve_base_ref(value: str | None) -> str:
+    candidate = (value or "").strip()
+    if candidate and set(candidate) != {"0"}:
+        return candidate
+    return "HEAD^"
+
+
+def _added_production_files(base_ref: str) -> list[str]:
+    output = _git(
+        "diff",
+        "--name-only",
+        "--diff-filter=A",
+        f"{base_ref}...HEAD",
+        "--",
+        "src/chatgpt_web_adapter",
+    )
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _new_import_time_mutations(base_ref: str) -> list[str]:
+    patch = _git(
+        "diff",
+        "--unified=0",
+        f"{base_ref}...HEAD",
+        "--",
+        "src/chatgpt_web_adapter",
+    )
+    violations: list[str] = []
+    current_path: str | None = None
+
+    for line in patch.splitlines():
+        if line.startswith("+++ b/"):
+            current_path = line.removeprefix("+++ b/")
+            continue
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+
+        addition = line[1:]
+        if not addition or addition[0].isspace() or ALLOW_MARKER in addition:
+            continue
+        if (
+            MODULE_ATTRIBUTE_ASSIGNMENT.match(addition)
+            or TOP_LEVEL_SETATTR.match(addition)
+            or TOP_LEVEL_INSTALL.match(addition)
+        ):
+            violations.append(f"{current_path or '<unknown>'}: {addition}")
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Prevent new research-era production topology and import-time mutation debt."
+    )
+    parser.add_argument(
+        "--base-ref",
+        default=None,
+        help="Git base SHA/ref. Defaults to HEAD^ when omitted or unavailable.",
+    )
+    args = parser.parse_args()
+    base_ref = _resolve_base_ref(args.base_ref)
+
+    violations: list[str] = []
+    for path in _added_production_files(base_ref):
+        suffix = Path(path).suffix.lower()
+        if suffix in {".py", ".js"} and LEGACY_PRODUCTION_NAME.search(Path(path).name):
+            violations.append(
+                f"new production module uses research-era PR/repair naming: {path}"
+            )
+
+    for mutation in _new_import_time_mutations(base_ref):
+        violations.append(f"new module-level runtime mutation: {mutation}")
+
+    if violations:
+        print("engineering quality gate failed:")
+        for violation in violations:
+            print(f"- {violation}")
+        print(
+            "Existing legacy debt is grandfathered, but new debt is blocked. "
+            "Refactor through explicit composition instead."
+        )
+        return 1
+
+    print(
+        "engineering quality gate passed: no new PR/repair-named production modules "
+        "or module-level runtime mutation debt"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Turn code-quality expectations into mandatory CI gates before the deeper Python-runtime cleanup begins.

PR12.1 is intentionally behavior-neutral: it does not change product writes, Browser Authority, canonical finality, browser runtime semantics, auth semantics, or public API behavior.

## Quality gates

Adds a dedicated `Engineering quality` job that runs once on Ubuntu before release artifacts are built:

- every added or modified Python file under `src`, `tests`, and `tools` must pass Ruff lint and Ruff formatting with zero suppressions;
- `python -m compileall -q src tests tools` still validates the full Python tree;
- `node --check` validates every packaged extension JavaScript file;
- a delta architecture-debt gate blocks new research-era topology and import-time mutation debt.

The build job requires both the full platform/Python test matrix and the engineering-quality job.

## Ruff baseline

`pyproject.toml` defines the repository Ruff policy and installs Ruff through the existing `test` extra. The lint set is deliberately conservative and correctness-oriented: import ordering, core pyflakes errors, and syntax/style classes `E4`, `E7`, `E9`, `F`, and `I`. Formatting is enforced separately through `ruff format --check`.

The first full-repository inventory found **445 pre-existing violations**, including **254 `I001` import-order violations**. A mass auto-fix would reorder legacy import-time compatibility/composition code and could change runtime behavior; blanket ignores or broad `noqa` would merely hide the debt.

PR12.1 therefore establishes a monotonic touched-file baseline:

- every added or modified `.py` file under `src`, `tests`, or `tools` must be fully Ruff-clean and format-clean;
- untouched historical debt remains grandfathered until that file is intentionally changed;
- there are no blanket Ruff rule disables, broad per-file suppressions, or mass runtime import rewrites;
- touching a legacy Python file makes that file subject to the current quality policy.

This freezes existing debt without a risky rewrite while preventing new lint/format debt from entering the repository.

## Architecture debt growth gate

`tools/engineering_quality_gate.py` also remains a delta gate over the PR/push base SHA. Existing research-era debt is grandfathered, but new debt is blocked:

- no newly added production `.py`/`.js` module may use `_prXX` or `repair` naming;
- no newly added module-level class/module attribute assignment, top-level `setattr(...)`, or top-level `install_*()` mutation may appear under `src/chatgpt_web_adapter`.

The intent is monotonic cleanup: existing compatibility archaeology may be removed over time, but new features must use explicit composition instead of extending the old patching pattern.

## Extension syntax gate

`tools/check_extension_js_syntax.py` validates every packaged extension `*.js` file through Node's parser. This complements behavioral/source-contract tests by catching syntax regressions before packaging.

## Safety / scope

Closing the first quality-gate failure required **no production `src/` changes**. The post-inventory changes are limited to CI policy, the quality gate itself, and mechanical formatting of the new quality tooling. Product write/read paths, Browser Authority, canonical finality, session/auth behavior, and public runtime semantics are unchanged.

## Final verification

Exact head: `f5e7622b8c45e50b3e839f828b3d40330550a925`

CI **#825** / run **`33744976034`** — **success**:

- Engineering quality ✅ — changed-file Ruff lint + format, full-tree `compileall`, extension JavaScript syntax, architecture-debt delta gate;
- platform/Python test matrix ✅ — **10/10** green (Ubuntu + Windows × Python 3.10–3.14);
- Build release artifacts ✅ — build, package metadata, release contract, artifact upload;
- Installed-wheel smoke ✅ — **4/4** green (Ubuntu/Windows × Python 3.10/3.14).
