### PR TITLE
Experiment PR13.2 — Identity-Bound Artifact Resolution Probe

### DIFF
--- a/docs/engineering/pr13_2_identity_bound_artifact_resolution_probe.md
+++ b/docs/engineering/pr13_2_identity_bound_artifact_resolution_probe.md
@@ -57,6 +57,44 @@ download_authority_granted = false
 
 The distinction matters: observing a product-owned resolver that emits a locator is not yet proof that the locator can be safely followed, that returned bytes are the expected artifact, or that the identity is longitudinally stable across later sessions.
 
+## Authenticated live evidence — 2026-09-10
+
+A clean exact-head authenticated run against the same saved conversation and generated text artifact used by PR13.1 returned:
+
+```text
+identity_discovery_characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
+identity_key = file_id
+target_record_present = true
+real_status_code = 200
+real_locator_field_present = true
+real_resolution_payload_recognized = true
+real_filename = cwa_pr13_1_identity_probe.txt
+real_size_bytes = 45
+control_performed = true
+control_status_code = 404
+control_locator_field_present = false
+identity_bound_resolution_surface_proven = true
+characterization = IDENTITY_BOUND_RESOLUTION_SURFACE_OBSERVED
+```
+
+The raw `file_id`, deterministic control identity, returned locator value, and raw response body are intentionally not recorded in repository evidence.
+
+The control is important: the resolver accepted the exact product-owned identity and rejected the otherwise identical request after the identity was deliberately changed. This establishes that the observed resolver is materially bound to the product identity rather than merely returning a conversation-level locator independent of `file_id`.
+
+The run also preserved all authority boundaries:
+
+```text
+identity_values_exported = false
+locator_values_exported = false
+download_attempted = false
+write_attempted = false
+artifact_bytes_proven = false
+stable_product_identity_proven = false
+download_authority_granted = false
+```
+
+This closes PR13.2's resolution-surface question positively. It does not prove safe byte retrieval, artifact integrity, longitudinal identity stability, or production download/materialization support.
+
 ## Fail-closed characterizations
 
 The gate keeps separate outcomes for:
@@ -87,15 +125,25 @@ The probe never follows a locator, downloads bytes, writes a product mutation, w
 
 PR13.1 established that one generated artifact exposed an explicit product-owned `file_id` and that the same `file_id` survived two independent immediate reads through fresh clients.
 
-PR13.2 asks only whether that product identity is accepted by a product-owned artifact resolver and rejected when the identity is deliberately changed.
+PR13.2 now establishes the next link: that exact product identity is accepted by a product-owned artifact resolver, while a deterministic nonmatching identity is rejected.
 
-Even a positive PR13.2 result does not by itself change the public frozen status:
+The proven chain is therefore:
+
+```text
+saved conversation
+  -> explicit product-owned file_id
+  -> same file_id across independent immediate reads
+  -> identity-bound product resolver
+  -> locator-bearing resolution response
+```
+
+Even this positive PR13.2 result does not by itself change the public frozen status:
 
 ```text
 ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY
 ```
 
-A later gate would still need to prove safe identity-bound byte retrieval and artifact integrity before production download/materialization can be considered.
+A later gate still needs to prove safe identity-bound byte retrieval and artifact integrity before production download/materialization can be considered.
 
 ## Running the live gate
 

--- a/docs/engineering/pr13_2_identity_bound_artifact_resolution_probe.md
+++ b/docs/engineering/pr13_2_identity_bound_artifact_resolution_probe.md
@@ -1,0 +1,106 @@
+# PR13.2 — Identity-Bound Artifact Resolution Probe
+
+## Question
+
+Given the explicit conversation-scoped `file_id` established by PR13.1, does ChatGPT expose a product-owned resolution surface that is actually bound to that identity?
+
+The generated-artifact candidate under test is:
+
+```text
+GET /backend-api/files/download/{file_id}?conversation_id={conversation_id}&inline=false
+```
+
+PR13.2 is a characterization experiment. It does not follow or export the returned locator and does not download artifact bytes.
+
+## Why this surface
+
+Recent browser-observed implementations for generated `file_...` / sediment artifacts use the `files/download/{file_id}` route with the owning conversation id. PR13.2 intentionally tests only that exact generated-file route rather than fuzzing multiple endpoint shapes.
+
+## Gate
+
+The live gate performs at most three authenticated read-only GET requests:
+
+1. Read `GET /backend-api/conversations/{conversation_id}/files` and select exactly one caller-named generated artifact.
+2. Resolve the product-owned `file_id` returned for that artifact through the generated-file resolution endpoint.
+3. Only if the real identity resolves to a recognized locator-bearing response, repeat the same resolution request with one deterministic nonmatching identity control.
+
+The filename is used only to select one record from the conversation-scoped files collection. It is never used as artifact identity and is never substituted into the resolution endpoint.
+
+## Positive characterization
+
+PR13.2 reports:
+
+```text
+IDENTITY_BOUND_RESOLUTION_SURFACE_OBSERVED
+```
+
+only when all of the following hold:
+
+- conversation-files exposes exactly one target record with an explicit product identity;
+- the real identity returns an HTTP 2xx response containing a recognized locator field;
+- the nonmatching control identity is rejected with a non-rate-limit, non-server-error response;
+- neither identity value nor any locator value is exported in the final report.
+
+A positive result may set:
+
+```text
+identity_bound_resolution_surface_proven = true
+```
+
+but deliberately continues to keep:
+
+```text
+stable_product_identity_proven = false
+artifact_bytes_proven = false
+download_authority_granted = false
+```
+
+The distinction matters: observing a product-owned resolver that emits a locator is not yet proof that the locator can be safely followed, that returned bytes are the expected artifact, or that the identity is longitudinally stable across later sessions.
+
+## Fail-closed characterizations
+
+The gate keeps separate outcomes for:
+
+- exact-head or tracked-clean preflight failure;
+- inability to establish the target explicit identity;
+- real-ID resolution request failure;
+- real-ID response without a recognized locator;
+- negative-control request failure;
+- negative control unexpectedly resolving;
+- negative-control rate-limit or server failure, which is inconclusive rather than positive evidence.
+
+No fallback endpoint is attempted.
+
+## Privacy and authority boundary
+
+The report does not contain:
+
+- the real `file_id` value;
+- the negative-control identity value;
+- signed URLs or other locator values;
+- raw resolver response bodies;
+- cookies, authorization material, tokens, or credentials.
+
+The probe never follows a locator, downloads bytes, writes a product mutation, writes an artifact to disk, grants retry authority, or changes write/finality authority.
+
+## Relationship to PR13.1 and PR10.1
+
+PR13.1 established that one generated artifact exposed an explicit product-owned `file_id` and that the same `file_id` survived two independent immediate reads through fresh clients.
+
+PR13.2 asks only whether that product identity is accepted by a product-owned artifact resolver and rejected when the identity is deliberately changed.
+
+Even a positive PR13.2 result does not by itself change the public frozen status:
+
+```text
+ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY
+```
+
+A later gate would still need to prove safe identity-bound byte retrieval and artifact integrity before production download/materialization can be considered.
+
+## Running the live gate
+
+From an exact clean checkout with an authenticated CWA session available:
+
+```powershell
+python tools/pr13_2_identity_bound_artifact_resolution_probe.py --conversation "https://chatgpt.com/c/<conversation-id>" --expected-filename cwa_pr13_1_identity_probe.txt --expected-head <exact-head-sha>
+```

--- a/tests/test_identity_bound_artifact_resolution_probe_pr13_2.py
+++ b/tests/test_identity_bound_artifact_resolution_probe_pr13_2.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from typing import Any
+
+import tools.pr13_2_identity_bound_artifact_resolution_probe as probe_mod
+from tools.pr13_2_identity_bound_artifact_resolution_probe import (
+    characterize_resolution_pair,
+    probe_resolution_request,
+    run_resolution_gate,
+    summarize_resolution_payload,
+)
+
+
+class _Client:
+    def __init__(self, responses: list[tuple[int, Any]]) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, str, Any, dict[str, str]]] = []
+
+    def _build_headers(self, additions: dict[str, str]) -> dict[str, str]:
+        return dict(additions)
+
+    def _json_request(self, method, url, payload, headers):
+        self.calls.append((method, url, payload, headers))
+        return self.responses.pop(0)
+
+
+def test_resolution_payload_exports_presence_not_locator_value() -> None:
+    report = summarize_resolution_payload(
+        {
+            "download_url": "https://example.invalid/signed?token=secret",
+            "file_name": "result.txt",
+            "file_size_bytes": 42,
+        }
+    )
+
+    assert report == {
+        "response_shape": "dict",
+        "locator_field_present": True,
+        "locator_value_exported": False,
+        "filename_key": "file_name",
+        "filename": "result.txt",
+        "size_key": "file_size_bytes",
+        "size_bytes": 42,
+        "resolution_payload_recognized": True,
+    }
+    assert "example.invalid" not in str(report)
+    assert "secret" not in str(report)
+
+
+def test_resolution_request_uses_exact_generated_file_identity_surface() -> None:
+    client = _Client(
+        [(200, {"download_url": "https://example.invalid/signed", "file_name": "x.txt"})]
+    )
+
+    report = probe_resolution_request(
+        client,
+        conversation_id="conversation-1",
+        file_id="file_abc123",
+    )
+
+    assert len(client.calls) == 1
+    method, url, payload, headers = client.calls[0]
+    assert method == "GET"
+    assert url == (
+        "https://chatgpt.com/backend-api/files/download/file_abc123"
+        "?conversation_id=conversation-1&inline=false"
+    )
+    assert payload is None
+    assert headers["accept"] == "application/json"
+    assert report["status_code"] == 200
+    assert report["locator_field_present"] is True
+    assert report["locator_value_exported"] is False
+
+
+def test_pair_requires_real_resolution_and_rejected_negative_control() -> None:
+    real = {
+        "status_code": 200,
+        "resolution_payload_recognized": True,
+        "locator_field_present": True,
+    }
+    control = {
+        "status_code": 404,
+        "resolution_payload_recognized": False,
+        "locator_field_present": False,
+    }
+
+    report = characterize_resolution_pair(real, control)
+
+    assert report["characterization"] == "IDENTITY_BOUND_RESOLUTION_SURFACE_OBSERVED"
+    assert report["identity_bound_resolution_surface_proven"] is True
+    assert report["stable_product_identity_proven"] is False
+    assert report["artifact_bytes_proven"] is False
+    assert report["download_authority_granted"] is False
+
+
+def test_pair_fails_closed_when_control_also_resolves() -> None:
+    real = {
+        "status_code": 200,
+        "resolution_payload_recognized": True,
+        "locator_field_present": True,
+    }
+    control = {
+        "status_code": 200,
+        "resolution_payload_recognized": True,
+        "locator_field_present": True,
+    }
+
+    report = characterize_resolution_pair(real, control)
+
+    assert report["characterization"] == "NEGATIVE_CONTROL_UNEXPECTEDLY_RESOLVED"
+    assert report["identity_bound_resolution_surface_proven"] is False
+
+
+def test_pair_treats_server_error_control_as_inconclusive() -> None:
+    real = {
+        "status_code": 200,
+        "resolution_payload_recognized": True,
+        "locator_field_present": True,
+    }
+    control = {
+        "status_code": 500,
+        "resolution_payload_recognized": False,
+        "locator_field_present": False,
+    }
+
+    report = characterize_resolution_pair(real, control)
+
+    assert report["characterization"] == "NEGATIVE_CONTROL_INCONCLUSIVE"
+    assert report["identity_bound_resolution_surface_proven"] is False
+
+
+def test_gate_derives_file_id_then_resolves_real_and_negative_control(monkeypatch) -> None:
+    monkeypatch.setattr(
+        probe_mod,
+        "_git_output",
+        lambda *args: "head-1" if args == ("rev-parse", "HEAD") else "",
+    )
+    client = _Client(
+        [
+            (
+                200,
+                {
+                    "items": [
+                        {
+                            "file_id": "file_abc123",
+                            "file_name": "result.txt",
+                            "mime_type": "text/plain",
+                        }
+                    ]
+                },
+            ),
+            (
+                200,
+                {
+                    "download_url": "https://example.invalid/signed?token=secret",
+                    "file_name": "result.txt",
+                    "file_size_bytes": 42,
+                },
+            ),
+            (404, {"detail": "not found"}),
+        ]
+    )
+
+    report = run_resolution_gate(
+        conversation_id="conversation-1",
+        expected_filename="result.txt",
+        expected_head="head-1",
+        timeout=1.0,
+        client_factory=lambda _timeout: client,
+    )
+
+    assert report["characterization"] == "IDENTITY_BOUND_RESOLUTION_SURFACE_OBSERVED"
+    assert report["request_count"] == 3
+    assert report["identity_discovery_request_count"] == 1
+    assert report["resolution_request_count"] == 1
+    assert report["negative_control_request_count"] == 1
+    assert report["identity_key"] == "file_id"
+    assert report["identity_values_exported"] is False
+    assert report["locator_values_exported"] is False
+    assert report["response_body_exported"] is False
+    assert report["identity_bound_resolution_surface_proven"] is True
+    assert report["artifact_bytes_proven"] is False
+    assert report["download_attempted"] is False
+    assert report["write_attempted"] is False
+    assert "file_abc123" not in str(report)
+    assert "example.invalid" not in str(report)
+    assert "secret" not in str(report)
+
+    assert len(client.calls) == 3
+    real_url = client.calls[1][1]
+    control_url = client.calls[2][1]
+    assert "file_abc123" in real_url
+    assert "file_abc120" in control_url
+    assert real_url != control_url
+
+
+def test_gate_does_not_run_control_when_real_id_does_not_resolve(monkeypatch) -> None:
+    monkeypatch.setattr(
+        probe_mod,
+        "_git_output",
+        lambda *args: "head-1" if args == ("rev-parse", "HEAD") else "",
+    )
+    client = _Client(
+        [
+            (
+                200,
+                {"items": [{"file_id": "file_abc123", "file_name": "result.txt"}]},
+            ),
+            (404, {"detail": "not found"}),
+        ]
+    )
+
+    report = run_resolution_gate(
+        conversation_id="conversation-1",
+        expected_filename="result.txt",
+        expected_head="head-1",
+        timeout=1.0,
+        client_factory=lambda _timeout: client,
+    )
+
+    assert report["characterization"] == "REAL_ID_RESOLUTION_NOT_PROVEN"
+    assert report["request_count"] == 2
+    assert report["negative_control_request_count"] == 0
+    assert report["identity_bound_resolution_surface_proven"] is False
+    assert len(client.calls) == 2

--- a/tests/test_identity_bound_artifact_resolution_probe_pr13_2.py
+++ b/tests/test_identity_bound_artifact_resolution_probe_pr13_2.py
@@ -49,7 +49,15 @@ def test_resolution_payload_exports_presence_not_locator_value() -> None:
 
 def test_resolution_request_uses_exact_generated_file_identity_surface() -> None:
     client = _Client(
-        [(200, {"download_url": "https://example.invalid/signed", "file_name": "x.txt"})]
+        [
+            (
+                200,
+                {
+                    "download_url": "https://example.invalid/signed",
+                    "file_name": "x.txt",
+                },
+            )
+        ]
     )
 
     report = probe_resolution_request(
@@ -129,7 +137,9 @@ def test_pair_treats_server_error_control_as_inconclusive() -> None:
     assert report["identity_bound_resolution_surface_proven"] is False
 
 
-def test_gate_derives_file_id_then_resolves_real_and_negative_control(monkeypatch) -> None:
+def test_gate_derives_file_id_then_resolves_real_and_negative_control(
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(
         probe_mod,
         "_git_output",

--- a/tools/pr13_2_identity_bound_artifact_resolution_probe.py
+++ b/tools/pr13_2_identity_bound_artifact_resolution_probe.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from typing import Any, Callable
+from urllib.parse import quote
+
+from pr13_1_conversation_files_identity_probe import (
+    CHATGPT_ORIGIN,
+    _conversation_id,
+    _safe_filename,
+    probe_conversation_files,
+)
+from pr13_1_conversation_files_live_gate import conversation_id_from_selector
+from pr13_1_conversation_files_stability_gate import _target_record
+
+from chatgpt_web_adapter import ChatGPTWebClient
+
+RESOLUTION_SCHEMA = "CWA_PR13_2_IDENTITY_BOUND_ARTIFACT_RESOLUTION_PROBE_V1"
+_RESOLUTION_LOCATOR_KEYS = ("download_url", "url", "href")
+_FILENAME_KEYS = ("file_name", "filename", "name")
+_SIZE_KEYS = ("file_size_bytes", "size_bytes", "size")
+
+
+def _git_output(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _safe_size(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _first_safe_filename(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    for key in _FILENAME_KEYS:
+        filename = _safe_filename(payload.get(key))
+        if filename is not None:
+            return key, filename
+    return None, None
+
+
+def _first_safe_size(payload: dict[str, Any]) -> tuple[str | None, int | None]:
+    for key in _SIZE_KEYS:
+        size = _safe_size(payload.get(key))
+        if size is not None:
+            return key, size
+    return None, None
+
+
+def summarize_resolution_payload(payload: Any) -> dict[str, Any]:
+    """Return locator-free evidence from one file-resolution response payload."""
+
+    if not isinstance(payload, dict):
+        return {
+            "response_shape": type(payload).__name__,
+            "locator_field_present": False,
+            "locator_value_exported": False,
+            "filename_key": None,
+            "filename": None,
+            "size_key": None,
+            "size_bytes": None,
+            "resolution_payload_recognized": False,
+        }
+
+    locator_field_present = any(
+        isinstance(payload.get(key), str) and bool(payload.get(key).strip())
+        for key in _RESOLUTION_LOCATOR_KEYS
+    )
+    filename_key, filename = _first_safe_filename(payload)
+    size_key, size_bytes = _first_safe_size(payload)
+    return {
+        "response_shape": "dict",
+        "locator_field_present": locator_field_present,
+        "locator_value_exported": False,
+        "filename_key": filename_key,
+        "filename": filename,
+        "size_key": size_key,
+        "size_bytes": size_bytes,
+        "resolution_payload_recognized": locator_field_present,
+    }
+
+
+def _negative_control_identity(identity: str) -> str:
+    """Produce one deterministic nonmatching opaque identity without exporting it."""
+
+    if not identity:
+        raise ValueError("EXPLICIT_FILE_ID_REQUIRED")
+    replacement = "0" if identity[-1] != "0" else "1"
+    control = f"{identity[:-1]}{replacement}"
+    if control == identity:
+        raise ValueError("NEGATIVE_CONTROL_IDENTITY_REQUIRED")
+    return control
+
+
+def _resolution_endpoint(conversation_id: str, file_id: str) -> str:
+    return (
+        f"{CHATGPT_ORIGIN}/backend-api/files/download/{quote(file_id, safe='')}"
+        f"?conversation_id={quote(conversation_id, safe='')}&inline=false"
+    )
+
+
+def probe_resolution_request(
+    client: Any,
+    *,
+    conversation_id: str,
+    file_id: str,
+) -> dict[str, Any]:
+    """Perform exactly one authenticated GET against the generated-file resolver."""
+
+    conversation_id = _conversation_id(conversation_id)
+    endpoint = _resolution_endpoint(conversation_id, file_id)
+    headers = client._build_headers(
+        {
+            "accept": "application/json",
+            "referer": f"{CHATGPT_ORIGIN}/c/{conversation_id}",
+        }
+    )
+    status, payload = client._json_request("GET", endpoint, None, headers)
+    report: dict[str, Any] = {
+        "method": "GET",
+        "request_count": 1,
+        "status_code": status,
+        "response_body_exported": False,
+        "locator_value_exported": False,
+        "download_attempted": False,
+        "write_attempted": False,
+    }
+    if status >= 400:
+        report.update(
+            {
+                "response_shape": type(payload).__name__,
+                "locator_field_present": False,
+                "resolution_payload_recognized": False,
+            }
+        )
+        return report
+    report.update(summarize_resolution_payload(payload))
+    return report
+
+
+def characterize_resolution_pair(
+    real: dict[str, Any],
+    control: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Characterize one real-ID resolution and one nonmatching-ID control."""
+
+    real_status = real.get("status_code")
+    real_resolved = (
+        isinstance(real_status, int)
+        and 200 <= real_status < 300
+        and real.get("resolution_payload_recognized") is True
+        and real.get("locator_field_present") is True
+    )
+    base: dict[str, Any] = {
+        "real_status_code": real_status,
+        "real_locator_field_present": real.get("locator_field_present") is True,
+        "real_resolution_payload_recognized": real.get("resolution_payload_recognized")
+        is True,
+        "control_performed": control is not None,
+        "control_status_code": None if control is None else control.get("status_code"),
+        "control_locator_field_present": False
+        if control is None
+        else control.get("locator_field_present") is True,
+        "identity_bound_resolution_surface_proven": False,
+        "stable_product_identity_proven": False,
+        "artifact_bytes_proven": False,
+        "download_authority_granted": False,
+        "download_attempted": False,
+        "write_attempted": False,
+        "identity_values_exported": False,
+        "locator_values_exported": False,
+    }
+
+    if not real_resolved:
+        base["characterization"] = "REAL_ID_RESOLUTION_NOT_PROVEN"
+        return base
+    if control is None:
+        base["characterization"] = "NEGATIVE_CONTROL_NOT_PERFORMED"
+        return base
+
+    control_status = control.get("status_code")
+    if not isinstance(control_status, int):
+        base["characterization"] = "NEGATIVE_CONTROL_STATUS_UNRECOGNIZED"
+        return base
+    if 200 <= control_status < 300:
+        base["characterization"] = "NEGATIVE_CONTROL_UNEXPECTEDLY_RESOLVED"
+        return base
+    if control_status >= 500 or control_status == 429:
+        base["characterization"] = "NEGATIVE_CONTROL_INCONCLUSIVE"
+        return base
+
+    base.update(
+        {
+            "identity_bound_resolution_surface_proven": True,
+            "characterization": "IDENTITY_BOUND_RESOLUTION_SURFACE_OBSERVED",
+        }
+    )
+    return base
+
+
+def _new_client(timeout: float) -> ChatGPTWebClient:
+    return ChatGPTWebClient(
+        auto_login=False,
+        auto_sentinel=False,
+        timeout=timeout,
+    )
+
+
+def run_resolution_gate(
+    *,
+    conversation_id: str,
+    expected_filename: str,
+    expected_head: str,
+    timeout: float,
+    client_factory: Callable[[float], Any] = _new_client,
+) -> dict[str, Any]:
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    conversation_id = _conversation_id(conversation_id)
+    filename = _safe_filename(expected_filename)
+    if filename is None:
+        raise ValueError("EXPECTED_FILENAME_REQUIRED")
+
+    head = _git_output("rev-parse", "HEAD")
+    tracked_clean = _git_output("status", "--porcelain", "--untracked-files=no") == ""
+    preflight: dict[str, Any] = {
+        "schema": RESOLUTION_SCHEMA,
+        "head": head,
+        "expected_head": expected_head,
+        "head_matches": head == expected_head,
+        "tracked_clean": tracked_clean,
+        "expected_filename": filename,
+        "request_count": 0,
+        "identity_discovery_request_count": 0,
+        "resolution_request_count": 0,
+        "negative_control_request_count": 0,
+        "identity_values_exported": False,
+        "locator_values_exported": False,
+        "response_body_exported": False,
+        "identity_bound_resolution_surface_proven": False,
+        "stable_product_identity_proven": False,
+        "artifact_bytes_proven": False,
+        "download_authority_granted": False,
+        "download_attempted": False,
+        "write_attempted": False,
+    }
+    if head != expected_head or not tracked_clean:
+        preflight["characterization"] = "EXACT_HEAD_OR_TRACKED_CLEAN_GATE_FAILED"
+        return preflight
+
+    client = client_factory(timeout)
+    try:
+        discovery = probe_conversation_files(client, conversation_id)
+    except Exception as exc:
+        preflight.update(
+            {
+                "request_count": 1,
+                "identity_discovery_request_count": 1,
+                "characterization": "IDENTITY_DISCOVERY_REQUEST_FAILED",
+                "error_type": type(exc).__name__,
+            }
+        )
+        return preflight
+
+    preflight["request_count"] = 1
+    preflight["identity_discovery_request_count"] = 1
+    preflight["identity_discovery_characterization"] = discovery.get("characterization")
+    target = _target_record(discovery, filename)
+    if target is None:
+        preflight["characterization"] = "TARGET_EXPLICIT_IDENTITY_NOT_PROVEN"
+        return preflight
+
+    file_id = target["explicit_identity"]
+    identity_key = target["explicit_identity_key"]
+    preflight["identity_key"] = identity_key
+    preflight["target_record_present"] = True
+
+    try:
+        real = probe_resolution_request(
+            client,
+            conversation_id=conversation_id,
+            file_id=file_id,
+        )
+    except Exception as exc:
+        preflight.update(
+            {
+                "request_count": 2,
+                "resolution_request_count": 1,
+                "characterization": "REAL_ID_RESOLUTION_REQUEST_FAILED",
+                "error_type": type(exc).__name__,
+            }
+        )
+        return preflight
+
+    preflight["request_count"] = 2
+    preflight["resolution_request_count"] = 1
+    real_status = real.get("status_code")
+    real_resolved = (
+        isinstance(real_status, int)
+        and 200 <= real_status < 300
+        and real.get("resolution_payload_recognized") is True
+        and real.get("locator_field_present") is True
+    )
+    if not real_resolved:
+        result = characterize_resolution_pair(real, None)
+        result.update(preflight)
+        result["characterization"] = "REAL_ID_RESOLUTION_NOT_PROVEN"
+        result["real_status_code"] = real_status
+        result["real_locator_field_present"] = real.get("locator_field_present") is True
+        return result
+
+    control_id = _negative_control_identity(file_id)
+    try:
+        control = probe_resolution_request(
+            client,
+            conversation_id=conversation_id,
+            file_id=control_id,
+        )
+    except Exception as exc:
+        preflight.update(
+            {
+                "request_count": 3,
+                "resolution_request_count": 1,
+                "negative_control_request_count": 1,
+                "characterization": "NEGATIVE_CONTROL_REQUEST_FAILED",
+                "control_error_type": type(exc).__name__,
+            }
+        )
+        return preflight
+
+    result = characterize_resolution_pair(real, control)
+    result.update(
+        {
+            **preflight,
+            "request_count": 3,
+            "resolution_request_count": 1,
+            "negative_control_request_count": 1,
+            "real_status_code": real.get("status_code"),
+            "real_locator_field_present": real.get("locator_field_present") is True,
+            "real_resolution_payload_recognized": real.get(
+                "resolution_payload_recognized"
+            )
+            is True,
+            "real_filename": real.get("filename"),
+            "real_size_bytes": real.get("size_bytes"),
+            "control_status_code": control.get("status_code"),
+            "control_locator_field_present": control.get("locator_field_present")
+            is True,
+            "identity_bound_resolution_surface_proven": result.get(
+                "identity_bound_resolution_surface_proven"
+            )
+            is True,
+            "characterization": result.get("characterization"),
+        }
+    )
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Resolve one product-owned conversation file_id through the generated-file "
+            "resolver and compare it with one nonmatching identity control."
+        )
+    )
+    parser.add_argument(
+        "--conversation",
+        required=True,
+        help="Raw conversation id or https://chatgpt.com/.../c/<conversation-id> URL.",
+    )
+    parser.add_argument("--expected-filename", required=True)
+    parser.add_argument("--expected-head", required=True)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    args = parser.parse_args()
+
+    try:
+        conversation_id = conversation_id_from_selector(args.conversation)
+        report = run_resolution_gate(
+            conversation_id=conversation_id,
+            expected_filename=args.expected_filename,
+            expected_head=args.expected_head,
+            timeout=args.timeout,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+    completed = {
+        "IDENTITY_BOUND_RESOLUTION_SURFACE_OBSERVED",
+        "REAL_ID_RESOLUTION_NOT_PROVEN",
+        "NEGATIVE_CONTROL_UNEXPECTEDLY_RESOLVED",
+        "NEGATIVE_CONTROL_INCONCLUSIVE",
+        "TARGET_EXPLICIT_IDENTITY_NOT_PROVEN",
+    }
+    return 0 if report.get("characterization") in completed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Question

Given the explicit conversation-scoped `file_id` established by PR13.1, does ChatGPT expose a product-owned resolver that is actually bound to that identity?

## Candidate under test

```text
GET /backend-api/files/download/{file_id}?conversation_id={conversation_id}&inline=false
```

Recent browser-observed generated-file implementations use this exact route for `file_...` / sediment artifacts. PR13.2 deliberately tests only this surface rather than fuzzing multiple endpoint shapes.

## Gate

At most three authenticated read-only GETs:

1. discover the target's exact product-owned `file_id` through `/backend-api/conversations/{conversation_id}/files`;
2. resolve that real ID through the generated-file resolver;
3. only after a recognized real-ID resolution, repeat with one deterministic nonmatching ID control.

Positive characterization requires real ID -> HTTP 2xx + recognized locator field, while the nonmatching control is rejected without a rate-limit/server-error ambiguity.

## Authenticated live result — 2026-09-10

A clean exact-head run against the same saved conversation and generated text artifact used by PR13.1 returned:

```text
identity_discovery_characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
identity_key = file_id
target_record_present = true
real_status_code = 200
real_locator_field_present = true
real_resolution_payload_recognized = true
real_filename = cwa_pr13_1_identity_probe.txt
real_size_bytes = 45
control_performed = true
control_status_code = 404
control_locator_field_present = false
identity_bound_resolution_surface_proven = true
characterization = IDENTITY_BOUND_RESOLUTION_SURFACE_OBSERVED
```

The raw `file_id`, deterministic control identity, returned locator and raw response body are intentionally not copied into repository evidence.

The real product-owned identity resolved while an otherwise identical request with a deliberately changed identity was rejected. This establishes that the observed resolution surface is materially bound to `file_id`, not merely to the conversation or filename.

## Result

PR13.2 closes its resolution-surface question positively. The proven chain is now:

```text
saved conversation
  -> explicit product-owned file_id
  -> same file_id across independent immediate reads
  -> identity-bound product resolver
  -> locator-bearing resolution response
```

## Privacy / authority boundary

The report never exports the real ID, control ID, signed locator, raw response body, token, cookie, credential or authorization value. It never follows the locator, downloads bytes, writes an artifact, performs product writes, retries, or changes write/finality authority.

Even after the positive live result, PR13.2 deliberately keeps:

```text
stable_product_identity_proven = false
artifact_bytes_proven = false
download_authority_granted = false
download_attempted = false
```

and does not yet change `ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY`.

## Scope

Only new characterization tool/tests/docs. No runtime promotion, no canonical-read changes, no #79/#80 work, no generated-artifact download implementation.

## Validation

Exact evidence head: `9327980997a7f5af996519ba1854427e8a4e6e7e`

CI #894 (`34473384083`): **SUCCESS**.

- Engineering Quality: PASS;
- source tests: Ubuntu + Windows, Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14 — PASS;
- Build release artifacts — PASS;
- installed-wheel smoke: Ubuntu 3.10/3.14 and Windows 3.10/3.14 — PASS.

The earlier pre-live CI #892 also passed after rerunning one pre-existing Windows 3.10 sentinel floating-point boundary flake without any code change. The final evidence-head CI #894 passed cleanly.

## Follow-up boundary

A future PR13.3 may investigate the remaining link `resolver locator -> artifact bytes -> integrity`. PR13.2 itself performs no locator follow and grants no download/materialization authority.