### PR TITLE
Experiment — Gemini Conversation Snapshot Probe

### DIFF
--- a/docs/gemini_conversation_snapshot_probe.md
+++ b/docs/gemini_conversation_snapshot_probe.md
@@ -1,0 +1,187 @@
+# Gemini conversation snapshot probe
+
+Status: **experimental, read-only, protocol probe**.
+
+This experiment checks whether an authenticated ordinary Gemini web conversation can
+support the same high-level snapshot workflow that CWA already has for ChatGPT:
+
+```text
+conversation URL
+      |
+      v
+provider-owned conversation read
+      |
+      +--> decoded raw payload (.json)
+      +--> normalized user/assistant messages (.json)
+      +--> summary-ready context (.md)
+```
+
+It intentionally does **not** add Gemini to `ChatGPTProductRuntime`, broaden the
+packaged ChatGPT extension permissions, or implement Gemini writes. The purpose is
+to prove the canonical-read side first.
+
+## What the probe reads
+
+Gemini's web product currently exposes saved conversation history through its
+same-origin batched RPC surface. The history method observed for this purpose is:
+
+```text
+RPC: hNvQHb
+product: gemini.google.com
+operation: list/read conversation turns
+```
+
+The probe obtains the current page bootstrap token from the target Gemini
+conversation page, calls the read-history RPC from the authenticated browser
+origin, and discards the token after the request. Cookies, the bootstrap token,
+and request headers are never written to an output artifact.
+
+This is an undocumented web-product contract and can change. The probe therefore
+keeps the decoded raw RPC payload as forensic evidence and fails instead of
+returning an empty context when the known message shape no longer matches.
+
+## Supported URLs
+
+The initial route parser accepts ordinary private conversation routes:
+
+```text
+https://gemini.google.com/app/<chat-id>
+https://gemini.google.com/gem/<gem-id>/<chat-id>
+https://gemini.google.com/u/<account-index>/app/<chat-id>
+https://gemini.google.com/u/<account-index>/gem/<gem-id>/<chat-id>
+```
+
+Public `g.co/gemini/share/...` snapshots are a different product surface and are
+not part of this probe.
+
+## Run it
+
+1. Open `https://gemini.google.com` in Chrome/Chromium and make sure the account
+   that owns the target chat is signed in.
+2. Open DevTools -> Sources -> Snippets and create a snippet containing
+   `experiments/gemini_conversation_snapshot_probe.js`.
+3. Run the snippet once. It installs `window.geminiConversationSnapshot` only in
+   the current Gemini page.
+4. In the DevTools console run:
+
+```js
+await geminiConversationSnapshot(
+  "https://gemini.google.com/app/<chat-id>",
+  { name: "project" },
+)
+```
+
+The call is read-only. It downloads:
+
+```text
+project_gemini_chat_context.md
+project_gemini_chat_messages.json
+project_gemini_chat_payload.json
+```
+
+To skip the raw payload backup:
+
+```js
+await geminiConversationSnapshot(url, {
+  name: "project",
+  includeRawPayload: false,
+})
+```
+
+A custom positive `turnLimit` may also be supplied. The default is 1000 turns.
+
+## Output contract
+
+### `*_gemini_chat_context.md`
+
+Summary-ready text using the same deliberately narrow shape as CWA conversation
+snapshots:
+
+```text
+## USER
+
+...
+
+---
+
+## ASSISTANT
+
+...
+```
+
+Only non-empty textual user/assistant messages are emitted.
+
+### `*_gemini_chat_messages.json`
+
+A normalized experimental envelope:
+
+```json
+{
+  "schema": "cwa.experimental.gemini.messages.v1",
+  "provider": "gemini-web",
+  "source_url": "https://gemini.google.com/app/...",
+  "conversation_id": "c_...",
+  "retrieved_at": "...",
+  "rpc": {
+    "id": "hNvQHb",
+    "decoded_payload_count": 1
+  },
+  "ordering": "chronological",
+  "messages": [
+    {
+      "role": "user",
+      "text": "...",
+      "turn_index": 0,
+      "request_id": "..."
+    },
+    {
+      "role": "assistant",
+      "text": "...",
+      "turn_index": 0,
+      "request_id": "...",
+      "candidate_id": "rc_..."
+    }
+  ]
+}
+```
+
+The provider currently returns history newest-first. The probe normalizes it to
+chronological order and emits user before assistant within each recovered turn.
+
+### `*_gemini_chat_payload.json`
+
+The decoded body of the `hNvQHb` response. This can contain more product metadata
+than the visible text messages, so use the normalized messages/context file for
+routine summarization. The raw payload exists to make parser drift diagnosable.
+
+## Current boundaries
+
+This initial proof intentionally does not claim support for:
+
+- public share-link extraction;
+- temporary/incognito Gemini chats;
+- complete attachment or citation normalization;
+- alternate/regenerated response branch selection beyond the first textual
+  candidate exposed by the current turn shape;
+- Gemini writes, model selection, tools, or generation finality;
+- a stable public Gemini API contract.
+
+If the live test succeeds, the next architectural step is not to put Gemini
+conditionals inside `ChatGPTProductRuntime`. It is to extract a provider-neutral
+conversation snapshot/read contract and implement a Gemini canonical reader
+behind that boundary.
+
+## Safety and authority
+
+The probe is intentionally read-only:
+
+```text
+conversation observation
+!= product mutation
+!= permission to write
+!= provider-independent canonicality
+```
+
+It uses only the already-authenticated Gemini browser session and never exports
+cookies or the anti-CSRF token. A failure to parse is treated as protocol drift,
+not as an empty conversation.

--- a/experiments/gemini_conversation_snapshot_mobile.user.js
+++ b/experiments/gemini_conversation_snapshot_mobile.user.js
@@ -1,0 +1,90 @@
+// ==UserScript==
+// @name         Gemini Conversation Snapshot (CWA experiment)
+// @namespace    https://github.com/kymuco/chatgpt-web-adapter
+// @version      0.1.0
+// @description  Read-only export of the current authenticated Gemini conversation to Markdown and JSON.
+// @match        https://gemini.google.com/*
+// @require      https://raw.githubusercontent.com/kymuco/chatgpt-web-adapter/experiment/gemini-conversation-snapshot/experiments/gemini_conversation_snapshot_probe.js
+// @grant        none
+// @run-at       document-idle
+// ==/UserScript==
+
+(() => {
+  "use strict";
+
+  const BUTTON_ID = "cwa-gemini-snapshot-export";
+
+  function isConversationRoute() {
+    return /\/(?:u\/\d+\/)?(?:app\/[^/?#]+|gem\/[^/?#]+\/[^/?#]+)(?:[/?#]|$)/.test(
+      location.pathname,
+    );
+  }
+
+  function setButtonState(button, text, disabled = false) {
+    button.textContent = text;
+    button.disabled = disabled;
+    button.style.opacity = disabled ? "0.65" : "1";
+  }
+
+  async function exportCurrentConversation(button) {
+    if (typeof window.geminiConversationSnapshot !== "function") {
+      throw new Error("Gemini snapshot probe did not load");
+    }
+    if (!isConversationRoute()) {
+      throw new Error("Open a saved Gemini conversation first");
+    }
+
+    const suggested = `gemini_${new Date().toISOString().slice(0, 10)}`;
+    const requested = window.prompt("Snapshot file prefix", suggested);
+    if (requested === null) {
+      return;
+    }
+
+    setButtonState(button, "Exporting…", true);
+    try {
+      const result = await window.geminiConversationSnapshot(location.href, {
+        name: requested.trim() || suggested,
+      });
+      setButtonState(button, `Exported ${result.message_count} msgs`, false);
+      window.setTimeout(() => setButtonState(button, "Export chat", false), 3000);
+    } catch (error) {
+      setButtonState(button, "Export failed", false);
+      window.alert(`Gemini snapshot failed: ${error instanceof Error ? error.message : String(error)}`);
+      window.setTimeout(() => setButtonState(button, "Export chat", false), 3000);
+    }
+  }
+
+  function installButton() {
+    if (document.getElementById(BUTTON_ID)) {
+      return;
+    }
+
+    const button = document.createElement("button");
+    button.id = BUTTON_ID;
+    button.type = "button";
+    button.textContent = "Export chat";
+    button.setAttribute("aria-label", "Export Gemini conversation snapshot");
+    Object.assign(button.style, {
+      position: "fixed",
+      right: "14px",
+      bottom: "18px",
+      zIndex: "2147483647",
+      padding: "11px 15px",
+      border: "0",
+      borderRadius: "999px",
+      background: "#1f1f1f",
+      color: "#fff",
+      font: "600 14px/1.2 system-ui, sans-serif",
+      boxShadow: "0 3px 16px rgba(0,0,0,.28)",
+      cursor: "pointer",
+    });
+    button.addEventListener("click", () => void exportCurrentConversation(button));
+    document.documentElement.appendChild(button);
+  }
+
+  installButton();
+  new MutationObserver(installButton).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+})();

--- a/experiments/gemini_conversation_snapshot_probe.js
+++ b/experiments/gemini_conversation_snapshot_probe.js
@@ -1,0 +1,445 @@
+/*
+ * Read-only Gemini web conversation snapshot probe.
+ *
+ * Usage (while signed in on https://gemini.google.com):
+ *   await geminiConversationSnapshot(
+ *     "https://gemini.google.com/app/<chat-id>",
+ *     { name: "conversation" },
+ *   );
+ *
+ * This deliberately performs no product writes. It reads the target conversation
+ * through Gemini's same-origin conversation-history RPC and downloads:
+ *   - a summary-ready Markdown context,
+ *   - a normalized JSON messages file,
+ *   - the decoded raw RPC payload (unless includeRawPayload is false).
+ */
+
+(() => {
+  "use strict";
+
+  const GEMINI_HOST = "gemini.google.com";
+  const READ_CHAT_RPC = "hNvQHb";
+  const DEFAULT_TURN_LIMIT = 1000;
+
+  function requiredString(value, name) {
+    if (typeof value !== "string" || !value.trim()) {
+      throw new TypeError(`${name} must be a non-empty string`);
+    }
+    return value.trim();
+  }
+
+  function parseGeminiConversationUrl(value) {
+    const url = new URL(requiredString(value, "conversationUrl"));
+    if (url.protocol !== "https:" || url.hostname !== GEMINI_HOST) {
+      throw new Error("Gemini conversation URL must use https://gemini.google.com");
+    }
+
+    const parts = url.pathname.split("/").filter(Boolean);
+    let index = 0;
+    let accountPrefix = "";
+
+    if (parts[index] === "u") {
+      const accountIndex = parts[index + 1];
+      if (!/^\d+$/.test(accountIndex || "")) {
+        throw new Error("Gemini /u/ route is missing a numeric account index");
+      }
+      accountPrefix = `/u/${accountIndex}`;
+      index += 2;
+    }
+
+    let gemId = null;
+    let chatId = null;
+    if (parts[index] === "app" && parts[index + 1]) {
+      chatId = parts[index + 1];
+      index += 2;
+    } else if (
+      parts[index] === "gem" &&
+      parts[index + 1] &&
+      parts[index + 2]
+    ) {
+      gemId = parts[index + 1];
+      chatId = parts[index + 2];
+      index += 3;
+    } else {
+      throw new Error(
+        "Unsupported Gemini conversation URL. Expected /app/<id> or /gem/<gem-id>/<id>, optionally under /u/<account-index>/",
+      );
+    }
+
+    if (index !== parts.length) {
+      throw new Error("Gemini conversation URL contains an unsupported trailing path");
+    }
+
+    const rpcConversationId = chatId.startsWith("c_") ? chatId : `c_${chatId}`;
+    return {
+      url,
+      accountPrefix,
+      gemId,
+      chatId,
+      rpcConversationId,
+      sourcePath: url.pathname,
+    };
+  }
+
+  function decodeJsonStringFragment(value) {
+    if (typeof value !== "string") {
+      return null;
+    }
+    try {
+      return JSON.parse(`"${value.replace(/"/g, '\\"')}"`);
+    } catch {
+      return value;
+    }
+  }
+
+  function extractQuotedBootstrapValue(html, key) {
+    const pattern = new RegExp(`"${key}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`);
+    const match = html.match(pattern);
+    return match ? decodeJsonStringFragment(match[1]) : null;
+  }
+
+  function extractBootstrap(html) {
+    if (typeof html !== "string" || !html) {
+      throw new Error("Gemini bootstrap HTML is empty");
+    }
+
+    let at = null;
+    if (typeof DOMParser !== "undefined") {
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      const input = doc.querySelector('input[name="at"]');
+      if (input && typeof input.value === "string" && input.value.trim()) {
+        at = input.value.trim();
+      }
+    }
+
+    at = at || extractQuotedBootstrapValue(html, "SNlM0e");
+    const buildLabel = extractQuotedBootstrapValue(html, "cfb2h");
+    const sessionId = extractQuotedBootstrapValue(html, "FdrFJe");
+
+    if (!at) {
+      throw new Error(
+        "Gemini anti-CSRF token (SNlM0e) was not found. Make sure this browser profile is signed in and the target chat is accessible.",
+      );
+    }
+
+    return { at, buildLabel, sessionId };
+  }
+
+  function walkForRpcPayload(value, rpcId, results) {
+    if (!Array.isArray(value)) {
+      return;
+    }
+
+    if (
+      value.length >= 3 &&
+      value[0] === "wrb.fr" &&
+      value[1] === rpcId &&
+      typeof value[2] === "string"
+    ) {
+      try {
+        results.push(JSON.parse(value[2]));
+      } catch (error) {
+        throw new Error(`Gemini ${rpcId} payload was not valid JSON: ${error}`);
+      }
+    }
+
+    for (const item of value) {
+      if (Array.isArray(item)) {
+        walkForRpcPayload(item, rpcId, results);
+      }
+    }
+  }
+
+  function parseBatchExecuteResponse(text, rpcId = READ_CHAT_RPC) {
+    const source = requiredString(text, "batch response").replace(/^\)\]\}'\s*/, "");
+    const results = [];
+
+    for (const rawLine of source.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || /^\d+$/.test(line) || (!line.startsWith("[") && !line.startsWith("{"))) {
+        continue;
+      }
+      let frame;
+      try {
+        frame = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      walkForRpcPayload(frame, rpcId, results);
+    }
+
+    if (!results.length) {
+      throw new Error(`Gemini batch response did not contain RPC ${rpcId}`);
+    }
+    return results;
+  }
+
+  function nested(value, path) {
+    let current = value;
+    for (const key of path) {
+      if (current == null || !(key in Object(current))) {
+        return undefined;
+      }
+      current = current[key];
+    }
+    return current;
+  }
+
+  function cleanText(value) {
+    return typeof value === "string" ? value.trim() : "";
+  }
+
+  function firstAssistantCandidate(turn) {
+    const candidates = nested(turn, [3, 0]);
+    if (!Array.isArray(candidates)) {
+      return null;
+    }
+    for (const candidate of candidates) {
+      if (!Array.isArray(candidate)) {
+        continue;
+      }
+      const text = cleanText(nested(candidate, [1, 0]));
+      if (!text) {
+        continue;
+      }
+      const candidateId = typeof candidate[0] === "string" ? candidate[0] : null;
+      return { text, candidateId };
+    }
+    return null;
+  }
+
+  function normalizeConversationPayload(payload, conversationId) {
+    const turns = nested(payload, [0]);
+    if (!Array.isArray(turns)) {
+      throw new Error("Gemini conversation payload does not contain a recognized turns array");
+    }
+
+    const messages = [];
+    const chronologicalTurns = [...turns].reverse();
+
+    chronologicalTurns.forEach((turn, chronologicalIndex) => {
+      if (!Array.isArray(turn)) {
+        return;
+      }
+
+      const requestId = typeof nested(turn, [0, 1]) === "string" ? nested(turn, [0, 1]) : null;
+      const userText = cleanText(nested(turn, [2, 0, 0]));
+      if (userText) {
+        messages.push({
+          role: "user",
+          text: userText,
+          turn_index: chronologicalIndex,
+          request_id: requestId,
+        });
+      }
+
+      const assistant = firstAssistantCandidate(turn);
+      if (assistant) {
+        messages.push({
+          role: "assistant",
+          text: assistant.text,
+          turn_index: chronologicalIndex,
+          request_id: requestId,
+          candidate_id: assistant.candidateId,
+        });
+      }
+    });
+
+    if (!messages.length) {
+      throw new Error(
+        "Gemini conversation payload was fetched, but no text user/assistant messages matched the known shape. Keep the raw payload and update the parser before trusting an empty summary context.",
+      );
+    }
+
+    return {
+      provider: "gemini-web",
+      conversation_id: conversationId,
+      ordering: "chronological",
+      messages,
+    };
+  }
+
+  function renderMarkdownContext(messages) {
+    return (
+      messages
+        .filter((message) => ["user", "assistant"].includes(message.role) && cleanText(message.text))
+        .map((message) => `## ${message.role.toUpperCase()}\n\n${message.text.trim()}`)
+        .join("\n\n---\n\n") + "\n"
+    );
+  }
+
+  function sanitizeName(value) {
+    const name = requiredString(value, "name");
+    const cleaned = name.replace(/[<>:"/\\|?*\x00-\x1F]/g, "_").replace(/\s+/g, "_");
+    if (!cleaned || cleaned === "." || cleaned === "..") {
+      throw new Error("name is not usable as a file-name prefix");
+    }
+    return cleaned;
+  }
+
+  function downloadTextFile(filename, content, mediaType) {
+    const blob = new Blob([content], { type: mediaType });
+    const href = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    anchor.download = filename;
+    anchor.style.display = "none";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    setTimeout(() => URL.revokeObjectURL(href), 1000);
+  }
+
+  function jsonText(value) {
+    return `${JSON.stringify(value, null, 2)}\n`;
+  }
+
+  async function fetchBootstrap(route) {
+    const response = await fetch(route.url.href, {
+      method: "GET",
+      credentials: "include",
+      cache: "no-store",
+      redirect: "follow",
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to open Gemini conversation page (${response.status})`);
+    }
+    if (new URL(response.url).hostname !== GEMINI_HOST) {
+      throw new Error("Gemini conversation page redirected away from gemini.google.com; sign in first");
+    }
+    return extractBootstrap(await response.text());
+  }
+
+  async function readConversationRpc(route, bootstrap, turnLimit) {
+    const rpcUrl = new URL(
+      `${route.accountPrefix}/_/BardChatUi/data/batchexecute`,
+      "https://gemini.google.com",
+    );
+    rpcUrl.searchParams.set("rpcids", READ_CHAT_RPC);
+    rpcUrl.searchParams.set("source-path", route.sourcePath);
+    rpcUrl.searchParams.set("hl", document.documentElement.lang || "en");
+    rpcUrl.searchParams.set("rt", "c");
+    rpcUrl.searchParams.set("_reqid", String(Math.floor(100000 + Math.random() * 900000)));
+    if (bootstrap.buildLabel) {
+      rpcUrl.searchParams.set("bl", bootstrap.buildLabel);
+    }
+    if (bootstrap.sessionId) {
+      rpcUrl.searchParams.set("f.sid", bootstrap.sessionId);
+    }
+
+    const rpcArgs = JSON.stringify([
+      route.rpcConversationId,
+      turnLimit,
+      null,
+      1,
+      [1],
+      [4],
+      null,
+      1,
+    ]);
+    const fReq = JSON.stringify([[[READ_CHAT_RPC, rpcArgs, null, "generic"]]]);
+    const body = new URLSearchParams({
+      "f.req": fReq,
+      at: bootstrap.at,
+    });
+
+    const response = await fetch(rpcUrl.href, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        accept: "*/*",
+        "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+        "x-same-domain": "1",
+      },
+      body: body.toString(),
+    });
+    const responseText = await response.text();
+    if (!response.ok) {
+      throw new Error(`Gemini conversation-history RPC failed (${response.status})`);
+    }
+
+    const decoded = parseBatchExecuteResponse(responseText, READ_CHAT_RPC);
+    const payload = decoded.find((candidate) => Array.isArray(nested(candidate, [0])));
+    if (!payload) {
+      throw new Error("Gemini history RPC returned data, but no recognized conversation payload was found");
+    }
+    return { payload, decodedCount: decoded.length };
+  }
+
+  async function geminiConversationSnapshot(conversationUrl, options = {}) {
+    if (location.hostname !== GEMINI_HOST) {
+      throw new Error("Run this probe from an authenticated https://gemini.google.com tab");
+    }
+
+    const route = parseGeminiConversationUrl(conversationUrl);
+    const turnLimit = Number.isInteger(options.turnLimit) && options.turnLimit > 0
+      ? options.turnLimit
+      : DEFAULT_TURN_LIMIT;
+    const name = sanitizeName(options.name || "conversation");
+    const includeRawPayload = options.includeRawPayload !== false;
+
+    const bootstrap = await fetchBootstrap(route);
+    const { payload, decodedCount } = await readConversationRpc(route, bootstrap, turnLimit);
+    const normalized = normalizeConversationPayload(payload, route.rpcConversationId);
+    const retrievedAt = new Date().toISOString();
+    const messagesDocument = {
+      schema: "cwa.experimental.gemini.messages.v1",
+      provider: normalized.provider,
+      source_url: route.url.href,
+      conversation_id: normalized.conversation_id,
+      retrieved_at: retrievedAt,
+      rpc: {
+        id: READ_CHAT_RPC,
+        decoded_payload_count: decodedCount,
+      },
+      ordering: normalized.ordering,
+      messages: normalized.messages,
+    };
+
+    const contextFilename = `${name}_gemini_chat_context.md`;
+    const messagesFilename = `${name}_gemini_chat_messages.json`;
+    const rawFilename = `${name}_gemini_chat_payload.json`;
+
+    downloadTextFile(
+      contextFilename,
+      renderMarkdownContext(normalized.messages),
+      "text/markdown;charset=utf-8",
+    );
+    downloadTextFile(
+      messagesFilename,
+      jsonText(messagesDocument),
+      "application/json;charset=utf-8",
+    );
+    if (includeRawPayload) {
+      downloadTextFile(rawFilename, jsonText(payload), "application/json;charset=utf-8");
+    }
+
+    return {
+      ok: true,
+      provider: "gemini-web",
+      conversation_id: route.rpcConversationId,
+      message_count: normalized.messages.length,
+      files: {
+        context: contextFilename,
+        messages: messagesFilename,
+        raw_payload: includeRawPayload ? rawFilename : null,
+      },
+    };
+  }
+
+  const testing = {
+    parseGeminiConversationUrl,
+    extractBootstrap,
+    parseBatchExecuteResponse,
+    normalizeConversationPayload,
+    renderMarkdownContext,
+  };
+
+  if (typeof window !== "undefined") {
+    window.geminiConversationSnapshot = geminiConversationSnapshot;
+    window.__geminiConversationSnapshotTesting = testing;
+  }
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = testing;
+  }
+})();

--- a/experiments/gemini_conversation_snapshot_probe.test.js
+++ b/experiments/gemini_conversation_snapshot_probe.test.js
@@ -1,0 +1,55 @@
+const assert = require("assert");
+const probe = require("./gemini_conversation_snapshot_probe.js");
+
+const route1 = probe.parseGeminiConversationUrl(
+  "https://gemini.google.com/app/abc123",
+);
+assert.equal(route1.rpcConversationId, "c_abc123");
+assert.equal(route1.accountPrefix, "");
+assert.equal(route1.sourcePath, "/app/abc123");
+
+const route2 = probe.parseGeminiConversationUrl(
+  "https://gemini.google.com/u/2/gem/gem42/c_def",
+);
+assert.equal(route2.rpcConversationId, "c_def");
+assert.equal(route2.accountPrefix, "/u/2");
+assert.equal(route2.gemId, "gem42");
+
+const payload = [
+  [
+    [[null, "r-new"], null, [["new user"]], [[["rc_new", ["new answer"]]]]],
+    [[null, "r-old"], null, [["old user"]], [[["rc_old", ["old answer"]]]]],
+  ],
+];
+const normalized = probe.normalizeConversationPayload(payload, "c_demo");
+assert.deepEqual(
+  normalized.messages.map((message) => [message.role, message.text]),
+  [
+    ["user", "old user"],
+    ["assistant", "old answer"],
+    ["user", "new user"],
+    ["assistant", "new answer"],
+  ],
+);
+assert(
+  probe
+    .renderMarkdownContext(normalized.messages)
+    .includes("## USER\n\nold user"),
+);
+
+const payloadString = JSON.stringify(payload);
+const frame = JSON.stringify([
+  ["wrb.fr", "hNvQHb", payloadString, null, null, null, "generic"],
+]);
+const response = `)]}'\n${frame.length}\n${frame}\n`;
+const decoded = probe.parseBatchExecuteResponse(response);
+assert.deepEqual(decoded[0], payload);
+
+const html =
+  '<script>window.WIZ_global_data={"SNlM0e":"token123","cfb2h":"build456","FdrFJe":"sid789"}</script>';
+const bootstrap = probe.extractBootstrap(html);
+assert.equal(bootstrap.at, "token123");
+assert.equal(bootstrap.buildLabel, "build456");
+assert.equal(bootstrap.sessionId, "sid789");
+
+console.log("gemini snapshot probe parser tests: OK");


### PR DESCRIPTION
## Purpose

Prove the narrow read-only analogue of CWA's ChatGPT conversation snapshot flow for an authenticated ordinary Gemini web conversation before introducing any multi-provider runtime abstraction.

Target flow:

```text
Gemini conversation URL
  -> provider-owned history read
  -> decoded raw RPC payload
  -> normalized user/assistant messages JSON
  -> summary-ready Markdown context
```

## Findings encoded by the probe

- ordinary saved Gemini conversations expose a same-origin batched history read through RPC `hNvQHb`;
- `/app/<id>`, `/gem/<gem>/<id>`, and `/u/<account>/...` routes can be reduced to the conversation identity used by that RPC;
- the current history payload is returned newest-first and can be normalized to chronological user/assistant turns;
- the browser page can supply the transient bootstrap/anti-CSRF state needed for the read without persisting cookies or tokens.

## Files

- `experiments/gemini_conversation_snapshot_probe.js` — browser-side read-only probe and local downloads;
- `experiments/gemini_conversation_snapshot_probe.test.js` — synthetic parser/route/RPC-frame self-test;
- `docs/gemini_conversation_snapshot_probe.md` — usage, output contract, and boundaries.

## Output

The probe downloads:

- `<name>_gemini_chat_context.md` — summary-ready USER/ASSISTANT context;
- `<name>_gemini_chat_messages.json` — normalized chronological message envelope;
- `<name>_gemini_chat_payload.json` — decoded raw `hNvQHb` payload for parser-drift forensics.

## Deliberate boundaries

This PR does **not**:

- add Gemini to `ChatGPTProductRuntime`;
- broaden the production CWA extension's host permissions;
- add Gemini product writes;
- claim public-share, temporary-chat, attachment/citation, or regenerated-branch completeness;
- treat the undocumented RPC shape as a stable provider-independent API.

The parser fails rather than silently emitting an empty summary context if the known message shape no longer matches.

## Verification

Locally verified with Node 22:

```text
node --check experiments/gemini_conversation_snapshot_probe.js
node experiments/gemini_conversation_snapshot_probe.test.js
# gemini snapshot probe parser tests: OK
```

A live authenticated Gemini chat is intentionally the next gate before any merge or runtime extraction.