### PR TITLE
Fix snapshot payload to preserve full conversation history

### DIFF
--- a/src/chatgpt_web_adapter/conversation_snapshot.py
+++ b/src/chatgpt_web_adapter/conversation_snapshot.py
@@ -37,8 +37,13 @@ def _normalize_snapshot_name(name: str) -> str:
         raise ValueError("snapshot name is required")
     if normalized in {".", ".."}:
         raise ValueError("snapshot name must be a file-name component")
-    if any(character in _SAFE_NAME_FORBIDDEN or ord(character) < 32 for character in normalized):
-        raise ValueError("snapshot name contains characters that are invalid in file names")
+    if any(
+        character in _SAFE_NAME_FORBIDDEN or ord(character) < 32
+        for character in normalized
+    ):
+        raise ValueError(
+            "snapshot name contains characters that are invalid in file names"
+        )
     return normalized
 
 
@@ -92,7 +97,10 @@ def _context_messages(messages: list[ChatMessage]) -> list[ChatMessage]:
 
 
 def render_snapshot_context(messages: list[ChatMessage]) -> str:
-    blocks = [f"## {(message.role or 'message').upper()}\n\n{message.text}" for message in messages]
+    blocks = [
+        f"## {(message.role or 'message').upper()}\n\n{message.text}"
+        for message in messages
+    ]
     if not blocks:
         return ""
     return _CONTEXT_SEPARATOR.join(blocks) + "\n"
@@ -139,12 +147,16 @@ def snapshot_conversation(
         if include_raw_payload
         else None
     )
-    manifest_path = directory / f"{normalized_name}_chat_snapshot_{normalized_index}.manifest.json"
+    manifest_path = (
+        directory / f"{normalized_name}_chat_snapshot_{normalized_index}.manifest.json"
+    )
 
     if context_path.exists():
         raise FileExistsError(f"snapshot context already exists: {context_path}")
     if raw_payload_path is not None and raw_payload_path.exists():
-        raise FileExistsError(f"snapshot raw payload already exists: {raw_payload_path}")
+        raise FileExistsError(
+            f"snapshot raw payload already exists: {raw_payload_path}"
+        )
     if manifest_path.exists():
         raise FileExistsError(f"snapshot manifest already exists: {manifest_path}")
 

--- a/src/chatgpt_web_adapter/conversation_snapshot.py
+++ b/src/chatgpt_web_adapter/conversation_snapshot.py
@@ -98,6 +98,15 @@ def render_snapshot_context(messages: list[ChatMessage]) -> str:
     return _CONTEXT_SEPARATOR.join(blocks) + "\n"
 
 
+def _snapshot_payload(client: Any, conversation_id: str) -> Any:
+    """Prefer complete history while preserving legacy lightweight-client compatibility."""
+
+    full_reader = getattr(client, "_get_full_conversation_payload", None)
+    if callable(full_reader):
+        return full_reader(conversation_id)
+    return client._get_conversation_payload(conversation_id)
+
+
 def snapshot_conversation(
     client: Any,
     conversation: ConversationRef | ChatConversation | dict[str, Any] | str,
@@ -151,7 +160,7 @@ def snapshot_conversation(
     raw_text: str | None = None
     if raw_payload_path is not None:
         ref = ConversationRef.from_any(conversation)
-        raw_payload = client._get_conversation_payload(ref.conversation_id)
+        raw_payload = _snapshot_payload(client, ref.conversation_id)
         raw_text = json.dumps(raw_payload, ensure_ascii=False, indent=2) + "\n"
 
     context_path.write_text(context_text, encoding="utf-8", newline="\n")

--- a/tests/test_conversation_snapshot.py
+++ b/tests/test_conversation_snapshot.py
@@ -42,7 +42,9 @@ def test_render_snapshot_context_is_stable_and_ends_with_newline() -> None:
     assert output == "## USER\n\nHello\n\n---\n\n## ASSISTANT\n\nHi\n"
 
 
-def test_snapshot_filters_internal_assistant_messages_and_auto_numbers(tmp_path: Path) -> None:
+def test_snapshot_filters_internal_assistant_messages_and_auto_numbers(
+    tmp_path: Path,
+) -> None:
     (tmp_path / "organism_lab_chat_context_1.md").write_text("old\n", encoding="utf-8")
     (tmp_path / "organism_lab_chat_context_3.md").write_text("old\n", encoding="utf-8")
 
@@ -95,7 +97,9 @@ def test_snapshot_filters_internal_assistant_messages_and_auto_numbers(tmp_path:
     assert client.payload_calls == ["conversation-1"]
 
 
-def test_snapshot_prefers_full_history_payload_reader_when_available(tmp_path: Path) -> None:
+def test_snapshot_prefers_full_history_payload_reader_when_available(
+    tmp_path: Path,
+) -> None:
     class _FullHistorySnapshotClient(_SnapshotClient):
         def __init__(self) -> None:
             super().__init__([], {"scope": "single"})
@@ -144,7 +148,9 @@ def test_snapshot_context_only_skips_raw_payload_request(tmp_path: Path) -> None
     assert result.context_path.exists()
 
 
-def test_snapshot_explicit_index_never_overwrites_existing_context(tmp_path: Path) -> None:
+def test_snapshot_explicit_index_never_overwrites_existing_context(
+    tmp_path: Path,
+) -> None:
     path = tmp_path / "project_chat_context_7.md"
     path.write_text("keep me\n", encoding="utf-8")
     client = _SnapshotClient([], {})
@@ -175,7 +181,9 @@ def test_snapshot_rejects_unsafe_file_names(tmp_path: Path, name: str) -> None:
         )
 
 
-def test_snapshot_cli_replaces_manual_export_script(monkeypatch, capsys, tmp_path: Path) -> None:
+def test_snapshot_cli_replaces_manual_export_script(
+    monkeypatch, capsys, tmp_path: Path
+) -> None:
     captured = {}
     fake_client = object()
 
@@ -229,7 +237,9 @@ def test_snapshot_cli_replaces_manual_export_script(monkeypatch, capsys, tmp_pat
     assert "messages:    27" in output
 
 
-def test_snapshot_cli_context_only_forwards_raw_opt_out(monkeypatch, tmp_path: Path) -> None:
+def test_snapshot_cli_context_only_forwards_raw_opt_out(
+    monkeypatch, tmp_path: Path
+) -> None:
     captured = {}
     monkeypatch.setattr(cli, "ChatGPTWebClient", lambda **kwargs: object())
 

--- a/tests/test_conversation_snapshot.py
+++ b/tests/test_conversation_snapshot.py
@@ -95,6 +95,36 @@ def test_snapshot_filters_internal_assistant_messages_and_auto_numbers(tmp_path:
     assert client.payload_calls == ["conversation-1"]
 
 
+def test_snapshot_prefers_full_history_payload_reader_when_available(tmp_path: Path) -> None:
+    class _FullHistorySnapshotClient(_SnapshotClient):
+        def __init__(self) -> None:
+            super().__init__([], {"scope": "single"})
+            self.full_payload_calls = []
+
+        def _get_full_conversation_payload(self, conversation_id: str):
+            self.full_payload_calls.append(conversation_id)
+            return {
+                "conversation_id": conversation_id,
+                "scope": "full",
+                "mapping": {"message-1": {"id": "message-1"}},
+            }
+
+    client = _FullHistorySnapshotClient()
+
+    result = snapshot_conversation(
+        client,
+        "conversation-1",
+        output_dir=tmp_path,
+        name="project",
+    )
+
+    raw_payload = json.loads(result.raw_payload_path.read_text(encoding="utf-8"))
+    assert raw_payload["scope"] == "full"
+    assert len(raw_payload["mapping"]) == 1
+    assert client.full_payload_calls == ["conversation-1"]
+    assert client.payload_calls == []
+
+
 def test_snapshot_context_only_skips_raw_payload_request(tmp_path: Path) -> None:
     client = _SnapshotClient(
         [ChatMessage(role="user", text="Hello")],


### PR DESCRIPTION
## Purpose

Align `cwa snapshot` raw-payload backup semantics with the full-history context semantics established by PR13.0.

## Problem

After PR13.0, snapshot context generation already uses `get_messages(..., limit=None)`, so long conversations are paginated to completion. The JSON backup still called `_get_conversation_payload()`, which intentionally reads only one bounded canonical response.

That created an asymmetric snapshot artifact:

- context markdown: full conversation history;
- JSON payload backup: one bounded response only.

## Change

- prefer `_get_full_conversation_payload()` for snapshot payload backups when the client provides it;
- retain `_get_conversation_payload()` as a compatibility fallback for lightweight/custom clients that only implement the historical reader seam;
- add a regression proving the full-history reader wins when both readers are present;
- keep existing tests as coverage for the historical lightweight-client fallback;
- apply Ruff formatting only within the same two touched files, as required by the delta quality gate.

## Resulting CLI semantics

The existing command syntax is unchanged. `cwa snapshot ...` now produces:

- curated context markdown from the complete paginated conversation history;
- JSON canonical payload backup from the complete paginated conversation history when using the production `ChatGPTWebClient`;
- the historical single-reader behavior only for custom/lightweight clients that do not expose a full-history reader.

## Scope

No CLI syntax change, no read-protocol change, no retry/fallback changes, no write-path changes, and no PR14.0 work.

## Base

Built directly on `main` merge commit `2112f3685e064c8f3ea1becaa95a766b5f5265a1` (PR13.0).

## Validation

Exact head: `688b19354dcd3eef7e84244af11fe49196eecc07`

CI #920 (`34563685134`): **SUCCESS**

- Engineering Quality: PASS;
- source tests: Ubuntu + Windows Python 3.10–3.14: PASS;
- Build release artifacts: PASS;
- installed-wheel smoke: Ubuntu/Windows: PASS.

Diff remains limited to two files:

- `src/chatgpt_web_adapter/conversation_snapshot.py`;
- `tests/test_conversation_snapshot.py`.

Ready for merge.