### PR TITLE
PR12.4 — Call-Time Observation Mutation Elimination

### DIFF
--- a/docs/engineering/pr12_4_call_time_observation_mutation_elimination.md
+++ b/docs/engineering/pr12_4_call_time_observation_mutation_elimination.md
@@ -1,0 +1,40 @@
+# PR12.4 — Call-Time Observation Mutation Elimination
+
+PR12.4 closes the observation-topology cleanup deliberately deferred by PR12.3. Canonical source/citation observation is now composed into the browser-native client when its functions are defined instead of being installed lazily by the first observed product execution.
+
+## Static ownership
+
+`browser_native_client.py` owns the two canonical observation composition points:
+
+- `_wait_for_new_final_assistant` is wrapped by `_gate_wait_for_new_final_assistant` at definition time;
+- `send_browser_native` is wrapped by `_gate_send_browser_native` at definition time.
+
+Modules and classes that import `send_browser_native` therefore receive the already-composed function. `product_runtime_observation_gate.py` only collects the standardized event stream and no longer imports or invokes the historical compatibility installer while a turn is running.
+
+The historical `install_canonical_product_observation_gate()` entry point remains for compatibility. Because the intrinsic browser-native functions are already marked and composed, invoking that installer is identity-stable and does not replace the active functions.
+
+## Runtime topology invariant
+
+An observed execution must not change the identities of:
+
+- `browser_native_client._wait_for_new_final_assistant`;
+- `browser_native_client.send_browser_native`;
+- `browser_owned_write_runtime.send_browser_native`;
+- `ChatGPTWebClient.send_browser_native`.
+
+PR12.4 adds a regression test for this invariant and also proves that the runtime observation gate contains no lazy canonical installer call.
+
+## Preserved contracts
+
+PR12.4 does not change:
+
+- Browser Authority or lease semantics;
+- submission acceptance or canonical-finality authority;
+- automatic retry/replay policy after ambiguous writes;
+- ordinary-text conversation identity authority;
+- Temporary Chat or rich-input behavior;
+- source/citation normalization, privacy filtering, or stream/canonical deduplication;
+- observation/approval separation;
+- browserless support or transport semantics.
+
+The change is topology-only: canonical observation behavior remains the same, but its ownership is explicit and stable before any product turn executes.

--- a/src/chatgpt_web_adapter/browser_native_client.py
+++ b/src/chatgpt_web_adapter/browser_native_client.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import inspect
 import time
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
@@ -46,7 +46,9 @@ class BrowserNativeSubmission:
     final_response: ChatResponse | None = None
 
 
-def set_browser_native_turn_provider(self: Any, provider: BrowserNativeTurnProvider | None) -> None:
+def set_browser_native_turn_provider(
+    self: Any, provider: BrowserNativeTurnProvider | None
+) -> None:
     if provider is not None and not callable(getattr(provider, "send_text", None)):
         raise TypeError("provider must expose a callable send_text() or be None")
     self._browser_native_turn_provider = provider
@@ -250,7 +252,11 @@ def submit_browser_native(
     self: Any,
     prompt: str,
     *,
-    conversation: ConversationRef | ChatConversation | dict[str, Any] | str | None = None,
+    conversation: ConversationRef
+    | ChatConversation
+    | dict[str, Any]
+    | str
+    | None = None,
     timeout: float = 150.0,
     poll_interval: float = 0.5,
     on_token: Callable[[str], None] | None = None,
@@ -275,7 +281,9 @@ def submit_browser_native(
         if scoped_paths is not None:
             attachment_paths = scoped_paths
     normalized_attachment_paths = tuple(attachment_paths or ())
-    if normalized_attachment_paths and not _callable_accepts_attachment_paths(provider.send_text):
+    if normalized_attachment_paths and not _callable_accepts_attachment_paths(
+        provider.send_text
+    ):
         raise RequestError(
             "BROWSER_NATIVE_RICH_INPUT_PROVIDER_UNSUPPORTED",
             request_stage="browser_native_turn_preflight",
@@ -366,7 +374,9 @@ def submit_browser_native(
                 **attachment_kwargs,
             )
     elif streaming_requested and callable(stream_send):
-        if normalized_attachment_paths and not _callable_accepts_attachment_paths(stream_send):
+        if normalized_attachment_paths and not _callable_accepts_attachment_paths(
+            stream_send
+        ):
             raise RequestError(
                 "BROWSER_NATIVE_RICH_INPUT_STREAM_PROVIDER_UNSUPPORTED",
                 request_stage="browser_native_turn_preflight",
@@ -464,13 +474,15 @@ def await_browser_native_final(
         1.0,
         submission.timeout - (time.monotonic() - submission.started_monotonic),
     )
-    final_message, canonical_payload, canonical_payload_read_count = _wait_for_new_final_assistant(
-        self,
-        turn.conversation_id,
-        baseline_assistant_ids=submission.baseline_assistant_ids,
-        timeout=remaining,
-        interval=submission.poll_interval,
-        include_readback=True,
+    final_message, canonical_payload, canonical_payload_read_count = (
+        _wait_for_new_final_assistant(
+            self,
+            turn.conversation_id,
+            baseline_assistant_ids=submission.baseline_assistant_ids,
+            timeout=remaining,
+            interval=submission.poll_interval,
+            include_readback=True,
+        )
     )
 
     if canonical_payload is not None:
@@ -550,7 +562,11 @@ def send_browser_native(
     self: Any,
     prompt: str,
     *,
-    conversation: ConversationRef | ChatConversation | dict[str, Any] | str | None = None,
+    conversation: ConversationRef
+    | ChatConversation
+    | dict[str, Any]
+    | str
+    | None = None,
     timeout: float = 150.0,
     poll_interval: float = 0.5,
     on_token: Callable[[str], None] | None = None,

--- a/src/chatgpt_web_adapter/browser_native_client.py
+++ b/src/chatgpt_web_adapter/browser_native_client.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from typing import Any, Callable, Sequence
 
 from .browser_native_provider import BrowserNativeTurnProvider
+from .canonical_product_observation_gate_pr9_3 import (
+    _gate_send_browser_native,
+    _gate_wait_for_new_final_assistant,
+)
 from .exceptions import ConversationTimeoutError, RequestError
 from .messages import _chat_message_from_node, _current_branch_nodes
 from .product_media import current_browser_owned_attachment_paths
@@ -99,6 +103,7 @@ def _assistant_candidates_from_payload(
     return candidates
 
 
+@_gate_wait_for_new_final_assistant
 def _wait_for_new_final_assistant(
     self: Any,
     conversation_id: str,
@@ -540,6 +545,7 @@ def await_browser_native_final(
     return response
 
 
+@_gate_send_browser_native
 def send_browser_native(
     self: Any,
     prompt: str,

--- a/src/chatgpt_web_adapter/product_runtime_observation_gate.py
+++ b/src/chatgpt_web_adapter/product_runtime_observation_gate.py
@@ -21,15 +21,11 @@ def gate_product_runtime_send_text_observed(
     privacy-filtered values. A transport cannot acquire typed-observation authority
     by pre-populating ``ProductRuntimeExecution.observations`` itself.
 
-    The function is intentionally side-effect-free at import/composition time.
+    The function is side-effect-free at import, composition, and execution time.
     Historical activity precedence, browser-owned capability graduation, submission
-    lifecycle, and UI-liveness ownership now live in their intrinsic modules/classes
-    rather than being installed as a consequence of importing this gate.
-
-    Canonical source/citation observation still uses the historical runtime-time
-    compatibility gate. That gate is installed only when an observed execution is
-    actually requested; eliminating that call-time patch is outside PR12.3's
-    import-time mutation scope.
+    lifecycle, UI-liveness ownership, and canonical source/citation observation
+    are composed in their intrinsic modules/classes rather than installed as a
+    consequence of importing or invoking this gate.
     """
 
     if getattr(send_text_observed, _PR93_PRODUCT_OBSERVATION_GATE_MARKER, False):
@@ -42,12 +38,6 @@ def gate_product_runtime_send_text_observed(
         *args: Any,
         **kwargs: Any,
     ) -> ProductRuntimeExecution:
-        from .canonical_product_observation_gate_pr9_3 import (
-            install_canonical_product_observation_gate,
-        )
-
-        install_canonical_product_observation_gate()
-
         caller_on_event = kwargs.get("on_event")
         collector = ProductArtifactObservationCollector()
 

--- a/tests/test_call_time_observation_mutation_elimination_pr12_4.py
+++ b/tests/test_call_time_observation_mutation_elimination_pr12_4.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import inspect
+
+import chatgpt_web_adapter.browser_native_client as browser_native_client
+import chatgpt_web_adapter.browser_owned_write_runtime as browser_owned_write_runtime
+from chatgpt_web_adapter.canonical_product_observation_gate_pr9_3 import (
+    _PR93_CANONICAL_OBSERVATION_GATE_MARKER,
+    install_canonical_product_observation_gate,
+)
+from chatgpt_web_adapter.client import ChatGPTWebClient
+from chatgpt_web_adapter.product_runtime_observation_gate import (
+    gate_product_runtime_send_text_observed,
+)
+from chatgpt_web_adapter.product_transport import ProductRuntimeExecution
+from chatgpt_web_adapter.types import ChatResponse
+
+
+def _topology_snapshot() -> tuple[object, object, object, object]:
+    return (
+        browser_native_client._wait_for_new_final_assistant,
+        browser_native_client.send_browser_native,
+        browser_owned_write_runtime.send_browser_native,
+        ChatGPTWebClient.send_browser_native,
+    )
+
+
+def test_canonical_observation_gates_are_statically_composed() -> None:
+    assert getattr(
+        browser_native_client._wait_for_new_final_assistant,
+        _PR93_CANONICAL_OBSERVATION_GATE_MARKER,
+        False,
+    )
+    assert getattr(
+        browser_native_client.send_browser_native,
+        _PR93_CANONICAL_OBSERVATION_GATE_MARKER,
+        False,
+    )
+    assert (
+        browser_owned_write_runtime.send_browser_native
+        is browser_native_client.send_browser_native
+    )
+    assert ChatGPTWebClient.send_browser_native is browser_native_client.send_browser_native
+
+
+def test_legacy_installer_is_identity_stable_after_static_composition() -> None:
+    before = _topology_snapshot()
+
+    install_canonical_product_observation_gate()
+
+    assert _topology_snapshot() == before
+
+
+def test_observed_execution_does_not_install_or_replace_browser_native_functions() -> None:
+    before = _topology_snapshot()
+
+    def fake_send_text_observed(self, text, *args, **kwargs):
+        assert text == "hello"
+        assert callable(kwargs.get("on_event"))
+        return ProductRuntimeExecution(
+            transport="test",
+            response=ChatResponse(text="ok"),
+            observation=None,
+        )
+
+    gated = gate_product_runtime_send_text_observed(fake_send_text_observed)
+    result = gated(object(), "hello")
+
+    assert result.response.text == "ok"
+    assert _topology_snapshot() == before
+
+
+def test_runtime_observation_gate_contains_no_lazy_canonical_installer() -> None:
+    source = inspect.getsource(gate_product_runtime_send_text_observed)
+
+    assert "install_canonical_product_observation_gate" not in source

--- a/tests/test_call_time_observation_mutation_elimination_pr12_4.py
+++ b/tests/test_call_time_observation_mutation_elimination_pr12_4.py
@@ -40,7 +40,10 @@ def test_canonical_observation_gates_are_statically_composed() -> None:
         browser_owned_write_runtime.send_browser_native
         is browser_native_client.send_browser_native
     )
-    assert ChatGPTWebClient.send_browser_native is browser_native_client.send_browser_native
+    assert (
+        ChatGPTWebClient.send_browser_native
+        is browser_native_client.send_browser_native
+    )
 
 
 def test_legacy_installer_is_identity_stable_after_static_composition() -> None:
@@ -51,7 +54,9 @@ def test_legacy_installer_is_identity_stable_after_static_composition() -> None:
     assert _topology_snapshot() == before
 
 
-def test_observed_execution_does_not_install_or_replace_browser_native_functions() -> None:
+def test_observed_execution_does_not_install_or_replace_browser_native_functions() -> (
+    None
+):
     before = _topology_snapshot()
 
     def fake_send_text_observed(self, text, *args, **kwargs):


### PR DESCRIPTION
## Purpose

Close the observation-topology cleanup deliberately deferred by PR12.3: canonical source/citation observation is now statically composed before a product turn executes instead of being installed lazily by the first `send_text_observed()` call.

## Change

- statically compose `_gate_wait_for_new_final_assistant` onto `browser_native_client._wait_for_new_final_assistant` at definition time;
- statically compose `_gate_send_browser_native` onto `browser_native_client.send_browser_native` at definition time;
- remove the lazy `install_canonical_product_observation_gate()` call from `product_runtime_observation_gate.py`;
- add runtime-topology regressions proving observed execution does not replace browser-native function identities;
- document the static ownership and preserved contracts;
- format the touched historical `browser_native_client.py` surface as required by the PR12.1 changed-file Ruff gate.

## Scope boundary

This PR is Python-side topology cleanup only. It does **not** touch the browser extension/service worker, ordinary-text conversation identity authority (#79/#80), Browser Authority, canonical-finality authority, retry/replay policy, Temporary Chat, rich-input authority, or browserless transport behavior.

## Observation contract

The existing PR9.3 helpers remain the implementation of exact-assistant source/citation normalization, privacy filtering, and stream/canonical deduplication. The historical installer remains compatibility-safe and identity-stable because the intrinsic browser-native functions are already composed and marked. Runtime behavior no longer depends on a previous observed execution having mutated function ownership.

## Validation

Exact head `71241dbbe33b5249952c32da68edb21dc2853675`, CI #863: **SUCCESS**.

- Engineering quality: PASS (Ruff delta + architecture debt, compileall, extension JS syntax)
- Ubuntu Python 3.10–3.14: PASS
- Windows Python 3.10–3.14: PASS
- release artifact build / package metadata / release contract: PASS
- installed-wheel smoke: Ubuntu + Windows, Python 3.10 + 3.14: PASS