### PR TITLE
Experiment PR13.3 — Identity-Bound Artifact Bytes & Integrity Probe

### DIFF
--- a/docs/engineering/pr13_3_artifact_bytes_integrity_probe.md
+++ b/docs/engineering/pr13_3_artifact_bytes_integrity_probe.md
@@ -1,0 +1,158 @@
+# PR13.3 — Identity-Bound Artifact Bytes & Integrity Probe
+
+## Question
+
+PR13.1 established an explicit product-owned `file_id` for one generated artifact and short-term stability across two independent reads. PR13.2 established that the real `file_id` resolves through a product-owned resolver while a deliberately changed identity is rejected.
+
+PR13.3 asks one narrower remaining question:
+
+> If we follow the locator returned for that exact product-owned identity, do we receive the exact artifact bytes we expect?
+
+This is still a characterization experiment. It does not add production download/materialization support.
+
+## Gate
+
+The live gate performs at most three read-only requests:
+
+1. `GET /backend-api/conversations/{conversation_id}/files` to discover the exact `file_id` for one caller-named generated artifact.
+2. `GET /backend-api/files/download/{file_id}?conversation_id={conversation_id}&inline=false` to obtain the product resolver payload.
+3. One GET against the returned locator, into memory only.
+
+The third request is the first step in PR13.x that intentionally follows the returned locator.
+
+## Integrity oracle
+
+The caller supplies two independent expectations for the known fixture:
+
+- exact byte size;
+- exact SHA-256 digest.
+
+A positive result therefore requires both:
+
+```text
+observed_size_bytes == expected_size_bytes
+observed_sha256 == expected_sha256
+```
+
+The filename is used only to select one record from the conversation-scoped files collection. It is not used as identity and is not used to validate bytes.
+
+For the PR13.1 text fixture created in the live ChatGPT conversation:
+
+```text
+filename = cwa_pr13_1_identity_probe.txt
+size = 45
+sha256 = d0bb354d72fad3715f5348740d75dd644435165f68034f54f7974c834cbe9f1d
+```
+
+## Locator policy
+
+PR13.3 does not treat an arbitrary URL from a product response as safe to fetch.
+
+Allowed locator classes are:
+
+- `https://chatgpt.com/...`
+- `https://*.oaiusercontent.com/...`
+- `https://oaiusercontent.com/...`
+
+Additional restrictions:
+
+- HTTPS only;
+- no URL userinfo;
+- no fragment;
+- no non-default port;
+- no unrecognized origin;
+- redirects are not followed.
+
+Credential handling is origin-sensitive:
+
+- same-origin `chatgpt.com` locator: use the authenticated CWA headers because current estuary content can require ChatGPT auth;
+- `oaiusercontent.com`: send no ChatGPT Authorization or Cookie headers.
+
+This prevents an observed locator from becoming a credential-forwarding primitive.
+
+## Positive characterization
+
+PR13.3 reports:
+
+```text
+IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED
+```
+
+only when:
+
+- the target record has explicit product identity;
+- the identity resolver returns an allowed locator;
+- one locator GET returns HTTP 2xx;
+- returned bytes exactly match both expected size and expected SHA-256.
+
+A positive result may set:
+
+```text
+artifact_bytes_proven = true
+artifact_integrity_proven = true
+identity_bound_byte_retrieval_proven = true
+```
+
+but deliberately keeps:
+
+```text
+stable_product_identity_proven = false
+download_authority_granted = false
+artifact_disk_write_attempted = false
+materialization_attempted = false
+write_attempted = false
+```
+
+The distinction matters: proving that bytes can be fetched and match a known fixture does not yet define a safe public API, destination policy, overwrite semantics, retry authority, or longitudinal identity guarantee.
+
+## Privacy boundary
+
+The final report never exports:
+
+- the real `file_id`;
+- the raw locator or signed query parameters;
+- Authorization/Cookie values;
+- raw artifact bytes;
+- raw resolver response bodies.
+
+It may report the observed SHA-256 digest and byte count because those are integrity evidence, not locator or credential material.
+
+The underlying generic CWA HTTP helper may use temporary transport/header files internally, but PR13.3 never writes the artifact body to a user-visible or persistent destination.
+
+## Fail-closed outcomes
+
+Separate characterizations are retained for:
+
+- exact-head or tracked-clean failure;
+- missing explicit target identity;
+- resolver failure;
+- missing resolver locator;
+- rejected locator origin;
+- locator redirect;
+- locator HTTP failure;
+- byte-size or SHA-256 mismatch.
+
+There is no endpoint fallback and no locator-origin fallback.
+
+## Relationship to the frozen PR10.1 status
+
+Even a positive PR13.3 result does not directly modify:
+
+```text
+ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY
+```
+
+PR13.3 would remove the separate uncertainty around identity-bound byte retrieval and integrity. A later promotion step can then decide whether the accumulated PR13.1–PR13.3 evidence is sufficient to revise the product capability contract, or whether one longitudinal identity gate is still required first.
+
+## Running the live gate
+
+From an exact clean checkout:
+
+```powershell
+python tools/pr13_3_artifact_bytes_integrity_probe.py `
+  --conversation "https://chatgpt.com/c/<conversation-id>" `
+  --expected-filename cwa_pr13_1_identity_probe.txt `
+  --expected-size 45 `
+  --expected-sha256 d0bb354d72fad3715f5348740d75dd644435165f68034f54f7974c834cbe9f1d `
+  --expected-head <exact-head-sha>
+```

--- a/docs/engineering/pr13_3_artifact_bytes_integrity_probe.md
+++ b/docs/engineering/pr13_3_artifact_bytes_integrity_probe.md
@@ -105,6 +105,59 @@ write_attempted = false
 
 The distinction matters: proving that bytes can be fetched and match a known fixture does not yet define a safe public API, destination policy, overwrite semantics, retry authority, or longitudinal identity guarantee.
 
+## Authenticated live result — 2026-09-10
+
+A clean exact-head run against the same saved conversation and generated text fixture used by PR13.1 and PR13.2 returned:
+
+```text
+head_matches = true
+tracked_clean = true
+identity_discovery_characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
+identity_key = file_id
+target_record_present = true
+resolution_status_code = 200
+resolution_locator_field_present = true
+resolution_locator_key = download_url
+locator_origin_class = CHATGPT_SAME_ORIGIN
+locator_fetch_status_code = 200
+observed_size_bytes = 45
+expected_size_bytes = 45
+size_matches = true
+observed_sha256 = d0bb354d72fad3715f5348740d75dd644435165f68034f54f7974c834cbe9f1d
+expected_sha256 = d0bb354d72fad3715f5348740d75dd644435165f68034f54f7974c834cbe9f1d
+sha256_matches = true
+artifact_bytes_proven = true
+artifact_integrity_proven = true
+identity_bound_byte_retrieval_proven = true
+characterization = IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED
+```
+
+Request accounting remained bounded and explicit:
+
+```text
+request_count = 3
+identity_discovery_request_count = 1
+resolution_request_count = 1
+locator_fetch_request_count = 1
+```
+
+The raw `file_id`, resolver locator, signed locator query, resolver response body and artifact bytes were not copied into repository evidence. The probe performed no artifact disk write, no materialization, no product write, and granted no download authority.
+
+This live result closes PR13.3's byte-retrieval question positively: the exact product-owned identity discovered from the conversation resolved to a same-origin product locator whose returned bytes exactly matched the independently known fixture by both size and SHA-256.
+
+The proven chain is now:
+
+```text
+saved conversation
+  -> explicit product-owned file_id
+  -> same file_id across independent immediate reads
+  -> identity-bound product resolver
+  -> locator-bearing resolution response
+  -> locator byte fetch
+  -> exact byte-count match
+  -> exact SHA-256 match
+```
+
 ## Privacy boundary
 
 The final report never exports:
@@ -136,13 +189,13 @@ There is no endpoint fallback and no locator-origin fallback.
 
 ## Relationship to the frozen PR10.1 status
 
-Even a positive PR13.3 result does not directly modify:
+The positive PR13.3 result removes the uncertainty around identity-bound byte retrieval and artifact integrity, but does not directly modify:
 
 ```text
 ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY
 ```
 
-PR13.3 would remove the separate uncertainty around identity-bound byte retrieval and integrity. A later promotion step can then decide whether the accumulated PR13.1–PR13.3 evidence is sufficient to revise the product capability contract, or whether one longitudinal identity gate is still required first.
+The remaining question is no longer whether generated artifact bytes are reachable or whether the resolver is identity-bound. It is whether the product-owned identity has enough longitudinal/session stability, and whether CWA has a sufficiently governed destination/overwrite/retry contract, to promote this evidence into a public production handoff.
 
 ## Running the live gate
 

--- a/tests/test_artifact_bytes_integrity_probe_pr13_3.py
+++ b/tests/test_artifact_bytes_integrity_probe_pr13_3.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import tools.pr13_3_artifact_bytes_integrity_probe as probe_mod
+from tools.pr13_3_artifact_bytes_integrity_probe import (
+    _extract_resolution_locator,
+    _locator_policy,
+    characterize_integrity,
+    probe_locator_bytes,
+    run_integrity_gate,
+)
+
+PAYLOAD = b"CWA_PR13_1_CONVERSATION_FILES_IDENTITY_PROBE\n"
+PAYLOAD_SHA256 = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+class _Client:
+    def __init__(
+        self,
+        *,
+        json_responses: list[tuple[int, Any]] | None = None,
+        raw_response: tuple[int, bytes, str] = (200, PAYLOAD, ""),
+    ) -> None:
+        self.json_responses = list(json_responses or [])
+        self.raw_response = raw_response
+        self.base_headers = {
+            "user-agent": "cwa-test",
+            "authorization": "Bearer base-secret",
+            "cookie": "session=base-secret",
+        }
+        self.json_calls: list[tuple[str, str, Any, dict[str, str]]] = []
+        self.raw_calls: list[dict[str, Any]] = []
+
+    def _build_headers(self, additions: dict[str, str]) -> dict[str, str]:
+        headers = dict(self.base_headers)
+        headers.update(additions)
+        return headers
+
+    def _json_request(self, method, url, payload, headers):
+        self.json_calls.append((method, url, payload, headers))
+        return self.json_responses.pop(0)
+
+    def _run_curl(
+        self,
+        method,
+        url,
+        headers,
+        body=None,
+        *,
+        persist_cookies=True,
+        follow_redirects=False,
+    ):
+        self.raw_calls.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers),
+                "body": body,
+                "persist_cookies": persist_cookies,
+                "follow_redirects": follow_redirects,
+            }
+        )
+        return self.raw_response
+
+
+def _patch_clean_head(monkeypatch, head: str = "head-1") -> None:
+    monkeypatch.setattr(
+        probe_mod,
+        "_git_output",
+        lambda *args: head if args == ("rev-parse", "HEAD") else "",
+    )
+
+
+def test_locator_policy_allows_only_known_https_origins() -> None:
+    assert _locator_policy("https://chatgpt.com/backend-api/estuary/content?id=x") == {
+        "locator_allowed": True,
+        "locator_origin_class": "CHATGPT_SAME_ORIGIN",
+        "attach_chatgpt_auth": True,
+    }
+    assert _locator_policy("https://files.oaiusercontent.com/signed") == {
+        "locator_allowed": True,
+        "locator_origin_class": "OAIUSERCONTENT",
+        "attach_chatgpt_auth": False,
+    }
+    assert _locator_policy("http://chatgpt.com/file")["locator_allowed"] is False
+    assert _locator_policy("https://example.com/file")["locator_allowed"] is False
+    assert _locator_policy("https://user:pass@chatgpt.com/file")[
+        "locator_allowed"
+    ] is False
+    assert _locator_policy("https://chatgpt.com:444/file")["locator_allowed"] is False
+
+
+def test_extract_resolution_locator_keeps_value_internal() -> None:
+    key, locator = _extract_resolution_locator(
+        {"download_url": "https://chatgpt.com/backend-api/estuary/content?sig=secret"}
+    )
+
+    assert key == "download_url"
+    assert locator is not None
+    assert "secret" in locator
+
+
+def test_same_origin_locator_uses_auth_but_exports_no_bytes_or_locator() -> None:
+    client = _Client()
+
+    report = probe_locator_bytes(
+        client,
+        conversation_id="conversation-1",
+        locator="https://chatgpt.com/backend-api/estuary/content?id=x&sig=secret",
+    )
+
+    assert report["characterization"] == "LOCATOR_BYTES_OBSERVED"
+    assert report["request_count"] == 1
+    assert report["bytes_observed"] is True
+    assert report["byte_count"] == len(PAYLOAD)
+    assert report["sha256"] == PAYLOAD_SHA256
+    assert report["bytes_exported"] is False
+    assert report["locator_value_exported"] is False
+    assert report["artifact_disk_write_attempted"] is False
+
+    call = client.raw_calls[0]
+    assert call["headers"]["authorization"] == "Bearer base-secret"
+    assert call["headers"]["cookie"] == "session=base-secret"
+    assert call["persist_cookies"] is False
+    assert call["follow_redirects"] is False
+    assert "secret" not in str(report)
+    assert PAYLOAD.decode().strip() not in str(report)
+
+
+def test_oaiusercontent_locator_never_receives_chatgpt_credentials() -> None:
+    client = _Client()
+
+    report = probe_locator_bytes(
+        client,
+        conversation_id="conversation-1",
+        locator="https://files.oaiusercontent.com/signed?sig=secret",
+    )
+
+    assert report["characterization"] == "LOCATOR_BYTES_OBSERVED"
+    call = client.raw_calls[0]
+    assert "authorization" not in call["headers"]
+    assert "cookie" not in call["headers"]
+    assert call["headers"]["user-agent"] == "cwa-test"
+    assert "secret" not in str(report)
+
+
+def test_redirect_is_not_followed() -> None:
+    client = _Client(raw_response=(302, b"", "location: https://example.invalid"))
+
+    report = probe_locator_bytes(
+        client,
+        conversation_id="conversation-1",
+        locator="https://chatgpt.com/backend-api/estuary/content?id=x",
+    )
+
+    assert report["characterization"] == "LOCATOR_REDIRECT_NOT_FOLLOWED"
+    assert report["bytes_observed"] is False
+    assert client.raw_calls[0]["follow_redirects"] is False
+
+
+def test_integrity_requires_exact_size_and_sha256() -> None:
+    byte_report = {
+        "bytes_observed": True,
+        "byte_count": len(PAYLOAD),
+        "sha256": PAYLOAD_SHA256,
+        "request_count": 1,
+        "status_code": 200,
+        "locator_origin_class": "CHATGPT_SAME_ORIGIN",
+    }
+
+    report = characterize_integrity(
+        byte_report,
+        expected_size=len(PAYLOAD),
+        expected_sha256=PAYLOAD_SHA256,
+    )
+
+    assert (
+        report["characterization"]
+        == "IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED"
+    )
+    assert report["size_matches"] is True
+    assert report["sha256_matches"] is True
+    assert report["artifact_bytes_proven"] is True
+    assert report["artifact_integrity_proven"] is True
+    assert report["identity_bound_byte_retrieval_proven"] is True
+    assert report["stable_product_identity_proven"] is False
+    assert report["download_authority_granted"] is False
+
+
+def test_integrity_mismatch_fails_closed() -> None:
+    byte_report = {
+        "bytes_observed": True,
+        "byte_count": len(PAYLOAD),
+        "sha256": PAYLOAD_SHA256,
+        "request_count": 1,
+        "status_code": 200,
+        "locator_origin_class": "CHATGPT_SAME_ORIGIN",
+    }
+
+    report = characterize_integrity(
+        byte_report,
+        expected_size=len(PAYLOAD),
+        expected_sha256="0" * 64,
+    )
+
+    assert report["characterization"] == "ARTIFACT_BYTES_OR_INTEGRITY_NOT_PROVEN"
+    assert report["artifact_bytes_proven"] is False
+    assert report["artifact_integrity_proven"] is False
+    assert report["identity_bound_byte_retrieval_proven"] is False
+
+
+def test_gate_proves_identity_bound_bytes_without_disk_write(monkeypatch) -> None:
+    _patch_clean_head(monkeypatch)
+    locator = "https://chatgpt.com/backend-api/estuary/content?id=x&sig=secret"
+    client = _Client(
+        json_responses=[
+            (
+                200,
+                {
+                    "items": [
+                        {
+                            "file_id": "file_abc123",
+                            "file_name": "result.txt",
+                            "mime_type": "text/plain",
+                        }
+                    ]
+                },
+            ),
+            (
+                200,
+                {
+                    "download_url": locator,
+                    "file_name": "result.txt",
+                    "file_size_bytes": len(PAYLOAD),
+                },
+            ),
+        ]
+    )
+
+    report = run_integrity_gate(
+        conversation_id="conversation-1",
+        expected_filename="result.txt",
+        expected_size=len(PAYLOAD),
+        expected_sha256=PAYLOAD_SHA256,
+        expected_head="head-1",
+        timeout=1.0,
+        client_factory=lambda _timeout: client,
+    )
+
+    assert (
+        report["characterization"]
+        == "IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED"
+    )
+    assert report["request_count"] == 3
+    assert report["identity_discovery_request_count"] == 1
+    assert report["resolution_request_count"] == 1
+    assert report["locator_fetch_request_count"] == 1
+    assert report["identity_key"] == "file_id"
+    assert report["resolution_locator_field_present"] is True
+    assert report["artifact_bytes_proven"] is True
+    assert report["artifact_integrity_proven"] is True
+    assert report["download_attempted"] is True
+    assert report["artifact_disk_write_attempted"] is False
+    assert report["materialization_attempted"] is False
+    assert report["download_authority_granted"] is False
+    assert report["identity_values_exported"] is False
+    assert report["locator_values_exported"] is False
+    assert report["artifact_bytes_exported"] is False
+    assert "file_abc123" not in str(report)
+    assert "secret" not in str(report)
+    assert PAYLOAD.decode().strip() not in str(report)
+
+    assert len(client.json_calls) == 2
+    assert len(client.raw_calls) == 1
+    assert "file_abc123" in client.json_calls[1][1]
+
+
+def test_gate_rejects_unrecognized_locator_before_byte_fetch(monkeypatch) -> None:
+    _patch_clean_head(monkeypatch)
+    client = _Client(
+        json_responses=[
+            (
+                200,
+                {"items": [{"file_id": "file_abc123", "file_name": "result.txt"}]},
+            ),
+            (
+                200,
+                {"download_url": "https://example.com/signed?sig=secret"},
+            ),
+        ]
+    )
+
+    report = run_integrity_gate(
+        conversation_id="conversation-1",
+        expected_filename="result.txt",
+        expected_size=len(PAYLOAD),
+        expected_sha256=PAYLOAD_SHA256,
+        expected_head="head-1",
+        timeout=1.0,
+        client_factory=lambda _timeout: client,
+    )
+
+    assert report["characterization"] == "LOCATOR_ORIGIN_REJECTED"
+    assert report["request_count"] == 2
+    assert report["locator_fetch_request_count"] == 0
+    assert report["artifact_bytes_proven"] is False
+    assert client.raw_calls == []
+    assert "example.com" not in str(report)
+    assert "secret" not in str(report)
+
+
+def test_gate_stops_when_resolver_has_no_locator(monkeypatch) -> None:
+    _patch_clean_head(monkeypatch)
+    client = _Client(
+        json_responses=[
+            (
+                200,
+                {"items": [{"file_id": "file_abc123", "file_name": "result.txt"}]},
+            ),
+            (200, {"status": "success"}),
+        ]
+    )
+
+    report = run_integrity_gate(
+        conversation_id="conversation-1",
+        expected_filename="result.txt",
+        expected_size=len(PAYLOAD),
+        expected_sha256=PAYLOAD_SHA256,
+        expected_head="head-1",
+        timeout=1.0,
+        client_factory=lambda _timeout: client,
+    )
+
+    assert report["characterization"] == "RESOLUTION_LOCATOR_NOT_PROVEN"
+    assert report["request_count"] == 2
+    assert report["locator_fetch_request_count"] == 0
+    assert client.raw_calls == []

--- a/tests/test_artifact_bytes_integrity_probe_pr13_3.py
+++ b/tests/test_artifact_bytes_integrity_probe_pr13_3.py
@@ -86,9 +86,10 @@ def test_locator_policy_allows_only_known_https_origins() -> None:
     }
     assert _locator_policy("http://chatgpt.com/file")["locator_allowed"] is False
     assert _locator_policy("https://example.com/file")["locator_allowed"] is False
-    assert _locator_policy("https://user:pass@chatgpt.com/file")[
-        "locator_allowed"
-    ] is False
+    assert (
+        _locator_policy("https://user:pass@chatgpt.com/file")["locator_allowed"]
+        is False
+    )
     assert _locator_policy("https://chatgpt.com:444/file")["locator_allowed"] is False
 
 
@@ -177,8 +178,7 @@ def test_integrity_requires_exact_size_and_sha256() -> None:
     )
 
     assert (
-        report["characterization"]
-        == "IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED"
+        report["characterization"] == "IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED"
     )
     assert report["size_matches"] is True
     assert report["sha256_matches"] is True
@@ -250,8 +250,7 @@ def test_gate_proves_identity_bound_bytes_without_disk_write(monkeypatch) -> Non
     )
 
     assert (
-        report["characterization"]
-        == "IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED"
+        report["characterization"] == "IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED"
     )
     assert report["request_count"] == 3
     assert report["identity_discovery_request_count"] == 1

--- a/tests/test_sentinel_transaction.py
+++ b/tests/test_sentinel_transaction.py
@@ -360,7 +360,9 @@ def test_absolute_finalize_expiry_clamps_relative_ttl() -> None:
 
     bundle = acquire_finalized_sentinel_bundle(client)
 
-    assert 20 <= bundle.expires_monotonic - bundle.acquired_monotonic <= 25
+    ttl = bundle.expires_monotonic - bundle.acquired_monotonic
+    assert 20 <= ttl
+    assert ttl <= 25 or ttl == pytest.approx(25, abs=1e-9)
 
 
 def test_finalize_failure_does_not_cache_or_restore_provider_evidence() -> None:

--- a/tools/pr13_3_artifact_bytes_integrity_probe.py
+++ b/tools/pr13_3_artifact_bytes_integrity_probe.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from typing import Any, Callable
+from urllib.parse import urlparse
+
+from pr13_1_conversation_files_identity_probe import (
+    CHATGPT_ORIGIN,
+    _conversation_id,
+    _safe_filename,
+    probe_conversation_files,
+)
+from pr13_1_conversation_files_live_gate import conversation_id_from_selector
+from pr13_1_conversation_files_stability_gate import _target_record
+from pr13_2_identity_bound_artifact_resolution_probe import _resolution_endpoint
+
+from chatgpt_web_adapter import ChatGPTWebClient
+
+INTEGRITY_SCHEMA = "CWA_PR13_3_ARTIFACT_BYTES_INTEGRITY_PROBE_V1"
+_LOCATOR_KEYS = ("download_url", "url", "href")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_MAX_EXPECTED_BYTES = 1024 * 1024
+
+
+def _git_output(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _normalized_sha256(value: str) -> str:
+    normalized = value.strip().lower()
+    if not _SHA256_RE.fullmatch(normalized):
+        raise ValueError("EXPECTED_SHA256_REQUIRED")
+    return normalized
+
+
+def _safe_expected_size(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("EXPECTED_SIZE_REQUIRED")
+    if value < 0 or value > _MAX_EXPECTED_BYTES:
+        raise ValueError("EXPECTED_SIZE_OUT_OF_RANGE")
+    return value
+
+
+def _extract_resolution_locator(payload: Any) -> tuple[str | None, str | None]:
+    if not isinstance(payload, dict):
+        return None, None
+    for key in _LOCATOR_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return key, value.strip()
+    return None, None
+
+
+def _locator_policy(locator: str) -> dict[str, Any]:
+    parsed = urlparse(locator)
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        port = -1
+
+    basic_safe = (
+        scheme == "https"
+        and bool(hostname)
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.fragment
+        and port in {None, 443}
+    )
+    if not basic_safe:
+        return {
+            "locator_allowed": False,
+            "locator_origin_class": "REJECTED",
+            "attach_chatgpt_auth": False,
+        }
+    if hostname == "chatgpt.com":
+        return {
+            "locator_allowed": True,
+            "locator_origin_class": "CHATGPT_SAME_ORIGIN",
+            "attach_chatgpt_auth": True,
+        }
+    if hostname == "oaiusercontent.com" or hostname.endswith(".oaiusercontent.com"):
+        return {
+            "locator_allowed": True,
+            "locator_origin_class": "OAIUSERCONTENT",
+            "attach_chatgpt_auth": False,
+        }
+    return {
+        "locator_allowed": False,
+        "locator_origin_class": "UNRECOGNIZED_HTTPS_ORIGIN",
+        "attach_chatgpt_auth": False,
+    }
+
+
+def _resolver_payload(
+    client: Any,
+    *,
+    conversation_id: str,
+    file_id: str,
+) -> tuple[int, Any]:
+    endpoint = _resolution_endpoint(conversation_id, file_id)
+    headers = client._build_headers(
+        {
+            "accept": "application/json",
+            "referer": f"{CHATGPT_ORIGIN}/c/{conversation_id}",
+        }
+    )
+    return client._json_request("GET", endpoint, None, headers)
+
+
+def probe_locator_bytes(
+    client: Any,
+    *,
+    conversation_id: str,
+    locator: str,
+) -> dict[str, Any]:
+    """Fetch one approved locator into memory without exporting or persisting bytes."""
+
+    policy = _locator_policy(locator)
+    report: dict[str, Any] = {
+        **policy,
+        "method": "GET",
+        "request_count": 0,
+        "status_code": None,
+        "byte_count": None,
+        "sha256": None,
+        "bytes_observed": False,
+        "bytes_exported": False,
+        "response_body_exported": False,
+        "locator_value_exported": False,
+        "artifact_disk_write_attempted": False,
+        "materialization_attempted": False,
+        "write_attempted": False,
+    }
+    if not policy["locator_allowed"]:
+        report["characterization"] = "LOCATOR_ORIGIN_REJECTED"
+        return report
+
+    if policy["attach_chatgpt_auth"]:
+        headers = client._build_headers(
+            {
+                "accept": "*/*",
+                "referer": f"{CHATGPT_ORIGIN}/c/{conversation_id}",
+            }
+        )
+    else:
+        headers = {
+            "accept": "*/*",
+            "user-agent": client.base_headers.get("user-agent", ""),
+        }
+
+    status, raw_body, _header_text = client._run_curl(
+        "GET",
+        locator,
+        headers,
+        persist_cookies=False,
+        follow_redirects=False,
+    )
+    report["request_count"] = 1
+    report["status_code"] = status
+
+    if 300 <= status < 400:
+        report["characterization"] = "LOCATOR_REDIRECT_NOT_FOLLOWED"
+        return report
+    if not 200 <= status < 300:
+        report["characterization"] = "LOCATOR_BYTE_FETCH_HTTP_ERROR"
+        return report
+
+    report.update(
+        {
+            "byte_count": len(raw_body),
+            "sha256": hashlib.sha256(raw_body).hexdigest(),
+            "bytes_observed": True,
+            "characterization": "LOCATOR_BYTES_OBSERVED",
+        }
+    )
+    return report
+
+
+def characterize_integrity(
+    byte_report: dict[str, Any],
+    *,
+    expected_size: int,
+    expected_sha256: str,
+) -> dict[str, Any]:
+    observed_size = byte_report.get("byte_count")
+    observed_sha256 = byte_report.get("sha256")
+    size_matches = observed_size == expected_size
+    sha256_matches = observed_sha256 == expected_sha256
+    proven = (
+        byte_report.get("bytes_observed") is True
+        and size_matches
+        and sha256_matches
+    )
+    return {
+        "locator_origin_class": byte_report.get("locator_origin_class"),
+        "locator_fetch_status_code": byte_report.get("status_code"),
+        "observed_size_bytes": observed_size,
+        "observed_sha256": observed_sha256,
+        "expected_size_bytes": expected_size,
+        "expected_sha256": expected_sha256,
+        "size_matches": size_matches,
+        "sha256_matches": sha256_matches,
+        "artifact_bytes_proven": proven,
+        "artifact_integrity_proven": proven,
+        "identity_bound_byte_retrieval_proven": proven,
+        "stable_product_identity_proven": False,
+        "download_authority_granted": False,
+        "download_attempted": byte_report.get("request_count") == 1,
+        "artifact_disk_write_attempted": False,
+        "materialization_attempted": False,
+        "write_attempted": False,
+        "identity_values_exported": False,
+        "locator_values_exported": False,
+        "artifact_bytes_exported": False,
+        "response_body_exported": False,
+        "characterization": (
+            "IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED"
+            if proven
+            else "ARTIFACT_BYTES_OR_INTEGRITY_NOT_PROVEN"
+        ),
+    }
+
+
+def _new_client(timeout: float) -> ChatGPTWebClient:
+    return ChatGPTWebClient(
+        auto_login=False,
+        auto_sentinel=False,
+        timeout=timeout,
+    )
+
+
+def run_integrity_gate(
+    *,
+    conversation_id: str,
+    expected_filename: str,
+    expected_size: int,
+    expected_sha256: str,
+    expected_head: str,
+    timeout: float,
+    client_factory: Callable[[float], Any] = _new_client,
+) -> dict[str, Any]:
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    conversation_id = _conversation_id(conversation_id)
+    filename = _safe_filename(expected_filename)
+    if filename is None:
+        raise ValueError("EXPECTED_FILENAME_REQUIRED")
+    expected_size = _safe_expected_size(expected_size)
+    expected_sha256 = _normalized_sha256(expected_sha256)
+
+    head = _git_output("rev-parse", "HEAD")
+    tracked_clean = _git_output("status", "--porcelain", "--untracked-files=no") == ""
+    report: dict[str, Any] = {
+        "schema": INTEGRITY_SCHEMA,
+        "head": head,
+        "expected_head": expected_head,
+        "head_matches": head == expected_head,
+        "tracked_clean": tracked_clean,
+        "expected_filename": filename,
+        "expected_size_bytes": expected_size,
+        "expected_sha256": expected_sha256,
+        "request_count": 0,
+        "identity_discovery_request_count": 0,
+        "resolution_request_count": 0,
+        "locator_fetch_request_count": 0,
+        "identity_values_exported": False,
+        "locator_values_exported": False,
+        "artifact_bytes_exported": False,
+        "response_body_exported": False,
+        "artifact_bytes_proven": False,
+        "artifact_integrity_proven": False,
+        "identity_bound_byte_retrieval_proven": False,
+        "stable_product_identity_proven": False,
+        "download_authority_granted": False,
+        "download_attempted": False,
+        "artifact_disk_write_attempted": False,
+        "materialization_attempted": False,
+        "write_attempted": False,
+    }
+    if head != expected_head or not tracked_clean:
+        report["characterization"] = "EXACT_HEAD_OR_TRACKED_CLEAN_GATE_FAILED"
+        return report
+
+    client = client_factory(timeout)
+    try:
+        discovery = probe_conversation_files(client, conversation_id)
+    except Exception as exc:
+        report.update(
+            {
+                "request_count": 1,
+                "identity_discovery_request_count": 1,
+                "characterization": "IDENTITY_DISCOVERY_REQUEST_FAILED",
+                "error_type": type(exc).__name__,
+            }
+        )
+        return report
+
+    report["request_count"] = 1
+    report["identity_discovery_request_count"] = 1
+    report["identity_discovery_characterization"] = discovery.get("characterization")
+    target = _target_record(discovery, filename)
+    if target is None:
+        report["characterization"] = "TARGET_EXPLICIT_IDENTITY_NOT_PROVEN"
+        return report
+
+    file_id = target["explicit_identity"]
+    report["identity_key"] = target["explicit_identity_key"]
+    report["target_record_present"] = True
+
+    try:
+        resolution_status, resolution_payload = _resolver_payload(
+            client,
+            conversation_id=conversation_id,
+            file_id=file_id,
+        )
+    except Exception as exc:
+        report.update(
+            {
+                "request_count": 2,
+                "resolution_request_count": 1,
+                "characterization": "RESOLUTION_REQUEST_FAILED",
+                "error_type": type(exc).__name__,
+            }
+        )
+        return report
+
+    report["request_count"] = 2
+    report["resolution_request_count"] = 1
+    report["resolution_status_code"] = resolution_status
+    if not 200 <= resolution_status < 300:
+        report["characterization"] = "RESOLUTION_LOCATOR_NOT_PROVEN"
+        return report
+
+    locator_key, locator = _extract_resolution_locator(resolution_payload)
+    report["resolution_locator_field_present"] = locator is not None
+    report["resolution_locator_key"] = locator_key
+    if locator is None:
+        report["characterization"] = "RESOLUTION_LOCATOR_NOT_PROVEN"
+        return report
+
+    try:
+        byte_report = probe_locator_bytes(
+            client,
+            conversation_id=conversation_id,
+            locator=locator,
+        )
+    except Exception as exc:
+        report.update(
+            {
+                "request_count": 3,
+                "locator_fetch_request_count": 1,
+                "download_attempted": True,
+                "characterization": "LOCATOR_BYTE_FETCH_REQUEST_FAILED",
+                "error_type": type(exc).__name__,
+            }
+        )
+        return report
+
+    report["locator_origin_class"] = byte_report.get("locator_origin_class")
+    if byte_report.get("request_count") != 1:
+        report["characterization"] = byte_report.get(
+            "characterization",
+            "LOCATOR_BYTE_FETCH_NOT_PROVEN",
+        )
+        return report
+
+    integrity = characterize_integrity(
+        byte_report,
+        expected_size=expected_size,
+        expected_sha256=expected_sha256,
+    )
+    report.update(integrity)
+    report["request_count"] = 3
+    report["locator_fetch_request_count"] = 1
+    report["resolution_locator_field_present"] = True
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Resolve one product-owned conversation file_id, fetch its approved "
+            "locator once into memory, and verify exact byte size plus SHA-256."
+        )
+    )
+    parser.add_argument(
+        "--conversation",
+        required=True,
+        help="Raw conversation id or https://chatgpt.com/.../c/<conversation-id> URL.",
+    )
+    parser.add_argument("--expected-filename", required=True)
+    parser.add_argument("--expected-size", required=True, type=int)
+    parser.add_argument("--expected-sha256", required=True)
+    parser.add_argument("--expected-head", required=True)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    args = parser.parse_args()
+
+    try:
+        conversation_id = conversation_id_from_selector(args.conversation)
+        report = run_integrity_gate(
+            conversation_id=conversation_id,
+            expected_filename=args.expected_filename,
+            expected_size=args.expected_size,
+            expected_sha256=args.expected_sha256,
+            expected_head=args.expected_head,
+            timeout=args.timeout,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    print(json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False))
+    completed = {
+        "IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED",
+        "ARTIFACT_BYTES_OR_INTEGRITY_NOT_PROVEN",
+        "RESOLUTION_LOCATOR_NOT_PROVEN",
+        "TARGET_EXPLICIT_IDENTITY_NOT_PROVEN",
+        "LOCATOR_ORIGIN_REJECTED",
+        "LOCATOR_REDIRECT_NOT_FOLLOWED",
+        "LOCATOR_BYTE_FETCH_HTTP_ERROR",
+    }
+    return 0 if report.get("characterization") in completed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/pr13_3_artifact_bytes_integrity_probe.py
+++ b/tools/pr13_3_artifact_bytes_integrity_probe.py
@@ -199,9 +199,7 @@ def characterize_integrity(
     size_matches = observed_size == expected_size
     sha256_matches = observed_sha256 == expected_sha256
     proven = (
-        byte_report.get("bytes_observed") is True
-        and size_matches
-        and sha256_matches
+        byte_report.get("bytes_observed") is True and size_matches and sha256_matches
     )
     return {
         "locator_origin_class": byte_report.get("locator_origin_class"),


### PR DESCRIPTION
## Question

Given PR13.1 explicit product identity and PR13.2 identity-bound resolution, does following the resolver locator for that exact `file_id` return the exact expected artifact bytes?

## Gate

At most three read-only requests:

1. discover the exact product-owned `file_id` through `/backend-api/conversations/{conversation_id}/files`;
2. resolve that ID through `/backend-api/files/download/{file_id}?conversation_id={conversation_id}&inline=false`;
3. fetch the returned locator exactly once into memory and verify both byte size and SHA-256.

For the known PR13.1 fixture:

```text
filename = cwa_pr13_1_identity_probe.txt
size = 45
sha256 = d0bb354d72fad3715f5348740d75dd644435165f68034f54f7974c834cbe9f1d
```

## Locator safety

Only HTTPS `chatgpt.com` and `oaiusercontent.com` origins are eligible. Same-origin ChatGPT locators may receive authenticated CWA headers; `oaiusercontent.com` locators never receive ChatGPT Authorization/Cookie values. Unknown origins, userinfo, non-default ports, fragments and redirects fail closed.

## Authenticated live result — 2026-09-10

A clean exact-head run against the same saved conversation and generated text artifact used by PR13.1 and PR13.2 returned:

```text
head_matches = true
tracked_clean = true
identity_discovery_characterization = EXPLICIT_PRODUCT_IDENTITY_CANDIDATES_OBSERVED
identity_key = file_id
target_record_present = true
resolution_status_code = 200
resolution_locator_field_present = true
resolution_locator_key = download_url
locator_origin_class = CHATGPT_SAME_ORIGIN
locator_fetch_status_code = 200
observed_size_bytes = 45
expected_size_bytes = 45
size_matches = true
observed_sha256 = d0bb354d72fad3715f5348740d75dd644435165f68034f54f7974c834cbe9f1d
expected_sha256 = d0bb354d72fad3715f5348740d75dd644435165f68034f54f7974c834cbe9f1d
sha256_matches = true
artifact_bytes_proven = true
artifact_integrity_proven = true
identity_bound_byte_retrieval_proven = true
characterization = IDENTITY_BOUND_ARTIFACT_BYTES_INTEGRITY_OBSERVED
```

Request accounting stayed bounded at exactly three reads: one identity discovery, one resolution request and one locator byte fetch.

The raw `file_id`, locator/signed query, resolver response body and artifact bytes are intentionally not copied into repository evidence.

## Result

PR13.3 closes its byte-retrieval and integrity question positively. The accumulated proven chain is now:

```text
saved conversation
  -> explicit product-owned file_id
  -> same file_id across independent immediate reads
  -> identity-bound product resolver
  -> locator-bearing resolution response
  -> locator byte fetch
  -> exact byte-count match
  -> exact SHA-256 match
```

## Privacy / authority boundary

The artifact body was observed only in memory by the probe. No user-visible artifact file was written and no public materialization API was added.

Even after the positive live result, PR13.3 deliberately keeps:

```text
stable_product_identity_proven = false
download_authority_granted = false
artifact_disk_write_attempted = false
materialization_attempted = false
write_attempted = false
identity_values_exported = false
locator_values_exported = false
artifact_bytes_exported = false
```

PR13.3 does not yet change `ARTIFACT_DOWNLOAD_HANDOFF_UNSUPPORTED_WITHOUT_STABLE_PRODUCT_IDENTITY`.

## Scope

Core PR13.3 scope is three new experiment files: tool, regression tests and engineering note. No production runtime promotion, no public download/materialization API and no unrelated endpoint work.

One additional test-only CI hygiene change is included in `tests/test_sentinel_transaction.py`: the pre-existing exact `<= 25` floating-point boundary assertion is made tolerant to representational noise. Windows Python 3.12 repeatedly produced `25.00000000000003`; no production sentinel logic is changed.

## Validation

Pre-live exact head: `35e507fea217b53a4e997d9bd015b8a3b8625aab`

CI #899 (`34486740572`): **SUCCESS**.

Live evidence commit: `dbf958d6a93f0df4a83817ff7ebb1c1d3a6288e2`.

Its CI #903 twice exposed the same pre-existing Windows 3.12 floating-point boundary failure in `test_absolute_finalize_expiry_clamps_relative_ttl`: the computed interval was `25.00000000000003` while the test required exact `<= 25`.

Final exact head: `3bdde66a1fdfa8680b52bacdc41cc4c875d6c3a2`

CI #904 (`34496151647`): **SUCCESS**.

- Engineering Quality: PASS;
- source tests: Ubuntu + Windows, Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14 — PASS;
- Build release artifacts — PASS;
- installed-wheel smoke: Ubuntu 3.10/3.14 and Windows 3.10/3.14 — PASS.

## Follow-up boundary

The remaining question is no longer endpoint discovery, resolver binding or byte integrity. A subsequent bounded promotion decision should determine whether one longitudinal/session identity gate is still required before revising the frozen PR10.1 status, and then define the governed destination/overwrite/retry contract for a production artifact handoff.