### PR TITLE
Experiment PR13.1 — Conversation Files Identity Probe

### DIFF
--- a/docs/engineering/pr13_1_conversation_files_identity_probe.md
+++ b/docs/engineering/pr13_1_conversation_files_identity_probe.md
@@ -98,6 +98,27 @@ download_authority_granted = false
 
 Two immediate independent reads are evidence of short-term identity stability, not proof that the identifier survives later sessions, regeneration, account transitions, or that it can be safely resolved into downloadable bytes.
 
+## Authenticated R2 evidence — 2026-09-10
+
+A clean exact-head authenticated run against the same saved conversation and generated text artifact performed two reads through two fresh clients and returned:
+
+```text
+first_characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
+second_characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
+first_identity_key = file_id
+second_identity_key = file_id
+first_target_record_present = true
+second_target_record_present = true
+same_explicit_identity = true
+same_identity_key = true
+short_term_identity_stability_proven = true
+characterization = SAME_EXPLICIT_IDENTITY_ACROSS_INDEPENDENT_READS
+```
+
+The raw identifier and its SHA-256 fingerprint are intentionally not copied into repository evidence. This result establishes that the same filename-anchored generated artifact exposed the same product-owned `file_id` across two independent immediate reads through fresh clients.
+
+This is sufficient to close PR13.1's short-term identity question. It is not sufficient to promote generated-artifact download support because longitudinal/session stability and an identity-bound resolution surface remain unproven.
+
 ## Relationship to PR10.1
 
 PR10.1 correctly froze generated-artifact download handoff as:
@@ -106,7 +127,7 @@ PR10.1 correctly froze generated-artifact download handoff as:
 ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY
 ```
 
-PR13.1 does not change that support status yet. R1 has now established an explicit product-owned identity candidate; R2 tests the first stability property required before any resolution-path research.
+PR13.1 does not change that support status. It has now established two narrower facts: the product exposes an explicit conversation-scoped `file_id` for the generated artifact, and that identity is stable across two independent immediate reads. Resolution-path research belongs to a separate follow-up gate.
 
 ## Running R1
 

--- a/docs/engineering/pr13_1_conversation_files_identity_probe.md
+++ b/docs/engineering/pr13_1_conversation_files_identity_probe.md
@@ -12,9 +12,9 @@ that is materially stronger than PR10.1's point-in-time generated-artifact obser
 
 This is a characterization experiment, not a production capability promotion.
 
-## Boundaries
+## R1 boundaries
 
-The probe performs exactly one authenticated GET for one caller-supplied saved-conversation identity.
+The R1 identity probe performs exactly one authenticated GET for one caller-supplied saved-conversation identity.
 
 It does not:
 
@@ -29,7 +29,7 @@ It does not:
 
 The report may export only bounded identity/metadata candidates such as an opaque explicit ID, basename-like filename, MIME type, non-negative size, and booleans describing whether conversation/message identity fields or locator fields were present.
 
-## Characterizations
+## R1 characterizations
 
 The probe distinguishes:
 
@@ -44,18 +44,59 @@ The probe distinguishes:
 - `DUPLICATE_EXPLICIT_IDENTITY_CANDIDATE_OBSERVED` — explicit identities are not unique within the response;
 - `EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED` — every file record exposes a safe explicit identity candidate and candidates are unique within that one response.
 
-## What a positive result means
+## Authenticated R1 evidence — 2026-09-10
 
-`EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED` is stronger evidence than a DOM-adjacent label or an inferred filename because the candidate originates from a conversation-scoped product response field.
+A clean exact-head authenticated run against a saved ChatGPT conversation containing one generated text artifact returned HTTP 200 and:
 
-It still does **not** prove that the identifier is stable across independent reads, sessions, regenerated artifacts, or account transitions. Therefore every PR13.1 report keeps:
+```text
+collection_key = items
+record_count = 1
+explicit_identity_key = file_id
+filename_key = file_name
+media_type_key = mime_type
+media_type = text/plain
+locator_field_present = false
+conversation_id_field_present = false
+message_id_field_present = false
+characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
+```
+
+The observed opaque identifier value is intentionally not recorded in repository evidence. The result establishes that the product endpoint exposes an explicit conversation-scoped `file_id` candidate for the generated artifact. It does not establish longitudinal stability or resolution/download semantics.
+
+## R2 — independent short-term stability
+
+R2 performs exactly two read-only authenticated requests through two fresh `ChatGPTWebClient` instances. A caller-supplied expected filename is used only as an anchor to select exactly one record from each response; filename equality is never treated as identity.
+
+R2 requires:
+
+- exactly one filename-anchored target in each read;
+- an explicit identity field in both reads;
+- the same explicit identity value in both reads;
+- the same identity key in both reads.
+
+The raw identity value is not exported by R2. The report contains only SHA-256 fingerprints plus equality booleans and identity-key names.
+
+A positive R2 characterization is:
+
+```text
+SAME_EXPLICIT_IDENTITY_ACROSS_INDEPENDENT_READS
+```
+
+and may set:
+
+```text
+short_term_identity_stability_proven = true
+```
+
+R2 deliberately continues to keep:
 
 ```text
 stable_product_identity_proven = false
+resolution_surface_proven = false
 download_authority_granted = false
 ```
 
-A later promotion gate would require at least independent repeated observation of the same artifact identity plus a browser-owned resolution path bound to that identity. Neither is part of PR13.1.
+Two immediate independent reads are evidence of short-term identity stability, not proof that the identifier survives later sessions, regeneration, account transitions, or that it can be safely resolved into downloadable bytes.
 
 ## Relationship to PR10.1
 
@@ -65,16 +106,25 @@ PR10.1 correctly froze generated-artifact download handoff as:
 ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY
 ```
 
-PR13.1 does not change that support status. It only tests whether a newer product endpoint supplies a stronger identity primitive worth investigating.
+PR13.1 does not change that support status yet. R1 has now established an explicit product-owned identity candidate; R2 tests the first stability property required before any resolution-path research.
 
-## Running the probe
+## Running R1
 
 From an exact clean checkout with an authenticated CWA session available:
 
 ```bash
-python tools/pr13_1_conversation_files_identity_probe.py \
-  --conversation-id <conversation-id> \
+python tools/pr13_1_conversation_files_live_gate.py \
+  --conversation "https://chatgpt.com/c/<conversation-id>" \
   --expected-head <exact-head-sha>
 ```
 
-The tool emits one sanitized JSON report. A completed characterization is not equivalent to capability support.
+## Running R2
+
+```bash
+python tools/pr13_1_conversation_files_stability_gate.py \
+  --conversation "https://chatgpt.com/c/<conversation-id>" \
+  --expected-filename cwa_pr13_1_identity_probe.txt \
+  --expected-head <exact-head-sha>
+```
+
+Both gates are characterization tools. Neither grants artifact resolution, download, filesystem-write, retry, or overwrite authority.

--- a/docs/engineering/pr13_1_conversation_files_identity_probe.md
+++ b/docs/engineering/pr13_1_conversation_files_identity_probe.md
@@ -1,0 +1,80 @@
+# PR13.1 — Conversation Files Identity Probe
+
+## Question
+
+Does the authenticated ChatGPT product expose an explicit conversation-scoped file identity surface at:
+
+```text
+GET /backend-api/conversations/{conversation_id}/files
+```
+
+that is materially stronger than PR10.1's point-in-time generated-artifact observation?
+
+This is a characterization experiment, not a production capability promotion.
+
+## Boundaries
+
+The probe performs exactly one authenticated GET for one caller-supplied saved-conversation identity.
+
+It does not:
+
+- submit a ChatGPT turn;
+- retry or fall back to another endpoint;
+- download an artifact;
+- follow a URL or signed locator;
+- write to the local filesystem other than normal process output;
+- grant download, overwrite, retry, write, or finality authority;
+- expose the raw response body;
+- export URL, signed URL, token, cookie, credential, or authorization values.
+
+The report may export only bounded identity/metadata candidates such as an opaque explicit ID, basename-like filename, MIME type, non-negative size, and booleans describing whether conversation/message identity fields or locator fields were present.
+
+## Characterizations
+
+The probe distinguishes:
+
+- `AUTHENTICATION_REQUIRED` — HTTP 401;
+- `ACCESS_CHALLENGED` — HTTP 403;
+- `ENDPOINT_ABSENT_OR_NOT_VISIBLE` — HTTP 404;
+- `FILES_ENDPOINT_HTTP_ERROR` — other HTTP failure;
+- `UNRECOGNIZED_FILES_RESPONSE_SHAPE` — successful response without a recognized list shape;
+- `EMPTY_FILE_COLLECTION_OBSERVED` — recognized empty collection;
+- `NON_OBJECT_FILE_RECORD_OBSERVED` — a collection contains a non-object item;
+- `FILE_RECORDS_WITHOUT_EXPLICIT_IDENTITY` — at least one file record has no safe explicit identity field;
+- `DUPLICATE_EXPLICIT_IDENTITY_CANDIDATE_OBSERVED` — explicit identities are not unique within the response;
+- `EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED` — every file record exposes a safe explicit identity candidate and candidates are unique within that one response.
+
+## What a positive result means
+
+`EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED` is stronger evidence than a DOM-adjacent label or an inferred filename because the candidate originates from a conversation-scoped product response field.
+
+It still does **not** prove that the identifier is stable across independent reads, sessions, regenerated artifacts, or account transitions. Therefore every PR13.1 report keeps:
+
+```text
+stable_product_identity_proven = false
+download_authority_granted = false
+```
+
+A later promotion gate would require at least independent repeated observation of the same artifact identity plus a browser-owned resolution path bound to that identity. Neither is part of PR13.1.
+
+## Relationship to PR10.1
+
+PR10.1 correctly froze generated-artifact download handoff as:
+
+```text
+ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY
+```
+
+PR13.1 does not change that support status. It only tests whether a newer product endpoint supplies a stronger identity primitive worth investigating.
+
+## Running the probe
+
+From an exact clean checkout with an authenticated CWA session available:
+
+```bash
+python tools/pr13_1_conversation_files_identity_probe.py \
+  --conversation-id <conversation-id> \
+  --expected-head <exact-head-sha>
+```
+
+The tool emits one sanitized JSON report. A completed characterization is not equivalent to capability support.

--- a/tests/test_conversation_files_identity_probe_pr13_1.py
+++ b/tests/test_conversation_files_identity_probe_pr13_1.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tools.pr13_1_conversation_files_identity_probe import (
+    probe_conversation_files,
+    summarize_files_payload,
+)
+
+
+class _Client:
+    def __init__(self, status: int, payload: Any) -> None:
+        self.status = status
+        self.payload = payload
+        self.calls: list[tuple[str, str, Any, dict[str, str]]] = []
+
+    def _build_headers(self, additions: dict[str, str]) -> dict[str, str]:
+        return dict(additions)
+
+    def _json_request(self, method, url, payload, headers):
+        self.calls.append((method, url, payload, headers))
+        return self.status, self.payload
+
+
+def test_probe_performs_exactly_one_get_and_exports_no_locator_values() -> None:
+    client = _Client(
+        200,
+        {
+            "files": [
+                {
+                    "file_id": "file_abc123",
+                    "filename": "result.txt",
+                    "mime_type": "text/plain",
+                    "size_bytes": 17,
+                    "download_url": "https://signed.example/secret?token=very-secret",
+                    "conversation_id": "conversation-1",
+                    "message_id": "message-1",
+                }
+            ]
+        },
+    )
+
+    report = probe_conversation_files(client, "conversation-1")
+
+    assert len(client.calls) == 1
+    method, url, payload, headers = client.calls[0]
+    assert method == "GET"
+    assert url == (
+        "https://chatgpt.com/backend-api/conversations/conversation-1/files"
+    )
+    assert payload is None
+    assert headers["accept"] == "application/json"
+    assert report["request_count"] == 1
+    assert report["write_attempted"] is False
+    assert report["download_attempted"] is False
+    assert report["locator_values_exported"] is False
+    assert report["sensitive_locator_fields_present"] is True
+    assert report["characterization"] == (
+        "EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED"
+    )
+    assert report["stable_product_identity_proven"] is False
+    assert report["download_authority_granted"] is False
+    assert report["records"] == [
+        {
+            "explicit_identity_key": "file_id",
+            "explicit_identity": "file_abc123",
+            "filename_key": "filename",
+            "filename": "result.txt",
+            "media_type_key": "mime_type",
+            "media_type": "text/plain",
+            "size_key": "size_bytes",
+            "size_bytes": 17,
+            "conversation_id_field_present": True,
+            "message_id_field_present": True,
+            "locator_field_present": True,
+        }
+    ]
+    assert "signed.example" not in str(report)
+    assert "very-secret" not in str(report)
+
+
+def test_duplicate_ids_are_not_promoted_to_identity_evidence() -> None:
+    report = summarize_files_payload(
+        [
+            {"id": "same-id", "name": "one.txt"},
+            {"id": "same-id", "name": "two.txt"},
+        ]
+    )
+
+    assert report["explicit_identity_candidate_count"] == 2
+    assert report["unique_identity_candidate_count"] == 1
+    assert report["identity_candidates_unique"] is False
+    assert report["characterization"] == (
+        "DUPLICATE_EXPLICIT_IDENTITY_CANDIDATE_OBSERVED"
+    )
+    assert report["stable_product_identity_proven"] is False
+
+
+def test_missing_identity_fails_closed_without_guessing_from_filename() -> None:
+    report = summarize_files_payload(
+        {"items": [{"filename": "looks-unique.txt", "size": 12}]}
+    )
+
+    assert report["explicit_identity_candidate_count"] == 0
+    assert report["all_records_have_explicit_identity_candidate"] is False
+    assert report["characterization"] == "FILE_RECORDS_WITHOUT_EXPLICIT_IDENTITY"
+
+
+def test_status_classification_never_retries_or_falls_back() -> None:
+    expected = {
+        401: "AUTHENTICATION_REQUIRED",
+        403: "ACCESS_CHALLENGED",
+        404: "ENDPOINT_ABSENT_OR_NOT_VISIBLE",
+        500: "FILES_ENDPOINT_HTTP_ERROR",
+    }
+
+    for status, characterization in expected.items():
+        client = _Client(status, {"detail": "not exported"})
+        report = probe_conversation_files(client, "conversation-1")
+
+        assert len(client.calls) == 1
+        assert report["characterization"] == characterization
+        assert report["response_body_exported"] is False
+        assert report["download_attempted"] is False
+        assert report["write_attempted"] is False
+
+
+def test_invalid_conversation_identity_is_rejected_before_any_request() -> None:
+    client = _Client(200, [])
+
+    for invalid in ("", "a/b", "a?b", "a#b"):
+        try:
+            probe_conversation_files(client, invalid)
+        except ValueError as exc:
+            assert str(exc) == "CONVERSATION_ID_REQUIRED"
+        else:
+            raise AssertionError("invalid conversation id was accepted")
+
+    assert client.calls == []

--- a/tests/test_conversation_files_identity_probe_pr13_1.py
+++ b/tests/test_conversation_files_identity_probe_pr13_1.py
@@ -45,9 +45,7 @@ def test_probe_performs_exactly_one_get_and_exports_no_locator_values() -> None:
     assert len(client.calls) == 1
     method, url, payload, headers = client.calls[0]
     assert method == "GET"
-    assert url == (
-        "https://chatgpt.com/backend-api/conversations/conversation-1/files"
-    )
+    assert url == ("https://chatgpt.com/backend-api/conversations/conversation-1/files")
     assert payload is None
     assert headers["accept"] == "application/json"
     assert report["request_count"] == 1

--- a/tests/test_conversation_files_live_gate_pr13_1.py
+++ b/tests/test_conversation_files_live_gate_pr13_1.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from tools.pr13_1_conversation_files_live_gate import conversation_id_from_selector
+
+
+def test_raw_conversation_id_is_preserved() -> None:
+    assert conversation_id_from_selector("conversation-123") == "conversation-123"
+
+
+def test_chatgpt_conversation_url_extracts_id() -> None:
+    assert (
+        conversation_id_from_selector(
+            "https://chatgpt.com/c/conversation-123?utm_source=fixture"
+        )
+        == "conversation-123"
+    )
+
+
+def test_nested_chatgpt_route_extracts_single_c_segment() -> None:
+    assert (
+        conversation_id_from_selector(
+            "https://chatgpt.com/g/g-fixture/c/conversation-456"
+        )
+        == "conversation-456"
+    )
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        "http://chatgpt.com/c/conversation-123",
+        "https://example.com/c/conversation-123",
+        "https://chatgpt.com/share/conversation-123",
+        "https://chatgpt.com/c/one/c/two",
+    ],
+)
+def test_noncanonical_or_ambiguous_url_fails_closed(selector: str) -> None:
+    with pytest.raises(ValueError, match="CHATGPT_CONVERSATION_URL_REQUIRED"):
+        conversation_id_from_selector(selector)

--- a/tests/test_conversation_files_stability_gate_pr13_1.py
+++ b/tests/test_conversation_files_stability_gate_pr13_1.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from tools.pr13_1_conversation_files_stability_gate import (
+    characterize_independent_reads,
+)
+
+
+def _report(identity: str, *, filename: str = "probe.txt", key: str = "file_id"):
+    return {
+        "characterization": "EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED",
+        "records": [
+            {
+                "explicit_identity_key": key,
+                "explicit_identity": identity,
+                "filename": filename,
+            }
+        ],
+    }
+
+
+def test_same_identity_across_independent_reads_is_proven_short_term_only() -> None:
+    report = characterize_independent_reads(
+        _report("file_same"),
+        _report("file_same"),
+        expected_filename="probe.txt",
+    )
+
+    assert report["characterization"] == (
+        "SAME_EXPLICIT_IDENTITY_ACROSS_INDEPENDENT_READS"
+    )
+    assert report["request_count"] == 2
+    assert report["fresh_client_count"] == 2
+    assert report["same_explicit_identity"] is True
+    assert report["same_identity_key"] is True
+    assert report["short_term_identity_stability_proven"] is True
+    assert report["stable_product_identity_proven"] is False
+    assert report["resolution_surface_proven"] is False
+    assert report["download_authority_granted"] is False
+    assert report["identity_values_exported"] is False
+    assert report["first_identity_fingerprint"] == report["second_identity_fingerprint"]
+    assert "file_same" not in str(report)
+
+
+def test_changed_identity_fails_stability_gate() -> None:
+    report = characterize_independent_reads(
+        _report("file_first"),
+        _report("file_second"),
+        expected_filename="probe.txt",
+    )
+
+    assert report["characterization"] == (
+        "EXPLICIT_IDENTITY_CHANGED_ACROSS_INDEPENDENT_READS"
+    )
+    assert report["same_explicit_identity"] is False
+    assert report["short_term_identity_stability_proven"] is False
+    assert report["first_identity_fingerprint"] != report["second_identity_fingerprint"]
+    assert "file_first" not in str(report)
+    assert "file_second" not in str(report)
+
+
+def test_identity_key_change_is_not_treated_as_stable() -> None:
+    report = characterize_independent_reads(
+        _report("same", key="file_id"),
+        _report("same", key="artifact_id"),
+        expected_filename="probe.txt",
+    )
+
+    assert report["same_explicit_identity"] is True
+    assert report["same_identity_key"] is False
+    assert report["short_term_identity_stability_proven"] is False
+    assert report["characterization"] == (
+        "EXPLICIT_IDENTITY_CHANGED_ACROSS_INDEPENDENT_READS"
+    )
+
+
+def test_filename_is_anchor_only_and_missing_target_fails_closed() -> None:
+    report = characterize_independent_reads(
+        _report("file_one", filename="other.txt"),
+        _report("file_one", filename="other.txt"),
+        expected_filename="probe.txt",
+    )
+
+    assert report["first_target_record_present"] is False
+    assert report["characterization"] == "FIRST_READ_TARGET_IDENTITY_NOT_PROVEN"
+    assert report["short_term_identity_stability_proven"] is False
+
+
+def test_ambiguous_duplicate_filename_target_fails_closed() -> None:
+    first = {
+        "characterization": "EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED",
+        "records": [
+            {
+                "explicit_identity_key": "file_id",
+                "explicit_identity": "one",
+                "filename": "probe.txt",
+            },
+            {
+                "explicit_identity_key": "file_id",
+                "explicit_identity": "two",
+                "filename": "probe.txt",
+            },
+        ],
+    }
+
+    report = characterize_independent_reads(
+        first,
+        _report("one"),
+        expected_filename="probe.txt",
+    )
+
+    assert report["characterization"] == "FIRST_READ_TARGET_IDENTITY_NOT_PROVEN"
+    assert report["short_term_identity_stability_proven"] is False

--- a/tools/pr13_1_conversation_files_identity_probe.py
+++ b/tools/pr13_1_conversation_files_identity_probe.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from typing import Any
+from urllib.parse import quote
+
+from chatgpt_web_adapter import ChatGPTWebClient
+
+CHATGPT_ORIGIN = "https://chatgpt.com"
+PROBE_SCHEMA = "CWA_PR13_1_CONVERSATION_FILES_IDENTITY_PROBE_V1"
+_IDENTITY_KEYS = ("file_id", "artifact_id", "asset_id", "id")
+_FILENAME_KEYS = ("filename", "file_name", "name")
+_MEDIA_TYPE_KEYS = ("media_type", "mime_type", "content_type")
+_SIZE_KEYS = ("size_bytes", "size")
+_COLLECTION_KEYS = ("files", "items", "data")
+_SENSITIVE_LOCATOR_KEYS = frozenset(
+    {
+        "url",
+        "href",
+        "download_url",
+        "signed_url",
+        "download_uri",
+        "upload_url",
+        "access_token",
+        "refresh_token",
+        "authorization",
+        "cookie",
+        "cookies",
+        "credential",
+        "credentials",
+        "secret",
+        "token",
+    }
+)
+_OPAQUE_ID_RE = re.compile(r"^[A-Za-z0-9_.:-]{1,192}$")
+_MEDIA_TYPE_RE = re.compile(r"^[A-Za-z0-9!#$&^_.+-]+/[A-Za-z0-9!#$&^_.+-]+$")
+
+
+def _optional_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _conversation_id(value: Any) -> str:
+    conversation_id = _optional_text(value)
+    if (
+        conversation_id is None
+        or len(conversation_id) > 256
+        or any(marker in conversation_id for marker in ("/", "?", "#"))
+    ):
+        raise ValueError("CONVERSATION_ID_REQUIRED")
+    return conversation_id
+
+
+def _safe_identity(value: Any) -> str | None:
+    text = _optional_text(value)
+    if text is None or not _OPAQUE_ID_RE.fullmatch(text):
+        return None
+    lowered = text.lower()
+    if any(
+        marker in lowered
+        for marker in ("token", "secret", "credential", "authorization", "cookie")
+    ):
+        return None
+    return text
+
+
+def _safe_filename(value: Any) -> str | None:
+    text = _optional_text(value)
+    if text is None or len(text) > 255:
+        return None
+    if text in {".", ".."} or "/" in text or "\\" in text:
+        return None
+    if any(ord(char) < 32 for char in text):
+        return None
+    return text
+
+
+def _safe_media_type(value: Any) -> str | None:
+    text = _optional_text(value)
+    if text is None:
+        return None
+    normalized = text.lower()
+    if len(normalized) > 128 or not _MEDIA_TYPE_RE.fullmatch(normalized):
+        return None
+    return normalized
+
+
+def _safe_size(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _first_safe(record: dict[str, Any], keys: tuple[str, ...], sanitizer):
+    for key in keys:
+        if key not in record:
+            continue
+        value = sanitizer(record.get(key))
+        if value is not None:
+            return key, value
+    return None, None
+
+
+def _collection(payload: Any) -> tuple[str, list[Any]] | None:
+    if isinstance(payload, list):
+        return "top_level_list", payload
+    if not isinstance(payload, dict):
+        return None
+    for key in _COLLECTION_KEYS:
+        value = payload.get(key)
+        if isinstance(value, list):
+            return key, value
+    return None
+
+
+def summarize_files_payload(payload: Any) -> dict[str, Any]:
+    """Return locator-free identity evidence from an unknown files payload shape."""
+
+    collection = _collection(payload)
+    if collection is None:
+        return {
+            "response_shape": type(payload).__name__,
+            "collection_key": None,
+            "record_count": 0,
+            "records": [],
+            "sensitive_locator_fields_present": False,
+            "explicit_identity_candidate_count": 0,
+            "unique_identity_candidate_count": 0,
+            "all_records_have_explicit_identity_candidate": False,
+            "identity_candidates_unique": False,
+            "characterization": "UNRECOGNIZED_FILES_RESPONSE_SHAPE",
+            "stable_product_identity_proven": False,
+            "download_authority_granted": False,
+        }
+
+    collection_key, raw_records = collection
+    records: list[dict[str, Any]] = []
+    sensitive_locator_fields_present = False
+    identities: list[str] = []
+    object_record_count = 0
+
+    for raw_record in raw_records:
+        if not isinstance(raw_record, dict):
+            records.append({"record_shape": type(raw_record).__name__})
+            continue
+        object_record_count += 1
+        sensitive_locator_fields_present = sensitive_locator_fields_present or any(
+            key in raw_record and raw_record.get(key) is not None
+            for key in _SENSITIVE_LOCATOR_KEYS
+        )
+        identity_key, identity = _first_safe(
+            raw_record,
+            _IDENTITY_KEYS,
+            _safe_identity,
+        )
+        filename_key, filename = _first_safe(
+            raw_record,
+            _FILENAME_KEYS,
+            _safe_filename,
+        )
+        media_type_key, media_type = _first_safe(
+            raw_record,
+            _MEDIA_TYPE_KEYS,
+            _safe_media_type,
+        )
+        size_key, size_bytes = _first_safe(raw_record, _SIZE_KEYS, _safe_size)
+
+        safe_record: dict[str, Any] = {
+            "explicit_identity_key": identity_key,
+            "explicit_identity": identity,
+            "filename_key": filename_key,
+            "filename": filename,
+            "media_type_key": media_type_key,
+            "media_type": media_type,
+            "size_key": size_key,
+            "size_bytes": size_bytes,
+            "conversation_id_field_present": isinstance(
+                raw_record.get("conversation_id"), str
+            ),
+            "message_id_field_present": isinstance(raw_record.get("message_id"), str),
+            "locator_field_present": any(
+                key in raw_record and raw_record.get(key) is not None
+                for key in _SENSITIVE_LOCATOR_KEYS
+            ),
+        }
+        records.append(safe_record)
+        if identity is not None:
+            identities.append(identity)
+
+    unique_identity_count = len(set(identities))
+    all_records_have_identity = bool(raw_records) and len(identities) == len(raw_records)
+    identities_unique = bool(identities) and unique_identity_count == len(identities)
+
+    if not raw_records:
+        characterization = "EMPTY_FILE_COLLECTION_OBSERVED"
+    elif object_record_count != len(raw_records):
+        characterization = "NON_OBJECT_FILE_RECORD_OBSERVED"
+    elif not all_records_have_identity:
+        characterization = "FILE_RECORDS_WITHOUT_EXPLICIT_IDENTITY"
+    elif not identities_unique:
+        characterization = "DUPLICATE_EXPLICIT_IDENTITY_CANDIDATE_OBSERVED"
+    else:
+        characterization = "EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED"
+
+    return {
+        "response_shape": type(payload).__name__,
+        "collection_key": collection_key,
+        "record_count": len(raw_records),
+        "records": records,
+        "sensitive_locator_fields_present": sensitive_locator_fields_present,
+        "explicit_identity_candidate_count": len(identities),
+        "unique_identity_candidate_count": unique_identity_count,
+        "all_records_have_explicit_identity_candidate": all_records_have_identity,
+        "identity_candidates_unique": identities_unique,
+        "characterization": characterization,
+        # A single endpoint observation can prove explicit product fields exist,
+        # but cannot prove longitudinal stability across independent observations.
+        "stable_product_identity_proven": False,
+        # Observation is never download/filesystem authority.
+        "download_authority_granted": False,
+    }
+
+
+def probe_conversation_files(
+    client: Any,
+    conversation_id: str,
+) -> dict[str, Any]:
+    """Perform exactly one authenticated, read-only conversation-files request."""
+
+    conversation_id = _conversation_id(conversation_id)
+    endpoint = (
+        f"{CHATGPT_ORIGIN}/backend-api/conversations/"
+        f"{quote(conversation_id, safe='')}/files"
+    )
+    headers = client._build_headers(
+        {
+            "accept": "application/json",
+            "referer": f"{CHATGPT_ORIGIN}/c/{conversation_id}",
+        }
+    )
+
+    status, payload = client._json_request("GET", endpoint, None, headers)
+    report: dict[str, Any] = {
+        "schema": PROBE_SCHEMA,
+        "request_count": 1,
+        "method": "GET",
+        "conversation_id_present": True,
+        "status_code": status,
+        "response_body_exported": False,
+        "locator_values_exported": False,
+        "download_attempted": False,
+        "write_attempted": False,
+        "stable_product_identity_proven": False,
+        "download_authority_granted": False,
+    }
+
+    if status == 401:
+        report["characterization"] = "AUTHENTICATION_REQUIRED"
+        return report
+    if status == 403:
+        report["characterization"] = "ACCESS_CHALLENGED"
+        return report
+    if status == 404:
+        report["characterization"] = "ENDPOINT_ABSENT_OR_NOT_VISIBLE"
+        return report
+    if status >= 400:
+        report["characterization"] = "FILES_ENDPOINT_HTTP_ERROR"
+        return report
+
+    report.update(summarize_files_payload(payload))
+    return report
+
+
+def _git_output(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def run_probe(
+    *,
+    conversation_id: str,
+    expected_head: str,
+    timeout: float,
+) -> dict[str, Any]:
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+
+    head = _git_output("rev-parse", "HEAD")
+    tracked_clean = _git_output("status", "--porcelain", "--untracked-files=no") == ""
+    report: dict[str, Any] = {
+        "schema": PROBE_SCHEMA,
+        "head": head,
+        "expected_head": expected_head,
+        "head_matches": head == expected_head,
+        "tracked_clean": tracked_clean,
+        "request_count": 0,
+        "download_attempted": False,
+        "write_attempted": False,
+        "stable_product_identity_proven": False,
+        "download_authority_granted": False,
+    }
+    if head != expected_head or not tracked_clean:
+        report["characterization"] = "EXACT_HEAD_OR_TRACKED_CLEAN_GATE_FAILED"
+        return report
+
+    client = ChatGPTWebClient(
+        auto_login=False,
+        auto_sentinel=False,
+        timeout=timeout,
+    )
+    try:
+        probe = probe_conversation_files(client, conversation_id)
+    except Exception as exc:
+        report.update(
+            {
+                "request_count": 1,
+                "characterization": "PROBE_REQUEST_FAILED",
+                "error_type": type(exc).__name__,
+            }
+        )
+        return report
+
+    report.update(probe)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run one read-only authenticated GET against the ChatGPT "
+            "conversation-files surface and emit locator-free identity evidence."
+        )
+    )
+    parser.add_argument("--conversation-id", required=True)
+    parser.add_argument("--expected-head", required=True)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    args = parser.parse_args()
+
+    report = run_probe(
+        conversation_id=args.conversation_id,
+        expected_head=args.expected_head,
+        timeout=args.timeout,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+
+    completed_characterizations = {
+        "AUTHENTICATION_REQUIRED",
+        "ACCESS_CHALLENGED",
+        "ENDPOINT_ABSENT_OR_NOT_VISIBLE",
+        "FILES_ENDPOINT_HTTP_ERROR",
+        "UNRECOGNIZED_FILES_RESPONSE_SHAPE",
+        "EMPTY_FILE_COLLECTION_OBSERVED",
+        "NON_OBJECT_FILE_RECORD_OBSERVED",
+        "FILE_RECORDS_WITHOUT_EXPLICIT_IDENTITY",
+        "DUPLICATE_EXPLICIT_IDENTITY_CANDIDATE_OBSERVED",
+        "EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED",
+    }
+    return 0 if report.get("characterization") in completed_characterizations else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pr13_1_conversation_files_identity_probe.py
+++ b/tools/pr13_1_conversation_files_identity_probe.py
@@ -194,7 +194,9 @@ def summarize_files_payload(payload: Any) -> dict[str, Any]:
             identities.append(identity)
 
     unique_identity_count = len(set(identities))
-    all_records_have_identity = bool(raw_records) and len(identities) == len(raw_records)
+    all_records_have_identity = bool(raw_records) and len(identities) == len(
+        raw_records
+    )
     identities_unique = bool(identities) and unique_identity_count == len(identities)
 
     if not raw_records:

--- a/tools/pr13_1_conversation_files_live_gate.py
+++ b/tools/pr13_1_conversation_files_live_gate.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import argparse
+import json
+from urllib.parse import urlparse
+
+from pr13_1_conversation_files_identity_probe import _conversation_id, run_probe
+
+_ALLOWED_CHATGPT_HOSTS = frozenset({"chatgpt.com", "www.chatgpt.com"})
+
+
+def conversation_id_from_selector(value: str) -> str:
+    """Accept either one explicit conversation id or a ChatGPT conversation URL."""
+
+    text = value.strip()
+    if "://" not in text:
+        return _conversation_id(text)
+
+    parsed = urlparse(text)
+    if parsed.scheme != "https" or parsed.hostname not in _ALLOWED_CHATGPT_HOSTS:
+        raise ValueError("CHATGPT_CONVERSATION_URL_REQUIRED")
+
+    parts = [part for part in parsed.path.split("/") if part]
+    candidates = [
+        parts[index + 1]
+        for index, part in enumerate(parts[:-1])
+        if part == "c"
+    ]
+    if len(candidates) != 1:
+        raise ValueError("CHATGPT_CONVERSATION_URL_REQUIRED")
+    return _conversation_id(candidates[0])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the read-only PR13.1 conversation-files identity probe using either "
+            "a saved ChatGPT conversation URL or a raw conversation id."
+        )
+    )
+    parser.add_argument(
+        "--conversation",
+        required=True,
+        help="Raw conversation id or https://chatgpt.com/.../c/<conversation-id> URL.",
+    )
+    parser.add_argument("--expected-head", required=True)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    args = parser.parse_args()
+
+    try:
+        conversation_id = conversation_id_from_selector(args.conversation)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    report = run_probe(
+        conversation_id=conversation_id,
+        expected_head=args.expected_head,
+        timeout=args.timeout,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+
+    completed_characterizations = {
+        "AUTHENTICATION_REQUIRED",
+        "ACCESS_CHALLENGED",
+        "ENDPOINT_ABSENT_OR_NOT_VISIBLE",
+        "FILES_ENDPOINT_HTTP_ERROR",
+        "UNRECOGNIZED_FILES_RESPONSE_SHAPE",
+        "EMPTY_FILE_COLLECTION_OBSERVED",
+        "NON_OBJECT_FILE_RECORD_OBSERVED",
+        "FILE_RECORDS_WITHOUT_EXPLICIT_IDENTITY",
+        "DUPLICATE_EXPLICIT_IDENTITY_CANDIDATE_OBSERVED",
+        "EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED",
+    }
+    return 0 if report.get("characterization") in completed_characterizations else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pr13_1_conversation_files_live_gate.py
+++ b/tools/pr13_1_conversation_files_live_gate.py
@@ -22,9 +22,7 @@ def conversation_id_from_selector(value: str) -> str:
 
     parts = [part for part in parsed.path.split("/") if part]
     candidates = [
-        parts[index + 1]
-        for index, part in enumerate(parts[:-1])
-        if part == "c"
+        parts[index + 1] for index, part in enumerate(parts[:-1]) if part == "c"
     ]
     if len(candidates) != 1:
         raise ValueError("CHATGPT_CONVERSATION_URL_REQUIRED")

--- a/tools/pr13_1_conversation_files_stability_gate.py
+++ b/tools/pr13_1_conversation_files_stability_gate.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from typing import Any, Callable
+
+from chatgpt_web_adapter import ChatGPTWebClient
+
+from pr13_1_conversation_files_identity_probe import (
+    _conversation_id,
+    _safe_filename,
+    probe_conversation_files,
+)
+from pr13_1_conversation_files_live_gate import conversation_id_from_selector
+
+STABILITY_SCHEMA = "CWA_PR13_1_CONVERSATION_FILES_STABILITY_GATE_V1"
+
+
+def _git_output(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _identity_fingerprint(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _target_record(report: dict[str, Any], expected_filename: str) -> dict[str, Any] | None:
+    records = report.get("records")
+    if not isinstance(records, list):
+        return None
+    matches = [
+        record
+        for record in records
+        if isinstance(record, dict) and record.get("filename") == expected_filename
+    ]
+    if len(matches) != 1:
+        return None
+    record = matches[0]
+    identity = record.get("explicit_identity")
+    identity_key = record.get("explicit_identity_key")
+    if not isinstance(identity, str) or not identity:
+        return None
+    if not isinstance(identity_key, str) or not identity_key:
+        return None
+    return record
+
+
+def characterize_independent_reads(
+    first: dict[str, Any],
+    second: dict[str, Any],
+    *,
+    expected_filename: str,
+) -> dict[str, Any]:
+    """Compare one exact generated-file target across two sanitized read reports."""
+
+    first_record = _target_record(first, expected_filename)
+    second_record = _target_record(second, expected_filename)
+    base: dict[str, Any] = {
+        "schema": STABILITY_SCHEMA,
+        "request_count": 2,
+        "fresh_client_count": 2,
+        "expected_filename": expected_filename,
+        "first_characterization": first.get("characterization"),
+        "second_characterization": second.get("characterization"),
+        "first_target_record_present": first_record is not None,
+        "second_target_record_present": second_record is not None,
+        "same_explicit_identity": False,
+        "same_identity_key": False,
+        "short_term_identity_stability_proven": False,
+        "stable_product_identity_proven": False,
+        "resolution_surface_proven": False,
+        "download_authority_granted": False,
+        "download_attempted": False,
+        "write_attempted": False,
+        "identity_values_exported": False,
+    }
+
+    if first_record is None:
+        base["characterization"] = "FIRST_READ_TARGET_IDENTITY_NOT_PROVEN"
+        return base
+    if second_record is None:
+        base["characterization"] = "SECOND_READ_TARGET_IDENTITY_NOT_PROVEN"
+        return base
+
+    first_identity = first_record["explicit_identity"]
+    second_identity = second_record["explicit_identity"]
+    first_key = first_record["explicit_identity_key"]
+    second_key = second_record["explicit_identity_key"]
+    same_identity = first_identity == second_identity
+    same_key = first_key == second_key
+
+    base.update(
+        {
+            "first_identity_key": first_key,
+            "second_identity_key": second_key,
+            "first_identity_fingerprint": _identity_fingerprint(first_identity),
+            "second_identity_fingerprint": _identity_fingerprint(second_identity),
+            "same_explicit_identity": same_identity,
+            "same_identity_key": same_key,
+            "short_term_identity_stability_proven": same_identity and same_key,
+            "characterization": (
+                "SAME_EXPLICIT_IDENTITY_ACROSS_INDEPENDENT_READS"
+                if same_identity and same_key
+                else "EXPLICIT_IDENTITY_CHANGED_ACROSS_INDEPENDENT_READS"
+            ),
+        }
+    )
+    return base
+
+
+def _new_client(timeout: float) -> ChatGPTWebClient:
+    return ChatGPTWebClient(
+        auto_login=False,
+        auto_sentinel=False,
+        timeout=timeout,
+    )
+
+
+def run_stability_gate(
+    *,
+    conversation_id: str,
+    expected_filename: str,
+    expected_head: str,
+    timeout: float,
+    client_factory: Callable[[float], Any] = _new_client,
+) -> dict[str, Any]:
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    conversation_id = _conversation_id(conversation_id)
+    filename = _safe_filename(expected_filename)
+    if filename is None:
+        raise ValueError("EXPECTED_FILENAME_REQUIRED")
+
+    head = _git_output("rev-parse", "HEAD")
+    tracked_clean = _git_output("status", "--porcelain", "--untracked-files=no") == ""
+    preflight: dict[str, Any] = {
+        "schema": STABILITY_SCHEMA,
+        "head": head,
+        "expected_head": expected_head,
+        "head_matches": head == expected_head,
+        "tracked_clean": tracked_clean,
+        "request_count": 0,
+        "fresh_client_count": 0,
+        "expected_filename": filename,
+        "short_term_identity_stability_proven": False,
+        "stable_product_identity_proven": False,
+        "resolution_surface_proven": False,
+        "download_authority_granted": False,
+        "download_attempted": False,
+        "write_attempted": False,
+        "identity_values_exported": False,
+    }
+    if head != expected_head or not tracked_clean:
+        preflight["characterization"] = "EXACT_HEAD_OR_TRACKED_CLEAN_GATE_FAILED"
+        return preflight
+
+    try:
+        first_client = client_factory(timeout)
+        first = probe_conversation_files(first_client, conversation_id)
+    except Exception as exc:
+        preflight.update(
+            {
+                "request_count": 1,
+                "fresh_client_count": 1,
+                "characterization": "FIRST_READ_FAILED",
+                "first_error_type": type(exc).__name__,
+            }
+        )
+        return preflight
+
+    try:
+        second_client = client_factory(timeout)
+        second = probe_conversation_files(second_client, conversation_id)
+    except Exception as exc:
+        preflight.update(
+            {
+                "request_count": 2,
+                "fresh_client_count": 2,
+                "first_characterization": first.get("characterization"),
+                "characterization": "SECOND_READ_FAILED",
+                "second_error_type": type(exc).__name__,
+            }
+        )
+        return preflight
+
+    result = characterize_independent_reads(
+        first,
+        second,
+        expected_filename=filename,
+    )
+    result.update(
+        {
+            "head": head,
+            "expected_head": expected_head,
+            "head_matches": True,
+            "tracked_clean": True,
+        }
+    )
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Perform two independent read-only authenticated conversation-files reads "
+            "through fresh clients and compare one filename-anchored explicit identity."
+        )
+    )
+    parser.add_argument(
+        "--conversation",
+        required=True,
+        help="Raw conversation id or https://chatgpt.com/.../c/<conversation-id> URL.",
+    )
+    parser.add_argument("--expected-filename", required=True)
+    parser.add_argument("--expected-head", required=True)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    args = parser.parse_args()
+
+    try:
+        conversation_id = conversation_id_from_selector(args.conversation)
+        report = run_stability_gate(
+            conversation_id=conversation_id,
+            expected_filename=args.expected_filename,
+            expected_head=args.expected_head,
+            timeout=args.timeout,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+    return (
+        0
+        if report.get("characterization")
+        == "SAME_EXPLICIT_IDENTITY_ACROSS_INDEPENDENT_READS"
+        else 1
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pr13_1_conversation_files_stability_gate.py
+++ b/tools/pr13_1_conversation_files_stability_gate.py
@@ -6,14 +6,14 @@ import json
 import subprocess
 from typing import Any, Callable
 
-from chatgpt_web_adapter import ChatGPTWebClient
-
 from pr13_1_conversation_files_identity_probe import (
     _conversation_id,
     _safe_filename,
     probe_conversation_files,
 )
 from pr13_1_conversation_files_live_gate import conversation_id_from_selector
+
+from chatgpt_web_adapter import ChatGPTWebClient
 
 STABILITY_SCHEMA = "CWA_PR13_1_CONVERSATION_FILES_STABILITY_GATE_V1"
 
@@ -32,7 +32,9 @@ def _identity_fingerprint(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def _target_record(report: dict[str, Any], expected_filename: str) -> dict[str, Any] | None:
+def _target_record(
+    report: dict[str, Any], expected_filename: str
+) -> dict[str, Any] | None:
     records = report.get("records")
     if not isinstance(records, list):
         return None


### PR DESCRIPTION
## Question

Does the authenticated ChatGPT product expose a stronger conversation-scoped generated-file identity primitive at `GET /backend-api/conversations/{conversation_id}/files` than PR10.1 could prove from point observations, and is that identity stable across independent reads?

## R1 — identity discovery

- one read-only authenticated GET for one caller-supplied saved conversation;
- no retry/fallback, product write, artifact download, locator following or local filesystem write;
- no raw response body or URL/signed-URL/token/cookie/credential/authorization export;
- sanitize explicit opaque identity candidates plus filename/MIME/size metadata and presence booleans;
- require every observed file record to expose a safe explicit ID and require uniqueness within the response before reporting `EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED`.

## Authenticated live R1 result — 2026-09-10

A clean exact-head run against a saved ChatGPT conversation containing one generated text artifact returned:

```text
HTTP 200
collection_key = items
record_count = 1
explicit_identity_key = file_id
filename_key = file_name
media_type_key = mime_type
media_type = text/plain
locator_field_present = false
conversation_id_field_present = false
message_id_field_present = false
characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
```

The opaque identifier value is intentionally not copied into repository evidence. This is live evidence that the product endpoint exposes an explicit conversation-scoped `file_id` candidate for the generated artifact.

## R2 — independent short-term stability

R2 performs exactly two read-only authenticated GETs through two fresh `ChatGPTWebClient` instances and anchors one target by exact filename only for record selection. Filename equality is never treated as identity.

Authenticated live R2 returned:

```text
first_characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
second_characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
first_identity_key = file_id
second_identity_key = file_id
first_target_record_present = true
second_target_record_present = true
same_explicit_identity = true
same_identity_key = true
short_term_identity_stability_proven = true
characterization = SAME_EXPLICIT_IDENTITY_ACROSS_INDEPENDENT_READS
```

The raw identifier and its SHA-256 fingerprint are intentionally not copied into repository evidence.

R2 deliberately keeps:

```text
stable_product_identity_proven = false
resolution_surface_proven = false
download_authority_granted = false
```

Two immediate independent reads prove the narrower short-term stability property, not longitudinal/session stability and not identity-bound resolution into downloadable bytes.

## Result

PR13.1 establishes two facts:

1. ChatGPT exposes an explicit conversation-scoped product-owned `file_id` for the generated artifact.
2. The same generated artifact exposes the same `file_id` across two independent immediate reads through fresh clients.

This closes PR13.1's identity/stability characterization question. Resolution-path research belongs to a separate follow-up gate.

## Scope boundary

This experiment does **not** change PR10.1's public support status `ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY`. It does not modify runtime, write/finality authority, canonical read, #79/#80, generated-artifact download behavior, retry semantics or product capability declarations.

## Validation

Exact head: `eebd48cef2896a285331896741e3ba0225e5cc5f`

CI #889 (`34466437830`): **SUCCESS**

- Engineering Quality: Ruff delta + architecture debt, compileall and extension JavaScript syntax — PASS;
- source tests: Ubuntu + Windows, Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14 — PASS;
- Build release artifacts: sdist/wheel, metadata and release artifact contract — PASS;
- installed-wheel smoke: Ubuntu 3.10/3.14 and Windows 3.10/3.14 — PASS.

## Follow-up boundary

A future PR13.2 may investigate whether the stable `file_id` has a product-owned, identity-bound resolution surface. PR13.1 itself performs no resolution or download attempt and grants no new artifact authority.