### PR TITLE
PR13.0 — Canonical Conversation Read v2

### DIFF
--- a/docs/engineering/pr13_0_canonical_conversation_read_v2.md
+++ b/docs/engineering/pr13_0_canonical_conversation_read_v2.md
@@ -1,0 +1,108 @@
+# PR13.0 — Canonical Conversation Read v2
+
+PR13.0 repairs the canonical read plane for the current ChatGPT conversation
+history surface while retaining a bounded compatibility path for cohorts that
+still expose the legacy conversation endpoint.
+
+## Drift evidence
+
+Independent dated product measurement in August/September 2026 observed the
+ordinary saved-conversation read move from:
+
+```text
+GET /backend-api/conversation/{id}
+```
+
+with a `mapping` tree to:
+
+```text
+GET /backend-api/conversations/{id}?include_has_versions=true&num_turns=100
+```
+
+with a flat `messages[]` current branch and `page_info` pagination. Older pages
+are requested with `before=<start_cursor>`. The observed endpoint rejects an
+unbounded `num_turns`; PR13.0 therefore uses the observed 100-turn page size and
+bounds total pagination separately.
+
+The external observation is treated as a drift signal, not as runtime authority.
+CWA preserves its own fail-closed identity, finality, retry and Browser Authority
+contracts.
+
+## Wire-shape normalization
+
+CWA consumers continue to operate on one canonical current-branch contract.
+
+- a legacy payload that already contains `mapping` remains unchanged;
+- a current payload containing ordered `messages[]` is normalized into a
+  deterministic linear `mapping` keyed by product-owned message ids;
+- parent/children links represent only the ordered current branch supplied by the
+  product;
+- no sibling/version tree is invented;
+- duplicate message ids or an unbound `current_node` fail closed.
+
+This keeps `status`, `attach`, canonical finality and existing message parsing
+independent of the upstream wire format.
+
+## Read policy
+
+The normal canonical read used by finality/status fetches one current page only.
+It must not paginate the full history during every finality poll.
+
+Full pagination is a separate path used when a consumer requests unbounded or
+large message history. Pagination:
+
+- follows `page_info.has_previous_page` through `start_cursor`;
+- sends `before=<cursor>`;
+- rejects repeated cursors;
+- is bounded to 100 pages;
+- rejects conversation-id disagreement across pages;
+- deduplicates stable message ids at page boundaries.
+
+## Compatibility fallback
+
+The current plural endpoint is always attempted first. A legacy singular read is
+authorized only by a current-endpoint HTTP 404. Authentication failures,
+challenges, validation failures and server errors do not trigger fallback.
+
+This keeps cohort compatibility without turning arbitrary current-endpoint
+failures into hidden transport substitution.
+
+## Browser-owned read plane
+
+`service_worker_canonical_read_v2.js` owns the active authenticated browser-context
+read. It preserves the PR11.2 authority lane and SHA-256 sealed chunk transfer.
+The active read-domain assembly imports v2 explicitly; the old PR11.2 file remains
+historical evidence and is not modified in place.
+
+For a one-page read the exact successful response bytes are transferred. When
+full history is requested, the browser assembles the bounded paginated payload,
+serializes that assembled object, and seals the resulting bytes before crossing
+the local bridge.
+
+## Authority invariants
+
+PR13.0 does not change:
+
+```text
+streaming != canonical finality
+observation != write authority
+ambiguous write -> reconciliation -> no automatic retry
+```
+
+It also does not touch ordinary-text write identity (#79/#80), rich-input request
+binding, Temporary Chat identity, connector authorization or generated-artifact
+handoff.
+
+## Follow-up experiment
+
+After PR13.0 stabilizes, the next bounded research gate is the newly observed
+conversation-owned files surface:
+
+```text
+GET /backend-api/conversations/{id}/files
+```
+
+That probe will test one narrow question: whether the product now exposes stable
+conversation-owned generated-artifact identity sufficient to reconsider the
+currently frozen artifact-download handoff. It is intentionally not part of
+PR13.0.

--- a/docs/engineering/pr13_0_canonical_conversation_read_v2.md
+++ b/docs/engineering/pr13_0_canonical_conversation_read_v2.md
@@ -16,17 +16,30 @@ GET /backend-api/conversation/{id}
 with a `mapping` tree to:
 
 ```text
-GET /backend-api/conversations/{id}?include_has_versions=true&num_turns=100
+GET /backend-api/conversations/{id}?include_has_versions=true&num_turns=<hint>
 ```
 
 with a flat `messages[]` current branch and `page_info` pagination. Older pages
-are requested with `before=<start_cursor>`. The observed endpoint rejects an
-unbounded `num_turns`; PR13.0 therefore uses the observed 100-turn page size and
-bounds total pagination separately.
+are requested with `before=<start_cursor>`.
 
-The external observation is treated as a drift signal, not as runtime authority.
-CWA preserves its own fail-closed identity, finality, retry and Browser Authority
-contracts.
+Initial external drift measurements commonly showed `num_turns=100`. An
+authenticated PR13.0 live gate on 2026-09-10 then reproduced a long-conversation
+failure on the same current plural surface: `num_turns=100` returned HTTP 500
+after about 30 seconds. The same conversation with `num_turns=20` returned HTTP
+200 with a flat `messages[]` response, `page_info.has_previous_page=true`, and a
+valid `start_cursor`. The response contained 1107 message records despite the
+query value 20. The singular `/backend-api/conversation/{id}` surface returned
+HTTP 500 for that conversation as well.
+
+PR13.0 therefore treats `num_turns=20` as a product-observed server query hint,
+not as a client-side page-size or message-count guarantee. Pagination completeness
+continues to be governed exclusively by `page_info`, while bounded `get_messages`
+requests decide whether another page is needed from the number of actually parsed
+messages rather than from the query hint.
+
+The external observation and authenticated live gate are treated as drift/evidence
+signals, not as runtime authority. CWA preserves its own fail-closed identity,
+finality, retry and Browser Authority contracts.
 
 ## Wire-shape normalization
 
@@ -45,11 +58,16 @@ independent of the upstream wire format.
 
 ## Read policy
 
-The normal canonical read used by finality/status fetches one current page only.
-It must not paginate the full history during every finality poll.
+The normal canonical read used by finality/status fetches one current response
+only. It must not paginate the full history during every finality poll.
 
-Full pagination is a separate path used when a consumer requests unbounded or
-large message history. Pagination:
+For `get_messages(limit=N)`, CWA first parses one bounded current response. If that
+response already supplies at least `N` matching messages, it stops there. If the
+response is insufficient and `page_info.has_previous_page=true`, it uses the full
+reader. This deliberately avoids assuming that the `num_turns` query hint equals a
+message count.
+
+Unbounded message history uses full pagination directly. Pagination:
 
 - follows `page_info.has_previous_page` through `start_cursor`;
 - sends `before=<cursor>`;
@@ -64,6 +82,10 @@ The current plural endpoint is always attempted first. A legacy singular read is
 authorized only by a current-endpoint HTTP 404. Authentication failures,
 challenges, validation failures and server errors do not trigger fallback.
 
+The long-chat live gate showed that the singular endpoint can itself return HTTP
+500, so PR13.0 deliberately does not hide current-endpoint server failures behind
+an unproven singular recovery path.
+
 This keeps cohort compatibility without turning arbitrary current-endpoint
 failures into hidden transport substitution.
 
@@ -74,7 +96,10 @@ read. It preserves the PR11.2 authority lane and SHA-256 sealed chunk transfer.
 The active read-domain assembly imports v2 explicitly; the old PR11.2 file remains
 historical evidence and is not modified in place.
 
-For a one-page read the exact successful response bytes are transferred. When
+The browser-owned path uses the same `num_turns=20` server query hint and the same
+`page_info`/`before` completeness contract as the direct canonical reader.
+
+For a one-response read the exact successful response bytes are transferred. When
 full history is requested, the browser assembles the bounded paginated payload,
 serializes that assembled object, and seals the resulting bytes before crossing
 the local bridge.
@@ -95,14 +120,5 @@ handoff.
 
 ## Follow-up experiment
 
-After PR13.0 stabilizes, the next bounded research gate is the newly observed
-conversation-owned files surface:
-
-```text
-GET /backend-api/conversations/{id}/files
-```
-
-That probe will test one narrow question: whether the product now exposes stable
-conversation-owned generated-artifact identity sufficient to reconsider the
-currently frozen artifact-download handoff. It is intentionally not part of
-PR13.0.
+The conversation-owned files surface was investigated separately in PR13.1–13.4
+and is not part of this canonical conversation-read change.

--- a/src/chatgpt_web_adapter/browser_context_canonical_v2.py
+++ b/src/chatgpt_web_adapter/browser_context_canonical_v2.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import socket
+import time
+import uuid
+from typing import Any
+
+from .browser_context_canonical import (
+    BROWSER_CONTEXT_CANONICAL_READ_PLANE,
+    BrowserContextCanonicalReadError,
+    _CanonicalReadChunkCollector,
+)
+from .browser_context_canonical import (
+    BrowserContextCanonicalClient as _LegacyBrowserContextCanonicalClient,
+)
+from .browser_context_canonical import (
+    BrowserContextCanonicalTransport as _LegacyBrowserContextCanonicalTransport,
+)
+from .browser_native_protocol import (
+    PROTOCOL_VERSION,
+    recv_local_message,
+    send_local_message,
+)
+from .browser_native_provider import BrowserNativeTurnProvider
+from .conversation_read_v2 import get_messages_v2, normalize_conversation_payload
+from .types import ConversationRef
+
+
+class BrowserContextCanonicalTransportV2(_LegacyBrowserContextCanonicalTransport):
+    """Read current ChatGPT conversation pages through the authenticated tab."""
+
+    def _read_wire_conversation(
+        self,
+        conversation_id: str,
+        *,
+        timeout: float | None = None,
+        include_all_pages: bool,
+    ) -> dict[str, Any]:
+        ref = ConversationRef(conversation_id)
+        read_timeout = self.read_timeout if timeout is None else float(timeout)
+        if read_timeout <= 0:
+            raise ValueError("timeout must be positive")
+
+        descriptor = self._descriptor()
+        request_id = str(uuid.uuid4())
+        request = {
+            "protocol": PROTOCOL_VERSION,
+            "token": descriptor["token"],
+            "type": "canonical_read",
+            "request_id": request_id,
+            "conversationId": ref.conversation_id,
+            "timeoutMs": int(read_timeout * 1000),
+            "browserAuthorityLeaseId": self._lease_id(),
+            "includeAllPages": bool(include_all_pages),
+        }
+        collector = _CanonicalReadChunkCollector(request_id=request_id)
+        deadline = time.monotonic() + read_timeout + 6.0
+
+        try:
+            remaining = max(0.1, deadline - time.monotonic())
+            with socket.create_connection(
+                (descriptor["host"], descriptor["port"]),
+                timeout=min(
+                    float(getattr(self.provider, "connect_timeout", 3.0)),
+                    remaining,
+                ),
+            ) as sock:
+                sock.settimeout(remaining)
+                send_local_message(sock, request)
+                while True:
+                    frame = recv_local_message(sock)
+                    if frame.get("protocol") != PROTOCOL_VERSION:
+                        raise BrowserContextCanonicalReadError(
+                            "CANONICAL_READ_PROTOCOL_MISMATCH",
+                            conversation_id=ref.conversation_id,
+                        )
+                    if frame.get("request_id") != request_id:
+                        raise BrowserContextCanonicalReadError(
+                            "CANONICAL_READ_RESPONSE_MISMATCH",
+                            conversation_id=ref.conversation_id,
+                        )
+                    if frame.get("type") == "canonical_read_chunk":
+                        try:
+                            collector.add(frame)
+                        except ValueError as error:
+                            raise BrowserContextCanonicalReadError(
+                                str(error),
+                                conversation_id=ref.conversation_id,
+                            ) from error
+                        continue
+                    response = frame
+                    break
+        except BrowserContextCanonicalReadError:
+            raise
+        except (OSError, EOFError, ValueError) as error:
+            raise BrowserContextCanonicalReadError(
+                "CANONICAL_READ_BRIDGE_FAILURE",
+                conversation_id=ref.conversation_id,
+            ) from error
+
+        if response.get("ok") is not True:
+            reason = response.get("reasonCode") or response.get("error")
+            status = response.get("status")
+            status_code = (
+                status
+                if isinstance(status, int) and not isinstance(status, bool)
+                else None
+            )
+            raise BrowserContextCanonicalReadError(
+                reason if isinstance(reason, str) else "CANONICAL_READ_FAILED",
+                conversation_id=ref.conversation_id,
+                status_code=status_code,
+                content_type=(
+                    response.get("contentType")
+                    if isinstance(response.get("contentType"), str)
+                    else None
+                ),
+                retryable=response.get("retryable") is True,
+            )
+        if response.get("type") != "canonical_read_result":
+            raise BrowserContextCanonicalReadError(
+                "CANONICAL_READ_RESULT_TYPE_INVALID",
+                conversation_id=ref.conversation_id,
+            )
+
+        try:
+            raw_body = collector.finish(response)
+            payload = json.loads(raw_body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+            reason = str(error)
+            raise BrowserContextCanonicalReadError(
+                reason
+                if reason.startswith("CANONICAL_READ_")
+                else "CANONICAL_READ_MALFORMED_JSON",
+                conversation_id=ref.conversation_id,
+                status_code=(
+                    response.get("status")
+                    if isinstance(response.get("status"), int)
+                    and not isinstance(response.get("status"), bool)
+                    else None
+                ),
+                content_type=(
+                    response.get("contentType")
+                    if isinstance(response.get("contentType"), str)
+                    else None
+                ),
+            ) from error
+        if not isinstance(payload, dict):
+            raise BrowserContextCanonicalReadError(
+                "CANONICAL_READ_JSON_OBJECT_REQUIRED",
+                conversation_id=ref.conversation_id,
+            )
+        return payload
+
+    def read_conversation(
+        self,
+        conversation_id: str,
+        *,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        payload = self._read_wire_conversation(
+            conversation_id,
+            timeout=timeout,
+            include_all_pages=False,
+        )
+        return normalize_conversation_payload(payload)
+
+    def read_full_conversation(
+        self,
+        conversation_id: str,
+        *,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        payload = self._read_wire_conversation(
+            conversation_id,
+            timeout=timeout,
+            include_all_pages=True,
+        )
+        return normalize_conversation_payload(payload)
+
+
+class BrowserContextCanonicalClientV2(_LegacyBrowserContextCanonicalClient):
+    """Canonical client that understands current flat/paginated conversation reads."""
+
+    def __init__(
+        self,
+        source_client: Any,
+        provider: BrowserNativeTurnProvider,
+        *,
+        read_timeout: float = 30.0,
+    ) -> None:
+        super().__init__(source_client, provider, read_timeout=read_timeout)
+        self.transport = BrowserContextCanonicalTransportV2(
+            provider,
+            read_timeout=read_timeout,
+        )
+
+    def _get_full_conversation_payload(self, conversation_id: str) -> dict[str, Any]:
+        return self.transport.read_full_conversation(conversation_id)
+
+    get_messages = get_messages_v2
+
+
+__all__ = [
+    "BROWSER_CONTEXT_CANONICAL_READ_PLANE",
+    "BrowserContextCanonicalClientV2",
+    "BrowserContextCanonicalReadError",
+    "BrowserContextCanonicalTransportV2",
+]

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_canonical_read_v2.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_canonical_read_v2.js
@@ -1,0 +1,459 @@
+const _cwaCanonicalPriorOnNativeMessage = onNativeMessage;
+const CWA_CANONICAL_CHUNK_BASE64_CHARS = 600_000;
+const CWA_CANONICAL_CURRENT_NUM_TURNS = 100;
+const CWA_CANONICAL_MAX_PAGES = 100;
+
+function _cwaCanonicalConversationId(value) {
+  const conversationId = typeof value === "string" ? value.trim() : "";
+  if (
+    !conversationId ||
+    conversationId.includes("/") ||
+    conversationId.includes("?") ||
+    conversationId.includes("#")
+  ) {
+    throw new Error("CANONICAL_READ_CONVERSATION_ID_REQUIRED");
+  }
+  return conversationId;
+}
+
+function _cwaCanonicalStableReason(error) {
+  const message = error instanceof Error ? error.message : String(error || "");
+  return /^[A-Z0-9_]+$/.test(message)
+    ? message
+    : "CANONICAL_READ_BROWSER_ERROR";
+}
+
+async function _cwaCanonicalRuntimeTab() {
+  const storedId = await storedRuntimeTabId();
+  if (Number.isInteger(storedId)) {
+    try {
+      const tab = await chrome.tabs.get(storedId);
+      if (isChatGPTUrl(tab?.url || "")) {
+        return tab.status === "complete" ? tab : waitForTabComplete(storedId);
+      }
+    } catch {
+      // Stale runtime-tab state is replaced without navigating another tab.
+    }
+  }
+
+  const tab = await chrome.tabs.create({ url: `${CHATGPT_ORIGIN}/`, active: false });
+  if (!Number.isInteger(tab?.id)) {
+    throw new Error("CANONICAL_READ_RUNTIME_TAB_CREATE_FAILED");
+  }
+  await storeRuntimeTabId(tab.id);
+  return waitForTabComplete(tab.id);
+}
+
+async function _cwaCanonicalFetch(
+  tabId,
+  conversationId,
+  timeoutMs,
+  includeAllPages
+) {
+  const debuggee = { tabId };
+  const encodedConversationId = encodeURIComponent(conversationId);
+  const currentEndpoint = `${CHATGPT_ORIGIN}/backend-api/conversations/${encodedConversationId}`;
+  const legacyEndpoint = `${CHATGPT_ORIGIN}/backend-api/conversation/${encodedConversationId}`;
+  const expression = `(async () => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ${JSON.stringify(timeoutMs)});
+    const currentNumTurns = ${JSON.stringify(CWA_CANONICAL_CURRENT_NUM_TURNS)};
+    const maxPages = ${JSON.stringify(CWA_CANONICAL_MAX_PAGES)};
+    const includeAllPages = ${JSON.stringify(includeAllPages === true)};
+    const currentEndpoint = ${JSON.stringify(currentEndpoint)};
+    const legacyEndpoint = ${JSON.stringify(legacyEndpoint)};
+
+    const failureForResponse = (response, contentType) => ({
+      ok: false,
+      status: response.status,
+      contentType,
+      reasonCode: response.status === 404
+        ? "CANONICAL_READ_NOT_VISIBLE"
+        : response.status === 401
+          ? "CANONICAL_READ_AUTHENTICATION_REQUIRED"
+          : response.status === 403
+            ? "CANONICAL_READ_ACCESS_CHALLENGED"
+            : "CANONICAL_READ_HTTP_ERROR",
+      retryable: response.status === 404
+    });
+
+    const fetchBytes = async (url) => {
+      const response = await fetch(url, {
+        method: "GET",
+        credentials: "include",
+        cache: "no-store",
+        headers: { accept: "application/json" },
+        signal: controller.signal
+      });
+      const contentType = (response.headers.get("content-type") || "").slice(0, 128);
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      if (!response.ok) {
+        return { ...failureForResponse(response, contentType), bytes };
+      }
+      if (!contentType.toLowerCase().includes("json")) {
+        return {
+          ok: false,
+          status: response.status,
+          contentType,
+          reasonCode: "CANONICAL_READ_NON_JSON",
+          retryable: false,
+          bytes
+        };
+      }
+      let payload;
+      try {
+        payload = JSON.parse(new TextDecoder().decode(bytes));
+      } catch {
+        return {
+          ok: false,
+          status: response.status,
+          contentType,
+          reasonCode: "CANONICAL_READ_MALFORMED_JSON",
+          retryable: false,
+          bytes
+        };
+      }
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        return {
+          ok: false,
+          status: response.status,
+          contentType,
+          reasonCode: "CANONICAL_READ_JSON_OBJECT_REQUIRED",
+          retryable: false,
+          bytes
+        };
+      }
+      return {
+        ok: true,
+        status: response.status,
+        contentType,
+        bytes,
+        payload
+      };
+    };
+
+    const currentUrl = (before = null) => {
+      const url = new URL(currentEndpoint);
+      url.searchParams.set("include_has_versions", "true");
+      url.searchParams.set("num_turns", String(currentNumTurns));
+      if (before !== null) url.searchParams.set("before", before);
+      return url.toString();
+    };
+
+    const messageIdentity = (item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) return null;
+      if (item.message && typeof item.message === "object" && !Array.isArray(item.message)) {
+        return typeof item.message.id === "string" && item.message.id
+          ? item.message.id
+          : typeof item.id === "string" && item.id
+            ? item.id
+            : null;
+      }
+      return typeof item.id === "string" && item.id ? item.id : null;
+    };
+
+    const transfer = async (bytes, status, contentType) => {
+      const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+      const sha256 = Array.from(
+        digest,
+        (value) => value.toString(16).padStart(2, "0")
+      ).join("");
+      let bodyBase64 = "";
+      const binaryBlockBytes = 24_576;
+      for (let offset = 0; offset < bytes.length; offset += binaryBlockBytes) {
+        const block = bytes.subarray(offset, offset + binaryBlockBytes);
+        let binary = "";
+        for (let index = 0; index < block.length; index += 1) {
+          binary += String.fromCharCode(block[index]);
+        }
+        bodyBase64 += btoa(binary);
+      }
+      return {
+        ok: true,
+        status,
+        contentType,
+        totalBytes: bytes.length,
+        sha256,
+        bodyBase64
+      };
+    };
+
+    try {
+      const first = await fetchBytes(currentUrl());
+      if (first.ok !== true) {
+        if (first.status !== 404) return first;
+        const legacy = await fetchBytes(legacyEndpoint);
+        if (legacy.ok !== true) return legacy;
+        if (!legacy.payload.mapping || typeof legacy.payload.mapping !== "object") {
+          return {
+            ok: false,
+            status: legacy.status,
+            contentType: legacy.contentType,
+            reasonCode: "CANONICAL_READ_LEGACY_SHAPE_INVALID",
+            retryable: false
+          };
+        }
+        return transfer(legacy.bytes, legacy.status, legacy.contentType);
+      }
+
+      if (Array.isArray(first.payload.messages)) {
+        if (!includeAllPages) {
+          return transfer(first.bytes, first.status, first.contentType);
+        }
+
+        const pages = [first.payload];
+        const seenCursors = new Set();
+        while (true) {
+          const page = pages[pages.length - 1];
+          const pageInfo = page.page_info;
+          if (!pageInfo || pageInfo.has_previous_page !== true) break;
+          const cursor = typeof pageInfo.start_cursor === "string"
+            ? pageInfo.start_cursor.trim()
+            : "";
+          if (!cursor) {
+            return {
+              ok: false,
+              status: first.status,
+              contentType: first.contentType,
+              reasonCode: "CANONICAL_READ_PAGINATION_CURSOR_INVALID",
+              retryable: false
+            };
+          }
+          if (seenCursors.has(cursor)) {
+            return {
+              ok: false,
+              status: first.status,
+              contentType: first.contentType,
+              reasonCode: "CANONICAL_READ_PAGINATION_CURSOR_REPEATED",
+              retryable: false
+            };
+          }
+          if (pages.length >= maxPages) {
+            return {
+              ok: false,
+              status: first.status,
+              contentType: first.contentType,
+              reasonCode: "CANONICAL_READ_PAGINATION_LIMIT",
+              retryable: false
+            };
+          }
+          seenCursors.add(cursor);
+          const older = await fetchBytes(currentUrl(cursor));
+          if (older.ok !== true) return older;
+          if (!Array.isArray(older.payload.messages)) {
+            return {
+              ok: false,
+              status: older.status,
+              contentType: older.contentType,
+              reasonCode: "CANONICAL_READ_CURRENT_SHAPE_INVALID",
+              retryable: false
+            };
+          }
+          if (
+            typeof first.payload.conversation_id === "string" &&
+            typeof older.payload.conversation_id === "string" &&
+            first.payload.conversation_id !== older.payload.conversation_id
+          ) {
+            return {
+              ok: false,
+              status: older.status,
+              contentType: older.contentType,
+              reasonCode: "CANONICAL_READ_PAGINATION_IDENTITY_MISMATCH",
+              retryable: false
+            };
+          }
+          pages.push(older.payload);
+        }
+
+        const mergedMessages = [];
+        const seenMessageIds = new Set();
+        for (const page of pages.slice().reverse()) {
+          for (const item of page.messages) {
+            const identity = messageIdentity(item);
+            if (identity && seenMessageIds.has(identity)) continue;
+            if (identity) seenMessageIds.add(identity);
+            mergedMessages.push(item);
+          }
+        }
+        const mergedPayload = { ...first.payload, messages: mergedMessages };
+        const mergedBytes = new TextEncoder().encode(JSON.stringify(mergedPayload));
+        return transfer(mergedBytes, first.status, first.contentType);
+      }
+
+      if (first.payload.mapping && typeof first.payload.mapping === "object") {
+        return transfer(first.bytes, first.status, first.contentType);
+      }
+
+      return {
+        ok: false,
+        status: first.status,
+        contentType: first.contentType,
+        reasonCode: "CANONICAL_READ_CURRENT_SHAPE_INVALID",
+        retryable: false
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        status: null,
+        contentType: null,
+        reasonCode: error?.name === "AbortError"
+          ? "CANONICAL_READ_TIMEOUT"
+          : "CANONICAL_READ_NETWORK_ERROR",
+        retryable: false
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  })()`;
+
+  let attached = false;
+  try {
+    await chrome.debugger.attach(debuggee, CDP_PROTOCOL_VERSION);
+    attached = true;
+    const result = await chrome.debugger.sendCommand(debuggee, "Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: true
+    });
+    if (result?.exceptionDetails) {
+      throw new Error("CANONICAL_READ_RUNTIME_EVALUATION_FAILED");
+    }
+    const value = result?.result?.value;
+    if (!value || typeof value !== "object") {
+      throw new Error("CANONICAL_READ_RUNTIME_RESULT_INVALID");
+    }
+    return value;
+  } finally {
+    if (attached) {
+      try { await chrome.debugger.detach(debuggee); } catch {}
+    }
+  }
+}
+
+async function _cwaCanonicalRead(message, port) {
+  const requestId = message.request_id;
+  const conversationId = _cwaCanonicalConversationId(message.conversationId);
+  const timeoutMs = Number.isFinite(message.timeoutMs)
+    ? Math.max(1_000, Math.min(Number(message.timeoutMs), 120_000))
+    : 30_000;
+  const leaseId =
+    typeof message.browserAuthorityLeaseId === "string" &&
+    message.browserAuthorityLeaseId.trim()
+      ? message.browserAuthorityLeaseId.trim()
+      : null;
+  const includeAllPages = message.includeAllPages === true;
+
+  if (leaseId !== null) {
+    const storedLeaseId = await _pr88StoredLeaseId();
+    if (storedLeaseId !== leaseId) {
+      throw new Error("CANONICAL_READ_AUTHORITY_LEASE_MISMATCH");
+    }
+  }
+
+  const tab = await _cwaCanonicalRuntimeTab();
+  if (!Number.isInteger(tab?.id)) {
+    throw new Error("CANONICAL_READ_RUNTIME_TAB_REQUIRED");
+  }
+  const fetched = await _cwaCanonicalFetch(
+    tab.id,
+    conversationId,
+    timeoutMs,
+    includeAllPages
+  );
+  if (fetched.ok !== true) {
+    safePortPost(port, {
+      protocol: BRIDGE_PROTOCOL_VERSION,
+      type: "canonical_read_result",
+      request_id: requestId,
+      ok: false,
+      reasonCode: fetched.reasonCode,
+      status: fetched.status,
+      contentType: fetched.contentType,
+      retryable: fetched.retryable === true
+    });
+    return;
+  }
+
+  const bodyBase64 = fetched.bodyBase64;
+  if (
+    typeof bodyBase64 !== "string" ||
+    !/^[0-9a-f]{64}$/.test(fetched.sha256 || "")
+  ) {
+    throw new Error("CANONICAL_READ_TRANSFER_SOURCE_INVALID");
+  }
+  const chunkCount = Math.max(
+    1,
+    Math.ceil(bodyBase64.length / CWA_CANONICAL_CHUNK_BASE64_CHARS)
+  );
+
+  for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+    const data = bodyBase64.slice(
+      chunkIndex * CWA_CANONICAL_CHUNK_BASE64_CHARS,
+      (chunkIndex + 1) * CWA_CANONICAL_CHUNK_BASE64_CHARS
+    );
+    if (!safePortPost(port, {
+      protocol: BRIDGE_PROTOCOL_VERSION,
+      type: "canonical_read_chunk",
+      request_id: requestId,
+      chunkIndex,
+      chunkCount,
+      totalBytes: fetched.totalBytes,
+      sha256: fetched.sha256,
+      data
+    })) {
+      throw new Error("CANONICAL_READ_CHUNK_DELIVERY_FAILED");
+    }
+  }
+
+  safePortPost(port, {
+    protocol: BRIDGE_PROTOCOL_VERSION,
+    type: "canonical_read_result",
+    request_id: requestId,
+    ok: true,
+    status: fetched.status,
+    contentType: fetched.contentType,
+    chunkCount,
+    totalBytes: fetched.totalBytes,
+    sha256: fetched.sha256,
+    browserAuthorityLeaseId: leaseId,
+    runtimeTabId: tab.id
+  });
+}
+
+onNativeMessage = async function _cwaOnNativeMessageWithCanonicalRead(message, port) {
+  if (
+    message?.protocol !== BRIDGE_PROTOCOL_VERSION ||
+    message?.type !== "canonical_read"
+  ) {
+    return _cwaCanonicalPriorOnNativeMessage(message, port);
+  }
+  const requestId = message.request_id;
+  if (typeof requestId !== "string" || !requestId) return;
+  if (activeRequestId !== null) {
+    safePortPost(port, {
+      protocol: BRIDGE_PROTOCOL_VERSION,
+      type: "canonical_read_result",
+      request_id: requestId,
+      ok: false,
+      reasonCode: "BROWSER_NATIVE_EXTENSION_BUSY",
+      retryable: false
+    });
+    return;
+  }
+
+  activeRequestId = requestId;
+  try {
+    await _cwaCanonicalRead(message, port);
+  } catch (error) {
+    safePortPost(port, {
+      protocol: BRIDGE_PROTOCOL_VERSION,
+      type: "canonical_read_result",
+      request_id: requestId,
+      ok: false,
+      reasonCode: _cwaCanonicalStableReason(error),
+      retryable: false
+    });
+  } finally {
+    activeRequestId = null;
+  }
+};

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_canonical_read_v2.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_canonical_read_v2.js
@@ -1,6 +1,7 @@
 const _cwaCanonicalPriorOnNativeMessage = onNativeMessage;
 const CWA_CANONICAL_CHUNK_BASE64_CHARS = 600_000;
-const CWA_CANONICAL_CURRENT_NUM_TURNS = 100;
+// Product-observed server query hint. It is not a message-count guarantee.
+const CWA_CANONICAL_CURRENT_NUM_TURNS = 20;
 const CWA_CANONICAL_MAX_PAGES = 100;
 
 function _cwaCanonicalConversationId(value) {

--- a/src/chatgpt_web_adapter/browser_native_extension/service_worker_runtime_read.js
+++ b/src/chatgpt_web_adapter/browser_native_extension/service_worker_runtime_read.js
@@ -4,4 +4,4 @@
 // reads are read-only. They do not acquire submit/retry authority.
 
 importScripts("service_worker_product_source_citations_pr9_3.js");
-importScripts("service_worker_canonical_read.js");
+importScripts("service_worker_canonical_read_v2.js");

--- a/src/chatgpt_web_adapter/browser_owned_product_transport.py
+++ b/src/chatgpt_web_adapter/browser_owned_product_transport.py
@@ -8,7 +8,10 @@ from .browser_authority_lease import (
     BrowserAuthorityPolicy,
     resolve_browser_authority_policy,
 )
-from .browser_context_canonical import BrowserContextCanonicalClient
+from .browser_context_canonical import (
+    BrowserContextCanonicalClient as _LegacyBrowserContextCanonicalClient,
+)
+from .browser_context_canonical_v2 import BrowserContextCanonicalClientV2
 from .browser_native_provider import BrowserNativeTurnProvider
 from .browser_owned_submission_lifecycle import BrowserOwnedSubmissionLifecycle
 from .browser_owned_write_runtime import BrowserOwnedProductWriteRuntime
@@ -49,9 +52,9 @@ class BrowserOwnedProductTransport(_core.BrowserOwnedProductTransport):
         )
         self.canonical_client = (
             source_canonical
-            if isinstance(source_canonical, BrowserContextCanonicalClient)
+            if isinstance(source_canonical, _LegacyBrowserContextCanonicalClient)
             or not self._browser_context_canonical_enabled
-            else BrowserContextCanonicalClient(source_canonical, self.provider)
+            else BrowserContextCanonicalClientV2(source_canonical, self.provider)
         )
         self._model_profile_selection_supported = callable(
             getattr(self.provider, "require_profile", None)

--- a/src/chatgpt_web_adapter/client.py
+++ b/src/chatgpt_web_adapter/client.py
@@ -12,12 +12,17 @@ from .browser_native_client import (
     set_browser_native_turn_provider as _set_browser_native_turn_provider,
 )
 from .browserless_request_guards import gate_browserless_poll_deadline
+from .conversation_read_v2 import (
+    get_messages_v2 as _get_messages_v2,
+)
+from .conversation_read_v2 import (
+    read_conversation_payload_v2 as _read_conversation_payload_v2,
+)
 from .conversation_send import send_to_conversation as _send_to_conversation
 from .diagnostic_metrics import (
     send_with_expanded_metrics as _send_with_expanded_metrics,
 )
 from .export import export_conversation as _export_conversation
-from .messages import get_messages as _get_messages
 from .model_registry import (
     DEFAULT_MODEL as DEFAULT_MODEL,
 )
@@ -105,6 +110,21 @@ CHAT_FILES_URL = _core.CHAT_FILES_URL
 CELSIUS_WS_USER_URL = _core.CELSIUS_WS_USER_URL
 
 
+def _conversation_endpoint_override_active() -> bool:
+    """Preserve the historical endpoint-override compatibility seam.
+
+    PR12.3 deliberately kept endpoint constants patchable from this public module.
+    A consumer that replaces either conversation endpoint is therefore opting into
+    that historical contract; do not silently reinterpret its mock/server as the
+    newer plural item endpoint.
+    """
+
+    return (
+        CHAT_CONVERSATION_URL != _core.CHAT_CONVERSATION_URL
+        or CHAT_CONVERSATIONS_URL != _core.CHAT_CONVERSATIONS_URL
+    )
+
+
 def _remap_legacy_endpoint(url: str) -> str:
     for historical, current in (
         (_core.CHAT_REQUIREMENTS_URL, CHAT_REQUIREMENTS_URL),
@@ -183,6 +203,34 @@ class ChatGPTWebClient(_core.ChatGPTWebClient):
             follow_redirects=follow_redirects,
         )
 
+    def _get_conversation_payload(self, conversation_id: str) -> dict[str, Any]:
+        if _conversation_endpoint_override_active():
+            return _core.ChatGPTWebClient._get_conversation_payload(
+                self,
+                conversation_id,
+            )
+        return _read_conversation_payload_v2(
+            self,
+            conversation_id,
+            current_base_url=CHAT_CONVERSATIONS_URL,
+            legacy_url_template=CHAT_CONVERSATION_URL,
+            include_all_pages=False,
+        )
+
+    def _get_full_conversation_payload(self, conversation_id: str) -> dict[str, Any]:
+        if _conversation_endpoint_override_active():
+            return _core.ChatGPTWebClient._get_conversation_payload(
+                self,
+                conversation_id,
+            )
+        return _read_conversation_payload_v2(
+            self,
+            conversation_id,
+            current_base_url=CHAT_CONVERSATIONS_URL,
+            legacy_url_template=CHAT_CONVERSATION_URL,
+            include_all_pages=True,
+        )
+
     _get_ready_requirements = _gate_prepared_get_ready_requirements(
         _gate_get_ready_requirements(_core.ChatGPTWebClient._get_ready_requirements)
     )
@@ -208,7 +256,7 @@ class ChatGPTWebClient(_core.ChatGPTWebClient):
     )
     attach_conversation = _attach_conversation
     export_conversation = _export_conversation
-    get_messages = _get_messages
+    get_messages = _get_messages_v2
     get_pending_approval = _get_pending_approval
     get_required_action = _get_required_action
     get_status = _get_status

--- a/src/chatgpt_web_adapter/conversation_read_v2.py
+++ b/src/chatgpt_web_adapter/conversation_read_v2.py
@@ -338,7 +338,9 @@ def get_messages_v2(
     ref = ConversationRef.from_any(url_or_id)
     if limit is None:
         payload = full_reader(ref.conversation_id)
-        return _legacy_get_messages(_FixedConversationPayloadReader(payload), ref, **kwargs)
+        return _legacy_get_messages(
+            _FixedConversationPayloadReader(payload), ref, **kwargs
+        )
 
     latest_reader = getattr(self, "_get_conversation_payload", None)
     if not callable(latest_reader):

--- a/src/chatgpt_web_adapter/conversation_read_v2.py
+++ b/src/chatgpt_web_adapter/conversation_read_v2.py
@@ -8,7 +8,10 @@ from .exceptions import RequestError
 from .messages import get_messages as _legacy_get_messages
 from .types import ChatConversation, ConversationRef
 
-CURRENT_CONVERSATION_NUM_TURNS = 100
+# Product-observed server query hint. This is not a client-side message-count
+# guarantee: a live long-chat response returned far more than 20 messages while
+# still requiring this smaller value to avoid an upstream HTTP 500.
+CURRENT_CONVERSATION_NUM_TURNS = 20
 MAX_CANONICAL_CONVERSATION_PAGES = 100
 
 
@@ -183,6 +186,11 @@ def _page_cursor(payload: dict[str, Any]) -> str | None:
     return cursor
 
 
+def _has_previous_page(payload: dict[str, Any]) -> bool:
+    page_info = payload.get("page_info")
+    return isinstance(page_info, dict) and page_info.get("has_previous_page") is True
+
+
 def _current_conversation_url(
     base_url: str,
     conversation_id: str,
@@ -297,9 +305,9 @@ def read_conversation_payload_v2(
 
 @dataclass
 class _FixedConversationPayloadReader:
-    payload: dict[str, Any]
+    payload: Any
 
-    def _get_conversation_payload(self, _conversation_id: str) -> dict[str, Any]:
+    def _get_conversation_payload(self, _conversation_id: str) -> Any:
         return self.payload
 
 
@@ -308,7 +316,7 @@ def get_messages_v2(
     url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
     **kwargs: Any,
 ):
-    """Use full pagination only when a requested history can exceed one page."""
+    """Use one bounded page when sufficient; paginate only when history requires it."""
 
     # Preserve the long-standing injected-reader seam. Tests and integrations may
     # replace ``_get_conversation_payload`` on one client instance with an exact
@@ -318,16 +326,36 @@ def get_messages_v2(
         return _legacy_get_messages(self, url_or_id, **kwargs)
 
     limit = kwargs.get("limit")
-    if limit is not None:
-        if isinstance(limit, bool) or not isinstance(limit, int):
-            return _legacy_get_messages(self, url_or_id, **kwargs)
-        if limit <= CURRENT_CONVERSATION_NUM_TURNS:
-            return _legacy_get_messages(self, url_or_id, **kwargs)
+    if limit is not None and (
+        isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0
+    ):
+        return _legacy_get_messages(self, url_or_id, **kwargs)
 
     full_reader = getattr(self, "_get_full_conversation_payload", None)
     if not callable(full_reader):
         return _legacy_get_messages(self, url_or_id, **kwargs)
 
     ref = ConversationRef.from_any(url_or_id)
+    if limit is None:
+        payload = full_reader(ref.conversation_id)
+        return _legacy_get_messages(_FixedConversationPayloadReader(payload), ref, **kwargs)
+
+    latest_reader = getattr(self, "_get_conversation_payload", None)
+    if not callable(latest_reader):
+        return _legacy_get_messages(self, ref, **kwargs)
+
+    latest_payload = latest_reader(ref.conversation_id)
+    latest_messages = _legacy_get_messages(
+        _FixedConversationPayloadReader(latest_payload),
+        ref,
+        **kwargs,
+    )
+    if (
+        len(latest_messages) >= limit
+        or not isinstance(latest_payload, dict)
+        or not _has_previous_page(latest_payload)
+    ):
+        return latest_messages
+
     payload = full_reader(ref.conversation_id)
     return _legacy_get_messages(_FixedConversationPayloadReader(payload), ref, **kwargs)

--- a/src/chatgpt_web_adapter/conversation_read_v2.py
+++ b/src/chatgpt_web_adapter/conversation_read_v2.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote, urlencode
+
+from .exceptions import RequestError
+from .messages import get_messages as _legacy_get_messages
+from .types import ChatConversation, ConversationRef
+
+CURRENT_CONVERSATION_NUM_TURNS = 100
+MAX_CANONICAL_CONVERSATION_PAGES = 100
+
+
+def _optional_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _message_from_flat_item(item: Any) -> tuple[str, dict[str, Any], str | None]:
+    if not isinstance(item, dict):
+        raise RequestError(
+            "canonical conversation messages[] item must be an object",
+            request_stage="conversation_fetch",
+        )
+
+    nested = item.get("message")
+    message = nested if isinstance(nested, dict) else item
+    message_id = _optional_str(message.get("id"))
+    if message_id is None:
+        raise RequestError(
+            "canonical conversation messages[] item missing stable message id",
+            request_stage="conversation_fetch",
+        )
+    source_node_id = _optional_str(item.get("id")) if nested is not None else None
+    return message_id, dict(message), source_node_id
+
+
+def normalize_conversation_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Normalize current flat and legacy tree conversation payloads.
+
+    CWA consumers historically interpret the canonical current branch through a
+    ``mapping`` tree. The current ChatGPT read endpoint instead returns the current
+    branch as an ordered, paginated ``messages[]`` list. For that wire shape we
+    construct a deterministic linear mapping keyed by product-owned message ids.
+
+    No sibling/version tree is fabricated: the synthetic parent/children links
+    represent only the ordered current branch supplied by the product.
+    """
+
+    if not isinstance(payload, dict):
+        raise TypeError("payload must be a dict")
+    if isinstance(payload.get("mapping"), dict):
+        return dict(payload)
+
+    flat_messages = payload.get("messages")
+    if not isinstance(flat_messages, list):
+        raise RequestError(
+            "canonical conversation response has neither mapping nor messages[]",
+            request_stage="conversation_fetch",
+        )
+
+    records: list[tuple[str, dict[str, Any], str | None]] = []
+    seen_ids: set[str] = set()
+    source_aliases: dict[str, str] = {}
+    for item in flat_messages:
+        message_id, message, source_node_id = _message_from_flat_item(item)
+        if message_id in seen_ids:
+            raise RequestError(
+                "canonical conversation messages[] contains duplicate message id",
+                request_stage="conversation_fetch",
+            )
+        seen_ids.add(message_id)
+        records.append((message_id, message, source_node_id))
+        if source_node_id is not None:
+            source_aliases[source_node_id] = message_id
+
+    mapping: dict[str, dict[str, Any]] = {}
+    for index, (message_id, message, _source_node_id) in enumerate(records):
+        parent = records[index - 1][0] if index > 0 else None
+        children = [records[index + 1][0]] if index + 1 < len(records) else []
+        mapping[message_id] = {
+            "id": message_id,
+            "parent": parent,
+            "children": children,
+            "message": message,
+        }
+
+    source_current_node = _optional_str(payload.get("current_node"))
+    normalized_current_node: str | None = None
+    if source_current_node is not None:
+        candidate = source_aliases.get(source_current_node, source_current_node)
+        if candidate not in mapping:
+            raise RequestError(
+                "canonical conversation current_node is not present in messages[]",
+                request_stage="conversation_fetch",
+            )
+        normalized_current_node = candidate
+    elif records:
+        normalized_current_node = records[-1][0]
+
+    normalized = dict(payload)
+    normalized["mapping"] = mapping
+    normalized["current_node"] = normalized_current_node
+    return normalized
+
+
+def _flat_item_identity(item: Any) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    nested = item.get("message")
+    if isinstance(nested, dict):
+        return _optional_str(nested.get("id")) or _optional_str(item.get("id"))
+    return _optional_str(item.get("id"))
+
+
+def merge_conversation_pages(
+    pages_latest_first: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Merge paginated current-endpoint pages into one ordered wire payload."""
+
+    if not pages_latest_first:
+        raise RequestError(
+            "canonical conversation pagination returned no pages",
+            request_stage="conversation_fetch",
+        )
+
+    latest = pages_latest_first[0]
+    expected_conversation_id = _optional_str(latest.get("conversation_id"))
+    merged_messages: list[Any] = []
+    seen_message_ids: set[str] = set()
+
+    for page in reversed(pages_latest_first):
+        if not isinstance(page, dict):
+            raise RequestError(
+                "canonical conversation pagination page must be an object",
+                request_stage="conversation_fetch",
+            )
+        page_conversation_id = _optional_str(page.get("conversation_id"))
+        if (
+            expected_conversation_id is not None
+            and page_conversation_id is not None
+            and page_conversation_id != expected_conversation_id
+        ):
+            raise RequestError(
+                "canonical conversation pagination identity mismatch",
+                request_stage="conversation_fetch",
+            )
+        page_messages = page.get("messages")
+        if not isinstance(page_messages, list):
+            raise RequestError(
+                "canonical conversation pagination page missing messages[]",
+                request_stage="conversation_fetch",
+            )
+        for item in page_messages:
+            identity = _flat_item_identity(item)
+            if identity is not None and identity in seen_message_ids:
+                continue
+            if identity is not None:
+                seen_message_ids.add(identity)
+            merged_messages.append(item)
+
+    merged = dict(latest)
+    merged["messages"] = merged_messages
+    return merged
+
+
+def _page_cursor(payload: dict[str, Any]) -> str | None:
+    page_info = payload.get("page_info")
+    if (
+        not isinstance(page_info, dict)
+        or page_info.get("has_previous_page") is not True
+    ):
+        return None
+    cursor = _optional_str(page_info.get("start_cursor"))
+    if cursor is None:
+        raise RequestError(
+            "canonical conversation pagination is missing start_cursor",
+            request_stage="conversation_fetch",
+        )
+    return cursor
+
+
+def _current_conversation_url(
+    base_url: str,
+    conversation_id: str,
+    *,
+    before: str | None = None,
+) -> str:
+    params: dict[str, str | int] = {
+        "include_has_versions": "true",
+        "num_turns": CURRENT_CONVERSATION_NUM_TURNS,
+    }
+    if before is not None:
+        params["before"] = before
+    return (
+        f"{base_url.rstrip('/')}/{quote(conversation_id, safe='')}?{urlencode(params)}"
+    )
+
+
+def read_conversation_payload_v2(
+    client: Any,
+    conversation_id: str,
+    *,
+    current_base_url: str,
+    legacy_url_template: str,
+    include_all_pages: bool = False,
+) -> dict[str, Any]:
+    """Read the current conversation endpoint with a cohort-safe legacy fallback."""
+
+    ref = ConversationRef(conversation_id)
+    headers = client._build_headers(
+        {
+            "accept": "application/json",
+            "referer": f"https://chatgpt.com/c/{ref.conversation_id}",
+        }
+    )
+
+    current_url = _current_conversation_url(current_base_url, ref.conversation_id)
+    status, data = client._json_request("GET", current_url, None, headers)
+    if status == 404:
+        legacy_url = legacy_url_template.format(conversation_id=ref.conversation_id)
+        legacy_status, legacy_data = client._json_request(
+            "GET", legacy_url, None, headers
+        )
+        if legacy_status >= 400:
+            raise RequestError(
+                f"conversation status={legacy_status}: {legacy_data}",
+                status_code=legacy_status,
+                endpoint="conversation",
+                request_stage="conversation_fetch",
+            )
+        if not isinstance(legacy_data, dict):
+            raise RequestError(
+                "conversation response expected JSON object",
+                request_stage="conversation_fetch",
+            )
+        return normalize_conversation_payload(legacy_data)
+
+    if status >= 400:
+        raise RequestError(
+            f"conversation status={status}: {data}",
+            status_code=status,
+            endpoint="conversations",
+            request_stage="conversation_fetch",
+        )
+    if not isinstance(data, dict):
+        raise RequestError(
+            "conversation response expected JSON object",
+            request_stage="conversation_fetch",
+        )
+
+    if not include_all_pages or not isinstance(data.get("messages"), list):
+        return normalize_conversation_payload(data)
+
+    pages = [data]
+    seen_cursors: set[str] = set()
+    while True:
+        cursor = _page_cursor(pages[-1])
+        if cursor is None:
+            break
+        if cursor in seen_cursors:
+            raise RequestError(
+                "canonical conversation pagination cursor repeated",
+                request_stage="conversation_fetch",
+            )
+        if len(pages) >= MAX_CANONICAL_CONVERSATION_PAGES:
+            raise RequestError(
+                "canonical conversation pagination exceeded bounded page limit",
+                request_stage="conversation_fetch",
+            )
+        seen_cursors.add(cursor)
+        page_url = _current_conversation_url(
+            current_base_url,
+            ref.conversation_id,
+            before=cursor,
+        )
+        page_status, page_data = client._json_request("GET", page_url, None, headers)
+        if page_status >= 400:
+            raise RequestError(
+                f"conversation status={page_status}: {page_data}",
+                status_code=page_status,
+                endpoint="conversations",
+                request_stage="conversation_fetch",
+            )
+        if not isinstance(page_data, dict):
+            raise RequestError(
+                "conversation pagination response expected JSON object",
+                request_stage="conversation_fetch",
+            )
+        pages.append(page_data)
+
+    return normalize_conversation_payload(merge_conversation_pages(pages))
+
+
+@dataclass
+class _FixedConversationPayloadReader:
+    payload: dict[str, Any]
+
+    def _get_conversation_payload(self, _conversation_id: str) -> dict[str, Any]:
+        return self.payload
+
+
+def get_messages_v2(
+    self: Any,
+    url_or_id: ConversationRef | ChatConversation | dict[str, Any] | str,
+    **kwargs: Any,
+):
+    """Use full pagination only when a requested history can exceed one page."""
+
+    # Preserve the long-standing injected-reader seam. Tests and integrations may
+    # replace ``_get_conversation_payload`` on one client instance with an exact
+    # payload source. A class-level full reader must not bypass that explicit
+    # instance override.
+    if "_get_conversation_payload" in getattr(self, "__dict__", {}):
+        return _legacy_get_messages(self, url_or_id, **kwargs)
+
+    limit = kwargs.get("limit")
+    if limit is not None:
+        if isinstance(limit, bool) or not isinstance(limit, int):
+            return _legacy_get_messages(self, url_or_id, **kwargs)
+        if limit <= CURRENT_CONVERSATION_NUM_TURNS:
+            return _legacy_get_messages(self, url_or_id, **kwargs)
+
+    full_reader = getattr(self, "_get_full_conversation_payload", None)
+    if not callable(full_reader):
+        return _legacy_get_messages(self, url_or_id, **kwargs)
+
+    ref = ConversationRef.from_any(url_or_id)
+    payload = full_reader(ref.conversation_id)
+    return _legacy_get_messages(_FixedConversationPayloadReader(payload), ref, **kwargs)

--- a/tests/test_browser_context_canonical_pr11_2.py
+++ b/tests/test_browser_context_canonical_pr11_2.py
@@ -14,7 +14,9 @@ from chatgpt_web_adapter.browser_context_canonical import (
     _CanonicalReadChunkCollector,
 )
 from chatgpt_web_adapter.browser_native_provider import BrowserNativeTurnProvider
-from chatgpt_web_adapter.browser_owned_product_transport import BrowserOwnedProductTransport
+from chatgpt_web_adapter.browser_owned_product_transport import (
+    BrowserOwnedProductTransport,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 EXTENSION = ROOT / "src" / "chatgpt_web_adapter" / "browser_native_extension"
@@ -65,13 +67,16 @@ def test_chunk_collector_reassembles_exact_sha256_sealed_bytes() -> None:
             }
         )
 
-    assert collector.finish(
-        {
-            "chunkCount": 2,
-            "totalBytes": len(body),
-            "sha256": digest,
-        }
-    ) == body
+    assert (
+        collector.finish(
+            {
+                "chunkCount": 2,
+                "totalBytes": len(body),
+                "sha256": digest,
+            }
+        )
+        == body
+    )
 
 
 def test_chunk_collector_rejects_integrity_mismatch() -> None:
@@ -127,10 +132,14 @@ def test_browser_context_client_owns_terminal_ack_contract(tmp_path) -> None:
     assert not callable(getattr(provider, "complete_canonical_readback", None))
 
 
-def test_browser_context_client_keeps_python_status_interpreter(tmp_path, monkeypatch) -> None:
+def test_browser_context_client_keeps_python_status_interpreter(
+    tmp_path, monkeypatch
+) -> None:
     provider = BrowserNativeTurnProvider(state_dir=tmp_path)
     client = BrowserContextCanonicalClient(object(), provider)
-    monkeypatch.setattr(client.transport, "read_conversation", lambda _conversation: _payload())
+    monkeypatch.setattr(
+        client.transport, "read_conversation", lambda _conversation: _payload()
+    )
 
     status = client.get_status("conversation-1")
 
@@ -180,7 +189,9 @@ def test_custom_provider_preserves_legacy_canonical_client_contract() -> None:
 
 
 def test_extension_layers_canonical_read_without_replacing_frozen_boundaries() -> None:
-    source = (EXTENSION / "service_worker_canonical_read.js").read_text(encoding="utf-8")
+    source = (EXTENSION / "service_worker_canonical_read_v2.js").read_text(
+        encoding="utf-8"
+    )
     read = (EXTENSION / "service_worker_runtime_read.js").read_text(encoding="utf-8")
     runtime = (EXTENSION / "service_worker_runtime.js").read_text(encoding="utf-8")
     bootstrap = (
@@ -199,18 +210,28 @@ def test_extension_layers_canonical_read_without_replacing_frozen_boundaries() -
     assert bootstrap.rstrip().endswith('importScripts("service_worker_runtime.js");')
     assert connector.rstrip().endswith("};")
     citations = 'importScripts("service_worker_product_source_citations_pr9_3.js");'
-    canonical = 'importScripts("service_worker_canonical_read.js");'
+    canonical = 'importScripts("service_worker_canonical_read_v2.js");'
     assert read.index(citations) < read.index(canonical)
-    assert runtime.index('importScripts("service_worker_runtime_write.js");') < runtime.index(
-        'importScripts("service_worker_runtime_read.js");'
+    assert runtime.index(
+        'importScripts("service_worker_runtime_write.js");'
+    ) < runtime.index('importScripts("service_worker_runtime_read.js");')
+    assert (
+        'importScripts("service_worker_temporary_chat_route_reopen_probe.js")'
+        not in source
     )
-    assert 'importScripts("service_worker_temporary_chat_route_reopen_probe.js")' not in source
 
     assert 'credentials: "include"' in source
     assert "response.arrayBuffer()" in source
     assert 'crypto.subtle.digest("SHA-256", bytes)' in source
     assert "CWA_CANONICAL_CHUNK_BASE64_CHARS = 600_000" in source
-    assert 'response.status === 404' in source
+    assert "/backend-api/conversations/" in source
+    assert 'url.searchParams.set("include_has_versions", "true")' in source
+    assert 'url.searchParams.set("num_turns", String(currentNumTurns))' in source
+    assert 'url.searchParams.set("before", before)' in source
+    assert "includeAllPages" in source
+    assert "/backend-api/conversation/" in source
+    assert "first.status !== 404" in source
+    assert "response.status === 404" in source
     assert '"CANONICAL_READ_AUTHENTICATION_REQUIRED"' in source
     assert '"CANONICAL_READ_ACCESS_CHALLENGED"' in source
     assert "document.cookie" not in source

--- a/tests/test_browser_runtime_consolidation_pr12_0.py
+++ b/tests/test_browser_runtime_consolidation_pr12_0.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 EXT = ROOT / "src" / "chatgpt_web_adapter" / "browser_native_extension"
 MANIFEST = EXT / "manifest.json"
@@ -101,6 +100,7 @@ def test_write_domain_owns_rich_and_text_write_assembly_only() -> None:
     assert positions == sorted(positions)
     assert len(_active_imports(source)) == len(ordered)
     assert "service_worker_canonical_read.js" not in source
+    assert "service_worker_canonical_read_v2.js" not in source
     assert "service_worker_ui_liveness.js" not in source
     assert "service_worker_connector_support_pr10_0.js" not in source
 
@@ -112,6 +112,7 @@ def test_write_domain_owns_rich_and_text_write_assembly_only() -> None:
         "service_worker_text_submit_commit_hardening_pr11_3.js",
         "service_worker_product_source_citations_pr9_3.js",
         "service_worker_canonical_read.js",
+        "service_worker_canonical_read_v2.js",
     ):
         assert cross_domain_import not in rich
 
@@ -119,7 +120,7 @@ def test_write_domain_owns_rich_and_text_write_assembly_only() -> None:
 def test_read_domain_is_explicit_and_excludes_write_and_observation() -> None:
     source = _source(READ)
     citations = 'importScripts("service_worker_product_source_citations_pr9_3.js");'
-    canonical = 'importScripts("service_worker_canonical_read.js");'
+    canonical = 'importScripts("service_worker_canonical_read_v2.js");'
 
     assert source.index(citations) < source.index(canonical)
     assert len(_active_imports(source)) == 2

--- a/tests/test_canonical_conversation_read_v2_pr13_0.py
+++ b/tests/test_canonical_conversation_read_v2_pr13_0.py
@@ -224,7 +224,7 @@ def test_current_endpoint_paginates_with_before_cursor() -> None:
     assert first.path == "/backend-api/conversations/conversation-1"
     assert parse_qs(first.query) == {
         "include_has_versions": ["true"],
-        "num_turns": ["100"],
+        "num_turns": ["20"],
     }
     assert parse_qs(second.query)["before"] == ["cursor-2"]
 
@@ -266,9 +266,7 @@ def test_current_non_404_failure_never_falls_back_to_legacy(status: int) -> None
     assert len(client.urls) == 1
 
 
-def test_message_limit_uses_latest_page_but_unbounded_history_uses_full_reader() -> (
-    None
-):
+def test_message_limit_uses_latest_page_when_it_already_satisfies_limit() -> None:
     class _Reader:
         def __init__(self):
             self.latest_reads = 0
@@ -276,7 +274,10 @@ def test_message_limit_uses_latest_page_but_unbounded_history_uses_full_reader()
 
         def _get_conversation_payload(self, _conversation_id: str):
             self.latest_reads += 1
-            return _legacy_payload("u3", "a4")
+            return {
+                **_legacy_payload("u3", "a4"),
+                "page_info": {"has_previous_page": True},
+            }
 
         def _get_full_conversation_payload(self, _conversation_id: str):
             self.full_reads += 1
@@ -294,6 +295,30 @@ def test_message_limit_uses_latest_page_but_unbounded_history_uses_full_reader()
 
     empty = get_messages_v2(reader, "conversation-1", limit=0)
     assert empty == []
+    assert (reader.latest_reads, reader.full_reads) == (1, 1)
+
+
+def test_message_limit_uses_full_reader_when_latest_page_is_insufficient() -> None:
+    class _Reader:
+        def __init__(self):
+            self.latest_reads = 0
+            self.full_reads = 0
+
+        def _get_conversation_payload(self, _conversation_id: str):
+            self.latest_reads += 1
+            return {
+                **_legacy_payload("u3", "a4"),
+                "page_info": {"has_previous_page": True},
+            }
+
+        def _get_full_conversation_payload(self, _conversation_id: str):
+            self.full_reads += 1
+            return _legacy_payload("u1", "a2", "u3", "a4")
+
+    reader = _Reader()
+    messages = get_messages_v2(reader, "conversation-1", limit=3)
+
+    assert [message.message_id for message in messages] == ["a2", "u3", "a4"]
     assert (reader.latest_reads, reader.full_reads) == (1, 1)
 
 

--- a/tests/test_canonical_conversation_read_v2_pr13_0.py
+++ b/tests/test_canonical_conversation_read_v2_pr13_0.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from chatgpt_web_adapter.browser_context_canonical_v2 import (
+    BrowserContextCanonicalClientV2,
+)
+from chatgpt_web_adapter.browser_owned_product_transport import (
+    BrowserOwnedProductTransport,
+)
+from chatgpt_web_adapter.conversation_read_v2 import (
+    get_messages_v2,
+    merge_conversation_pages,
+    normalize_conversation_payload,
+    read_conversation_payload_v2,
+)
+from chatgpt_web_adapter.exceptions import RequestError
+from chatgpt_web_adapter.messages import get_messages
+from chatgpt_web_adapter.status import _status_from_payload
+
+
+def _message(
+    message_id: str,
+    role: str,
+    text: str,
+    *,
+    finish: bool = False,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if finish:
+        metadata["finish_details"] = {"type": "stop"}
+    return {
+        "id": message_id,
+        "author": {"role": role},
+        "recipient": "all",
+        "create_time": float(message_id.strip("ua") or 0),
+        "content": {"content_type": "text", "parts": [text]},
+        "metadata": metadata,
+        "end_turn": finish,
+    }
+
+
+def _legacy_payload(*message_ids: str) -> dict[str, Any]:
+    mapping: dict[str, Any] = {}
+    for index, message_id in enumerate(message_ids):
+        role = "assistant" if message_id.startswith("a") else "user"
+        mapping[message_id] = {
+            "id": message_id,
+            "parent": message_ids[index - 1] if index else None,
+            "children": [message_ids[index + 1]]
+            if index + 1 < len(message_ids)
+            else [],
+            "message": _message(
+                message_id,
+                role,
+                message_id,
+                finish=index + 1 == len(message_ids) and role == "assistant",
+            ),
+        }
+    return {
+        "conversation_id": "conversation-1",
+        "current_node": message_ids[-1] if message_ids else None,
+        "mapping": mapping,
+    }
+
+
+def test_flat_messages_normalize_to_current_branch_mapping() -> None:
+    payload = {
+        "conversation_id": "conversation-1",
+        "current_node": "a2",
+        "messages": [
+            _message("u1", "user", "hello"),
+            _message("a2", "assistant", "done", finish=True),
+        ],
+        "page_info": {
+            "has_previous_page": False,
+            "has_next_page": False,
+        },
+    }
+
+    normalized = normalize_conversation_payload(payload)
+
+    assert normalized["current_node"] == "a2"
+    assert normalized["mapping"]["u1"]["parent"] is None
+    assert normalized["mapping"]["u1"]["children"] == ["a2"]
+    assert normalized["mapping"]["a2"]["parent"] == "u1"
+    assert normalized["mapping"]["a2"]["children"] == []
+    assert _status_from_payload(normalized).status == "completed"
+
+    class _Reader:
+        def _get_conversation_payload(self, _conversation_id: str):
+            return normalized
+
+    messages = get_messages(_Reader(), "conversation-1")
+    assert [(message.message_id, message.text) for message in messages] == [
+        ("u1", "hello"),
+        ("a2", "done"),
+    ]
+
+
+def test_nested_flat_items_translate_current_node_alias_without_guessing() -> None:
+    payload = {
+        "conversation_id": "conversation-1",
+        "current_node": "node-a2",
+        "messages": [
+            {"id": "node-u1", "message": _message("u1", "user", "hello")},
+            {
+                "id": "node-a2",
+                "message": _message("a2", "assistant", "done", finish=True),
+            },
+        ],
+    }
+
+    normalized = normalize_conversation_payload(payload)
+
+    assert normalized["current_node"] == "a2"
+    assert list(normalized["mapping"]) == ["u1", "a2"]
+
+
+def test_flat_shape_fails_closed_on_duplicate_or_unbound_current_node() -> None:
+    duplicate = {
+        "messages": [
+            _message("u1", "user", "one"),
+            _message("u1", "user", "two"),
+        ]
+    }
+    with pytest.raises(RequestError, match="duplicate message id"):
+        normalize_conversation_payload(duplicate)
+
+    unbound = {
+        "current_node": "missing",
+        "messages": [_message("u1", "user", "one")],
+    }
+    with pytest.raises(RequestError, match="current_node"):
+        normalize_conversation_payload(unbound)
+
+
+def test_paginated_pages_merge_oldest_first_and_dedupe_overlap() -> None:
+    latest = {
+        "conversation_id": "conversation-1",
+        "current_node": "a4",
+        "messages": [
+            _message("u3", "user", "three"),
+            _message("a4", "assistant", "four", finish=True),
+        ],
+        "page_info": {
+            "has_previous_page": True,
+            "start_cursor": "cursor-2",
+        },
+    }
+    older = {
+        "conversation_id": "conversation-1",
+        "messages": [
+            _message("u1", "user", "one"),
+            _message("a2", "assistant", "two"),
+            _message("u3", "user", "three"),
+        ],
+        "page_info": {"has_previous_page": False},
+    }
+
+    merged = merge_conversation_pages([latest, older])
+    normalized = normalize_conversation_payload(merged)
+
+    assert list(normalized["mapping"]) == ["u1", "a2", "u3", "a4"]
+    assert normalized["current_node"] == "a4"
+
+
+class _RequestClient:
+    def __init__(self, responses: list[tuple[int, Any]]) -> None:
+        self.responses = list(responses)
+        self.urls: list[str] = []
+
+    def _build_headers(self, additions: dict[str, str]) -> dict[str, str]:
+        return dict(additions)
+
+    def _json_request(self, method, url, payload, headers):
+        assert method == "GET"
+        assert payload is None
+        assert headers["accept"] == "application/json"
+        self.urls.append(url)
+        return self.responses.pop(0)
+
+
+def test_current_endpoint_paginates_with_before_cursor() -> None:
+    latest = {
+        "conversation_id": "conversation-1",
+        "current_node": "a4",
+        "messages": [
+            _message("u3", "user", "three"),
+            _message("a4", "assistant", "four", finish=True),
+        ],
+        "page_info": {
+            "has_previous_page": True,
+            "start_cursor": "cursor-2",
+        },
+    }
+    older = {
+        "conversation_id": "conversation-1",
+        "messages": [
+            _message("u1", "user", "one"),
+            _message("a2", "assistant", "two"),
+        ],
+        "page_info": {"has_previous_page": False},
+    }
+    client = _RequestClient([(200, latest), (200, older)])
+
+    payload = read_conversation_payload_v2(
+        client,
+        "conversation-1",
+        current_base_url="https://chatgpt.com/backend-api/conversations",
+        legacy_url_template=(
+            "https://chatgpt.com/backend-api/conversation/{conversation_id}"
+        ),
+        include_all_pages=True,
+    )
+
+    assert list(payload["mapping"]) == ["u1", "a2", "u3", "a4"]
+    assert len(client.urls) == 2
+    first = urlparse(client.urls[0])
+    second = urlparse(client.urls[1])
+    assert first.path == "/backend-api/conversations/conversation-1"
+    assert parse_qs(first.query) == {
+        "include_has_versions": ["true"],
+        "num_turns": ["100"],
+    }
+    assert parse_qs(second.query)["before"] == ["cursor-2"]
+
+
+def test_only_current_404_authorizes_legacy_endpoint_fallback() -> None:
+    client = _RequestClient(
+        [(404, {"detail": "missing"}), (200, _legacy_payload("u1", "a2"))]
+    )
+
+    payload = read_conversation_payload_v2(
+        client,
+        "conversation-1",
+        current_base_url="https://chatgpt.com/backend-api/conversations",
+        legacy_url_template=(
+            "https://chatgpt.com/backend-api/conversation/{conversation_id}"
+        ),
+    )
+
+    assert payload["current_node"] == "a2"
+    assert len(client.urls) == 2
+    assert urlparse(client.urls[1]).path == "/backend-api/conversation/conversation-1"
+
+
+@pytest.mark.parametrize("status", [401, 403, 422, 500])
+def test_current_non_404_failure_never_falls_back_to_legacy(status: int) -> None:
+    client = _RequestClient([(status, {"detail": "no"})])
+
+    with pytest.raises(RequestError) as captured:
+        read_conversation_payload_v2(
+            client,
+            "conversation-1",
+            current_base_url="https://chatgpt.com/backend-api/conversations",
+            legacy_url_template=(
+                "https://chatgpt.com/backend-api/conversation/{conversation_id}"
+            ),
+        )
+
+    assert captured.value.status_code == status
+    assert len(client.urls) == 1
+
+
+def test_message_limit_uses_latest_page_but_unbounded_history_uses_full_reader() -> (
+    None
+):
+    class _Reader:
+        def __init__(self):
+            self.latest_reads = 0
+            self.full_reads = 0
+
+        def _get_conversation_payload(self, _conversation_id: str):
+            self.latest_reads += 1
+            return _legacy_payload("u3", "a4")
+
+        def _get_full_conversation_payload(self, _conversation_id: str):
+            self.full_reads += 1
+            return _legacy_payload("u1", "a2", "u3", "a4")
+
+    reader = _Reader()
+
+    bounded = get_messages_v2(reader, "conversation-1", limit=1)
+    assert [message.message_id for message in bounded] == ["a4"]
+    assert (reader.latest_reads, reader.full_reads) == (1, 0)
+
+    unbounded = get_messages_v2(reader, "conversation-1")
+    assert [message.message_id for message in unbounded] == ["u1", "a2", "u3", "a4"]
+    assert (reader.latest_reads, reader.full_reads) == (1, 1)
+
+    empty = get_messages_v2(reader, "conversation-1", limit=0)
+    assert empty == []
+    assert (reader.latest_reads, reader.full_reads) == (1, 1)
+
+
+def test_default_browser_owned_transport_uses_v2_canonical_client() -> None:
+    class _Canonical:
+        def get_status(self, conversation):
+            raise AssertionError("not used")
+
+        def get_messages(self, conversation, **kwargs):
+            raise AssertionError("not used")
+
+        def attach_conversation(self, conversation):
+            raise AssertionError("not used")
+
+    transport = BrowserOwnedProductTransport(_Canonical())
+
+    assert isinstance(transport.canonical_client, BrowserContextCanonicalClientV2)

--- a/tests/test_canonical_read_v2_compatibility_pr13_0.py
+++ b/tests/test_canonical_read_v2_compatibility_pr13_0.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import chatgpt_web_adapter.client as client_mod
+
+
+def _payload() -> dict:
+    return {
+        "conversation_id": "conversation-1",
+        "current_node": "assistant-1",
+        "mapping": {
+            "assistant-1": {
+                "id": "assistant-1",
+                "parent": None,
+                "children": [],
+                "message": {
+                    "id": "assistant-1",
+                    "author": {"role": "assistant"},
+                    "recipient": "all",
+                    "content": {"content_type": "text", "parts": ["done"]},
+                },
+            }
+        },
+    }
+
+
+def test_explicit_endpoint_override_preserves_legacy_conversation_reader(
+    monkeypatch,
+) -> None:
+    expected = _payload()
+    calls: list[str] = []
+
+    def legacy_reader(_self, conversation_id: str):
+        calls.append(conversation_id)
+        return expected
+
+    monkeypatch.setattr(
+        client_mod._core.ChatGPTWebClient,
+        "_get_conversation_payload",
+        legacy_reader,
+    )
+    monkeypatch.setattr(
+        client_mod,
+        "CHAT_CONVERSATION_URL",
+        "http://fixture.test/backend-api/conversation/{conversation_id}",
+    )
+
+    client = object.__new__(client_mod.ChatGPTWebClient)
+    payload = client._get_conversation_payload("conversation-1")
+
+    assert payload is expected
+    assert calls == ["conversation-1"]
+
+
+def test_instance_injected_reader_is_not_bypassed_by_full_history_reader() -> None:
+    client = object.__new__(client_mod.ChatGPTWebClient)
+    client._get_conversation_payload = lambda _conversation_id: _payload()
+    client._get_full_conversation_payload = lambda _conversation_id: (
+        _ for _ in ()
+    ).throw(AssertionError("full reader must not bypass explicit instance reader"))
+
+    messages = client.get_messages("conversation-1")
+
+    assert [(message.message_id, message.text) for message in messages] == [
+        ("assistant-1", "done")
+    ]

--- a/tests/test_text_submit_commit_point_hardening_pr11_3.py
+++ b/tests/test_text_submit_commit_point_hardening_pr11_3.py
@@ -16,29 +16,33 @@ READ = EXTENSION / "service_worker_runtime_read.js"
 RUNTIME = EXTENSION / "service_worker_runtime.js"
 
 
-def test_text_submit_hardening_loads_after_rich_authority_before_observation_layers() -> None:
+def test_text_submit_hardening_loads_after_rich_authority_before_observation_layers() -> (
+    None
+):
     schema_loader = SCHEMA_LOADER.read_text(encoding="utf-8")
     write = WRITE.read_text(encoding="utf-8")
     read = READ.read_text(encoding="utf-8")
     runtime = RUNTIME.read_text(encoding="utf-8")
     rich = 'importScripts("service_worker_rich_input_schema29_repair_pr9_2.js");'
-    hardening = 'importScripts("service_worker_text_submit_commit_hardening_pr11_3.js");'
+    hardening = (
+        'importScripts("service_worker_text_submit_commit_hardening_pr11_3.js");'
+    )
     observation = 'importScripts("service_worker_product_source_citations_pr9_3.js");'
-    canonical_read = 'importScripts("service_worker_canonical_read.js");'
+    canonical_read = 'importScripts("service_worker_canonical_read_v2.js");'
 
     assert rich in schema_loader
     assert hardening in write
     assert read.index(observation) < read.index(canonical_read)
-    assert runtime.index('importScripts("service_worker_runtime_write.js");') < runtime.index(
-        'importScripts("service_worker_runtime_read.js");'
-    )
+    assert runtime.index(
+        'importScripts("service_worker_runtime_write.js");'
+    ) < runtime.index('importScripts("service_worker_runtime_read.js");')
 
 
 def test_text_submit_hardening_declares_exact_protected_boundaries() -> None:
     text = OVERLAY.read_text(encoding="utf-8")
 
-    assert 'PR11_3_TEXT_MOUSE_RELEASE_OUTCOME_UNCONFIRMED' in text
-    assert 'PR11_3_TEXT_ENTER_KEYDOWN_OUTCOME_UNCONFIRMED' in text
+    assert "PR11_3_TEXT_MOUSE_RELEASE_OUTCOME_UNCONFIRMED" in text
+    assert "PR11_3_TEXT_ENTER_KEYDOWN_OUTCOME_UNCONFIRMED" in text
     assert 'type: "mouseReleased"' in text
     assert 'type: "keyDown"' in text
     assert 'type: "keyUp"' in text


### PR DESCRIPTION
## Purpose

Repair CWA's canonical conversation read plane for the current plural `/backend-api/conversations/{id}` surface and flat paginated `messages[]` response, including the long-chat backend failure reproduced during authenticated live validation.

## Current product drift and live evidence

Independent dated product measurement observed the saved-conversation read move from the legacy singular `/backend-api/conversation/{id}` + `mapping` tree to `/backend-api/conversations/{id}` + ordered `messages[]` / `page_info`, with older history fetched through `before=<start_cursor>`.

Authenticated long-chat validation on 2026-09-10 established an important refinement:

- current plural with `include_has_versions=true&num_turns=100` returned HTTP 500 after about 30 seconds;
- the same saved conversation with `num_turns=20` returned HTTP 200;
- that successful response contained 1107 `messages[]` records while still reporting `page_info.has_previous_page=true` and a `start_cursor`;
- the singular `/backend-api/conversation/{id}` surface returned HTTP 500 for the same conversation.

Therefore `num_turns` is treated as a product-observed **server query hint**, not as a client-side page-size/message-count guarantee. The production hint is now `20`; completeness remains governed by `page_info`.

The external measurements and authenticated live gate are evidence/drift signals only; CWA retains its own runtime authority contracts.

## Change

- add a dual-shape canonical normalization boundary: legacy `mapping` remains valid; current ordered `messages[]` becomes one deterministic linear current-branch mapping;
- use the current plural endpoint first with `include_has_versions=true&num_turns=20`;
- retain singular endpoint fallback only after a current-endpoint HTTP 404;
- do **not** hide 500/502/503/504 behind singular fallback or automatic retry;
- add bounded pagination through `page_info.has_previous_page` + `before=<start_cursor>`, with repeated-cursor and cross-page conversation-identity guards;
- keep ordinary status/finality reads to one current response;
- make `get_messages(limit=N)` adaptive: parse one current response first, stop if it actually supplies at least N matching messages, otherwise use the full reader when older history is reported;
- use full pagination directly for unbounded history;
- preserve the PR12.3 public endpoint-override seam and instance-injected `_get_conversation_payload` reader seam;
- keep the authenticated browser-context canonical-read v2 path aligned with the same `num_turns=20` hint and `page_info`/`before` completeness contract;
- preserve SHA-256 sealed bridge transfer and Browser Authority serialization;
- add/update deterministic dual-shape, pagination, fallback, adaptive-limit, compatibility and topology regressions.

## Scope boundary

This PR does **not** change write identity authority, submit/retry semantics, rich-input binding, Temporary Chat identity, source/citation observations, connector authorization or generated-artifact handoff. It also does not add DOM scraping or a second long-chat protocol.

## Semantic rebase

PR13.0 was rebuilt on current `main` after PR13.1–PR13.4 landed. Base remains `3eb8565fd2dcb4c4da534a76ea3440f78e09e86a`; the PR still changes only its original 12 paths.

## Validation

Exact head: `5392cee3c2d66f3f34177d6928bfd714b74e6790`

CI #912 (`34512639570`): **SUCCESS**

- Engineering Quality: PASS;
- source tests: Ubuntu + Windows Python 3.10–3.14: PASS;
- Build release artifacts: PASS;
- installed-wheel smoke: Ubuntu/Windows: PASS.

The first Windows Python 3.12 attempt hit an unrelated pre-existing floating-point boundary assertion (`10.000000000000014 <= 10.0`) in a PR9.1 context-isolation test. Re-running that exact job on the same head passed; no unrelated test or production-code change was added to this PR.

## Full-history authenticated acceptance — PASS

On the same pathological long saved conversation that reproduced the original HTTP 500, the exact-head full-history gate completed successfully on 2026-09-12:

- characterization: `FULL_CANONICAL_HISTORY_PAGINATION_COMPLETED`;
- exact head matched and tracked worktree was clean;
- 6/6 requests used the current plural surface;
- all requests used `include_has_versions=true&num_turns=20`;
- request 1 had no `before` cursor; requests 2–6 used `before`;
- page message counts were `1107, 758, 886, 886, 450, 595`;
- the final response explicitly reported `page_info.has_previous_page=false`, proving terminal history boundary;
- merged canonical mapping contained 4682 records;
- wire total was also 4682, so cross-page overlap removal count was 0;
- normalized `current_node` was present;
- no writes were attempted;
- no conversation ID, message IDs, message content, cursor values, credentials or raw response body were exported.

This closes the original long-chat acceptance gate: the production path can traverse the complete current plural history chain to an explicit terminal boundary and normalize the merged conversation without relying on the failing singular endpoint, automatic retries, or DOM fallback.